### PR TITLE
feat: 문서 언어 스위처 노출 및 모바일 반응형 개선

### DIFF
--- a/packages/theme-docs/src/components/Header.astro
+++ b/packages/theme-docs/src/components/Header.astro
@@ -1,17 +1,16 @@
 ---
 import { DocHeader } from "./DocHeader";
-import LanguageSwitcher from "./LanguageSwitcher.astro";
 import config from "virtual:barodoc/config";
 import { locales, defaultLocale } from "virtual:barodoc/i18n";
 
 interface Props {
   currentLocale?: string;
+  currentPath?: string;
 }
 
-const { currentLocale = defaultLocale } = Astro.props;
+const { currentLocale = defaultLocale, currentPath = "" } = Astro.props;
 const hasMultipleLocales = locales.length > 1;
 
-// Build locale labels from config
 const localeLabels: Record<string, string> = config.i18n?.labels || {};
 ---
 
@@ -23,10 +22,7 @@ const localeLabels: Record<string, string> = config.i18n?.labels || {};
   hasMultipleLocales={hasMultipleLocales}
   currentLocale={currentLocale}
   localeLabels={localeLabels}
+  currentPath={currentPath}
+  locales={locales}
+  defaultLocale={defaultLocale}
 />
-
-{hasMultipleLocales && (
-  <div class="hidden">
-    <LanguageSwitcher currentLocale={currentLocale} />
-  </div>
-)}

--- a/packages/theme-docs/src/layouts/DocsLayout.astro
+++ b/packages/theme-docs/src/layouts/DocsLayout.astro
@@ -30,11 +30,11 @@ const currentLocale = getLocaleFromPath(currentPath, i18nConfig);
 ---
 
 <BaseLayout title={title} description={description}>
-  <Header currentLocale={currentLocale} />
+  <Header currentLocale={currentLocale} currentPath={currentPath} />
   
   <!-- Centered container for docs layout -->
-  <div class="w-full min-h-[calc(100vh-3.5rem)] flex justify-center">
-    <div class="flex w-full max-w-[1120px]">
+  <div class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex justify-center overflow-x-hidden">
+    <div class="flex w-full max-w-[1120px] min-w-0">
       <!-- Desktop Sidebar -->
       <aside class="hidden lg:block w-[220px] shrink-0">
         <div class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto py-6 pr-4">
@@ -42,10 +42,10 @@ const currentLocale = getLocaleFromPath(currentPath, i18nConfig);
         </div>
       </aside>
 
-      <!-- Main Content -->
-      <main class="flex-1 min-w-0 min-w-[650px] max-w-[720px]">
-        <div class="px-8 py-8">
-          <article class="prose prose-gray dark:prose-invert max-w-none">
+      <!-- Main Content: no min-width on mobile to avoid horizontal scroll -->
+      <main class="flex-1 min-w-0 lg:min-w-[650px] max-w-[720px]">
+        <div class="px-4 py-6 sm:px-6 sm:py-8 lg:px-8 lg:py-8">
+          <article class="prose prose-gray dark:prose-invert max-w-none min-w-0 overflow-x-auto">
             <slot />
           </article>
           

--- a/packages/theme-docs/src/styles/global.css
+++ b/packages/theme-docs/src/styles/global.css
@@ -63,6 +63,7 @@
     background-color: var(--color-bg);
     color: var(--color-text);
     font-feature-settings: "rlig" 1, "calt" 1;
+    overflow-x: hidden;
   }
 
   /* Smooth transitions for all interactive elements */


### PR DESCRIPTION
## 변경 사항
- Header에서 LanguageSwitcher 노출, DocHeader에 언어 스위처 UI 추가
- DocsLayout/global.css 모바일 min-width, overflow, padding 조정

Closes #18

Made with [Cursor](https://cursor.com)