### PR TITLE
chore: changeset linked 패키지 확장 및 docs ignore 추가

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,10 +4,18 @@
   "commit": false,
   "fixed": [],
   "linked": [
-    ["@barodoc/core", "@barodoc/theme-docs"]
+    [
+      "@barodoc/core", "@barodoc/theme-docs", "create-barodoc",
+      "barodoc",
+      "@barodoc/plugin-sitemap", 
+      "@barodoc/plugin-search", 
+      "@barodoc/plugin-analytics"
+    ]
   ],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [
+    "docs"
+  ]
 }


### PR DESCRIPTION
## 변경 사항
- `.changeset/config.json`
  - **linked**: `create-barodoc`, `barodoc`, `@barodoc/plugin-sitemap`, `@barodoc/plugin-search`, `@barodoc/plugin-analytics` 추가
  - **ignore**: `docs` 추가

Closes #10

Made with [Cursor](https://cursor.com)