### PR TITLE
chore: update pnpm-lock.yaml for theme-docs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,9 +272,6 @@ importers:
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.18
-      tsup:
-        specifier: ^8.3.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3


### PR DESCRIPTION
Lockfile was out of date (still had tsup); run pnpm install --no-frozen-lockfile to sync.

Closes #5

Made with [Cursor](https://cursor.com)