### PR TITLE
feat: 404 페이지 추가 및 create-barodoc/설치 문서 정리

### DIFF
--- a/.changeset/404-and-docs.md
+++ b/.changeset/404-and-docs.md
@@ -1,0 +1,5 @@
+---
+"@barodoc/theme-docs": patch
+---
+
+Add custom 404 page and align docs with CLI (zero-config) vs manual Astro setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,30 @@ pnpm build:packages
 pnpm barodoc --help
 ```
 
+### create-barodoc 동작 확인
+
+`create-barodoc`으로 만든 프로젝트가 CLI(`barodoc serve` / `build`)에서 정상 동작하는지 확인할 때:
+
+1. **저장소 루트에서** (패키지 빌드 후):
+
+   ```bash
+   pnpm build:packages
+   pnpm create barodoc test-docs
+   cd test-docs
+   npx barodoc serve
+   ```
+
+2. **기대하는 구조** (create-barodoc 출력):
+   - `docs/en/introduction.md`, `docs/en/quickstart.md`
+   - `public/logo.svg`
+   - `barodoc.config.json` (name, logo, navigation, i18n.defaultLocale/locales, topbar)
+   - `.gitignore`
+   - `src/`, `package.json`, `astro.config.mjs`는 **없음** (제로 설정 모드)
+
+3. **이 저장소의 docs/와의 차이**  
+   이 리포지터리의 **docs/** 디렉터리는 **풀 커스텀(Astro) 모드**입니다. `docs/` 안에 `src/content/docs/`, `astro.config.mjs`, `package.json`이 있고 `pnpm dev`로 실행합니다.  
+   **create-barodoc**으로 만든 프로젝트는 위 구조처럼 `docs/en/` + `public/` + `barodoc.config.json`만 있고, `npx barodoc serve`로 실행합니다. 두 방식의 콘텐츠 규칙(슬러그, frontmatter)은 동일합니다.
+
 ## 문서 작성
 
 - 한국어와 영어 문서 모두 작성

--- a/docs/src/content/docs/en/guides/content-structure.mdx
+++ b/docs/src/content/docs/en/guides/content-structure.mdx
@@ -3,9 +3,23 @@ title: Content Structure
 description: Where to put content and how URLs are built
 ---
 
-Barodoc content lives under `src/content/docs/`. Each locale has its own folder; the folder structure becomes the URL path.
+Barodoc content is organized by locale; the folder structure becomes the URL path. In **CLI (zero-config)** mode, content lives under **`docs/`** (e.g. `docs/en/`, `docs/ko/`). In **manual Astro** mode, it lives under **`src/content/docs/`** (e.g. `src/content/docs/en/`). The rules below apply to both.
 
 ## Directory layout
+
+**CLI mode** (`docs/` at project root):
+
+```
+docs/
+├── en/
+│   ├── introduction.mdx    → /docs/introduction
+│   └── guides/
+│       └── installation.mdx → /docs/guides/installation
+└── ko/
+    └── ...
+```
+
+**Manual Astro mode** (`src/content/docs/`):
 
 ```
 src/content/docs/

--- a/docs/src/content/docs/en/guides/installation.mdx
+++ b/docs/src/content/docs/en/guides/installation.mdx
@@ -1,35 +1,73 @@
 ---
 title: Installation
-description: Install Barodoc in your project
+description: Install Barodoc: CLI (zero-config) or manual Astro setup
 ---
 
-## Using the CLI (Recommended)
+Two ways to use Barodoc: **CLI (zero-config)** for a docs-only project, or **Manual (Astro)** for a full Astro app.
 
-The fastest way to get started:
+## CLI (zero-config, recommended for new docs)
+
+No `package.json` or Astro config in your repo. You only have `docs/`, `public/`, and `barodoc.config.json`.
+
+### Create project
 
 ```bash
 pnpm create barodoc my-docs
+cd my-docs
 ```
 
-## Manual Installation
+### Structure created
 
-If you prefer manual setup:
+| Path | Purpose |
+|------|--------|
+| `docs/en/` | Markdown/MDX files for the default locale. Add `docs/ko/`, etc. for i18n. |
+| `public/` | Static assets (logo, favicon). |
+| `barodoc.config.json` | Site name, `navigation`, `theme`, `i18n`, `topbar`, etc. |
+| `.gitignore` | Ignores `.barodoc/`, `dist/`, `node_modules/`. |
 
-### 1. Create an Astro project
+No `src/` or `astro.config.mjs` in the project. The CLI generates a temporary Astro project under `.barodoc/` when you run commands.
+
+### Commands
+
+```bash
+# Development
+npx barodoc serve
+
+# Optional: custom port or config
+npx barodoc serve --port 3000
+npx barodoc serve --config custom.config.json
+
+# Production build (output: dist/)
+npx barodoc build
+
+# Preview production build
+npx barodoc preview
+```
+
+Install is not required in the project; `npx barodoc` runs the CLI.
+
+---
+
+## Manual installation (Astro integration)
+
+Use this when you want a normal Astro project (e.g. custom routes, other integrations). Content lives under `src/content/docs/`, and you run `pnpm dev` / `pnpm build`.
+
+### 1. Create Astro project
 
 ```bash
 pnpm create astro@latest my-docs
+cd my-docs
 ```
 
 ### 2. Install Barodoc packages
 
 ```bash
-pnpm add @barodoc/core @barodoc/theme-docs
+pnpm add @barodoc/core @barodoc/theme-docs astro
 ```
 
 ### 3. Configure Astro
 
-Update `astro.config.mjs`:
+In `astro.config.mjs`:
 
 ```js
 import { defineConfig } from "astro/config";
@@ -48,30 +86,45 @@ export default defineConfig({
 
 ### 4. Create config file
 
-Create `barodoc.config.json`:
+Create `barodoc.config.json` in the project root:
 
 ```json
 {
   "name": "My Docs",
+  "logo": "/logo.svg",
   "navigation": [
     {
       "group": "Getting Started",
-      "pages": ["introduction"]
+      "pages": ["introduction", "quickstart"]
     }
-  ]
+  ],
+  "i18n": {
+    "defaultLocale": "en",
+    "locales": ["en"]
+  }
 }
 ```
 
 ### 5. Add content
 
-Create `src/content/docs/en/introduction.mdx`:
+Create `src/content/docs/en/introduction.mdx` (and optionally other locales under `src/content/docs/ko/`, etc.). See [Content structure](/docs/guides/content-structure) for layout and slugs.
 
 ```mdx
 ---
 title: Introduction
+description: Welcome to the docs
 ---
 
 # Welcome
 
 Your documentation starts here.
 ```
+
+### 6. Run the project
+
+```bash
+pnpm dev
+pnpm build
+```
+
+Content structure and URL rules are the same as in CLI mode; only the directory is `src/content/docs/` instead of `docs/`.

--- a/docs/src/content/docs/en/quickstart.mdx
+++ b/docs/src/content/docs/en/quickstart.mdx
@@ -3,7 +3,7 @@ title: Quick Start
 description: Get started with Barodoc in under 5 minutes
 ---
 
-Create a new documentation site with Barodoc.
+Create a new documentation site with the CLI (zero-config). No `package.json` or `node_modules` in your project.
 
 ## Prerequisites
 
@@ -14,53 +14,80 @@ Create a new documentation site with Barodoc.
 
 ```bash
 pnpm create barodoc my-docs
+cd my-docs
 ```
 
-The CLI will prompt you for:
-- Project name
-- Site name
-- Primary color
-- i18n support
+This creates a project with Markdown files and config only—no Astro config or dependencies in the project directory.
 
-## Project Structure
+## Project Structure (CLI / zero-config)
 
-After creation, your project will look like:
+After creation, the project looks like:
 
 ```
 my-docs/
-├── src/
-│   └── content/
-│       └── docs/
-│           └── en/
-│               ├── introduction.mdx
-│               └── quickstart.mdx
+├── docs/
+│   └── en/
+│       ├── introduction.md
+│       └── quickstart.md
 ├── public/
 │   └── logo.svg
 ├── barodoc.config.json
-├── astro.config.mjs
-└── package.json
+└── .gitignore
 ```
+
+- **docs/** – Content per locale (`en/`, `ko/`, etc.). File path = URL slug (e.g. `en/introduction.md` → `/docs/introduction`).
+- **public/** – Static assets (logo, favicon, images).
+- **barodoc.config.json** – Site name, navigation, theme, i18n.
+
+No `src/`, no `package.json`, no `astro.config.mjs` in this mode.
 
 ## Development
 
 ```bash
-cd my-docs
-pnpm install
-pnpm dev
+npx barodoc serve
 ```
+
+Opens the site (e.g. `http://localhost:4321`). The CLI creates a temporary Astro project under `.barodoc/` and runs the dev server. You edit only `docs/` and `barodoc.config.json`.
 
 ## Build
 
 ```bash
-pnpm build
+npx barodoc build
 ```
 
-This generates a static site in the `dist/` directory.
+Output goes to `dist/` (or the path set in config). Deploy this folder to any static host (GitHub Pages, Vercel, Netlify, Cloudflare Pages).
 
-## Deploy
+## Preview production build
 
-Deploy the `dist/` folder to any static hosting:
-- GitHub Pages
-- Vercel
-- Netlify
-- Cloudflare Pages
+```bash
+npx barodoc preview
+```
+
+Serves the `dist/` output locally so you can check the production build.
+
+## Adding more pages
+
+1. Add a file under `docs/en/` (e.g. `docs/en/guides/installation.md`).
+2. Add the slug to `barodoc.config.json` under `navigation`:
+
+```json
+{
+  "navigation": [
+    { "group": "Getting Started", "pages": ["introduction", "quickstart"] },
+    { "group": "Guides", "pages": ["guides/installation"] }
+  ]
+}
+```
+
+Slug = path without locale and without extension: `guides/installation.md` → `guides/installation`.
+
+## Full custom (Astro) mode
+
+If you need a full Astro project (e.g. custom pages, integrations), use [Installation → Manual](/docs/guides/installation#manual-installation). That setup uses `src/content/docs/`, `astro.config.mjs`, and `pnpm dev` / `pnpm build`. This repo’s **docs/** site is an example of that mode.
+
+## Next steps
+
+- [Installation](/docs/guides/installation) – CLI vs manual setup
+- [Configuration](/docs/guides/configuration) – theme, search, i18n
+- [Content structure](/docs/guides/content-structure) – URLs, frontmatter, MDX
+- [i18n](/docs/guides/i18n) – adding locales

--- a/docs/src/content/docs/ko/guides/content-structure.mdx
+++ b/docs/src/content/docs/ko/guides/content-structure.mdx
@@ -3,9 +3,23 @@ title: Content Structure
 description: 콘텐츠 위치와 URL 구조
 ---
 
-Barodoc 콘텐츠는 `src/content/docs/` 아래에 있습니다. locale별 폴더 구조가 URL 경로가 됩니다.
+Barodoc 콘텐츠는 locale별로 정리되며, 폴더 구조가 URL 경로가 됩니다. **CLI(제로 설정)** 모드에서는 **`docs/`** 아래에 두고(예: `docs/en/`, `docs/ko/`), **수동 Astro** 모드에서는 **`src/content/docs/`** 아래에 둡니다(예: `src/content/docs/en/`). 아래 규칙은 두 방식 모두에 적용됩니다.
 
 ## 디렉터리 구조
+
+**CLI 모드** (프로젝트 루트의 `docs/`):
+
+```
+docs/
+├── en/
+│   ├── introduction.mdx    → /docs/introduction
+│   └── guides/
+│       └── installation.mdx → /docs/guides/installation
+└── ko/
+    └── ...
+```
+
+**수동 Astro 모드** (`src/content/docs/`):
 
 ```
 src/content/docs/

--- a/docs/src/content/docs/ko/guides/installation.mdx
+++ b/docs/src/content/docs/ko/guides/installation.mdx
@@ -1,61 +1,130 @@
 ---
 title: 설치
-description: Barodoc 설치 가이드
+description: Barodoc 설치: CLI(제로 설정) 또는 수동 Astro 설정
 ---
 
-Barodoc을 설치하는 여러 방법을 안내합니다.
+Barodoc을 쓰는 방법은 두 가지입니다. **CLI(제로 설정)**은 문서 전용 프로젝트용이고, **수동(Astro)**은 Astro 앱 전체를 쓰는 경우입니다.
 
-## 요구 사항
+## CLI (제로 설정, 새 문서 사이트 권장)
 
-- Node.js 20 이상
-- pnpm, npm, 또는 yarn
+프로젝트에 `package.json`이나 Astro 설정이 없습니다. `docs/`, `public/`, `barodoc.config.json`만 있습니다.
 
-## 빠른 설치
-
-새 프로젝트를 시작하는 가장 쉬운 방법:
+### 프로젝트 생성
 
 ```bash
-npx barodoc create my-docs
+pnpm create barodoc my-docs
 cd my-docs
-barodoc serve
 ```
 
-## 기존 프로젝트에 추가
+### 생성되는 구조
 
-기존 Astro 프로젝트에 Barodoc을 추가할 수 있습니다:
+| 경로 | 용도 |
+|------|------|
+| `docs/en/` | 기본 로케일용 Markdown/MDX. i18n 시 `docs/ko/` 등 추가. |
+| `public/` | 정적 파일 (로고, 파비콘). |
+| `barodoc.config.json` | 사이트 이름, `navigation`, `theme`, `i18n`, `topbar` 등. |
+| `.gitignore` | `.barodoc/`, `dist/`, `node_modules/` 제외. |
+
+프로젝트 안에는 `src/`나 `astro.config.mjs`가 없습니다. 명령 실행 시 CLI가 `.barodoc/` 아래에 임시 Astro 프로젝트를 만듭니다.
+
+### 명령어
 
 ```bash
-pnpm add @barodoc/core @barodoc/theme-docs
+# 개발
+npx barodoc serve
+
+# 선택: 포트/설정 파일 지정
+npx barodoc serve --port 3000
+npx barodoc serve --config custom.config.json
+
+# 프로덕션 빌드 (결과: dist/)
+npx barodoc build
+
+# 빌드 미리보기
+npx barodoc preview
 ```
 
-`astro.config.mjs`를 설정하세요:
+프로젝트 안에서 별도 설치 없이 `npx barodoc`으로 실행합니다.
 
-```javascript
+---
+
+## 수동 설치 (Astro 통합)
+
+일반 Astro 프로젝트가 필요할 때(커스텀 라우트, 다른 통합 등) 사용합니다. 콘텐츠는 `src/content/docs/`에 두고 `pnpm dev` / `pnpm build`로 실행합니다.
+
+### 1. Astro 프로젝트 생성
+
+```bash
+pnpm create astro@latest my-docs
+cd my-docs
+```
+
+### 2. Barodoc 패키지 설치
+
+```bash
+pnpm add @barodoc/core @barodoc/theme-docs astro
+```
+
+### 3. Astro 설정
+
+`astro.config.mjs`에 다음을 추가합니다:
+
+```js
 import { defineConfig } from "astro/config";
 import barodoc from "@barodoc/core";
 import docsTheme from "@barodoc/theme-docs";
 
 export default defineConfig({
-  site: "https://example.com",
-  i18n: {
-    defaultLocale: "ko",
-    locales: ["ko", "en"],
-    routing: { prefixDefaultLocale: false },
-  },
   integrations: [
     barodoc({
+      config: "./barodoc.config.json",
       theme: docsTheme(),
     }),
   ],
 });
 ```
 
-## 전역 설치
+### 4. 설정 파일 생성
 
-CLI를 전역으로 설치하면 어디서든 사용할 수 있습니다:
+프로젝트 루트에 `barodoc.config.json` 생성:
 
-```bash
-npm install -g barodoc
+```json
+{
+  "name": "My Docs",
+  "logo": "/logo.svg",
+  "navigation": [
+    {
+      "group": "시작하기",
+      "pages": ["introduction", "quickstart"]
+    }
+  ],
+  "i18n": {
+    "defaultLocale": "en",
+    "locales": ["en"]
+  }
+}
 ```
 
-이제 `barodoc` 명령을 어디서든 실행할 수 있습니다.
+### 5. 콘텐츠 추가
+
+`src/content/docs/en/introduction.mdx`를 만들고, 필요하면 `src/content/docs/ko/` 등 다른 로케일도 추가합니다. 구조와 슬러그는 [콘텐츠 구조](/ko/docs/guides/content-structure)를 참고하세요.
+
+```mdx
+---
+title: 소개
+description: 문서에 오신 것을 환영합니다
+---
+
+# 환영합니다
+
+문서 내용을 여기에 작성하세요.
+```
+
+### 6. 실행
+
+```bash
+pnpm dev
+pnpm build
+```
+
+콘텐츠 구조와 URL 규칙은 CLI 모드와 동일하고, 디렉터리만 `docs/` 대신 `src/content/docs/`를 사용합니다.

--- a/docs/src/content/docs/ko/quickstart.mdx
+++ b/docs/src/content/docs/ko/quickstart.mdx
@@ -1,50 +1,93 @@
 ---
 title: 빠른 시작
-description: Barodoc으로 문서 사이트 빠르게 시작하기
+description: 5분 안에 Barodoc 문서 사이트 만들기
 ---
 
-5분 안에 첫 번째 문서 사이트를 만들어보세요.
+CLI(제로 설정)로 새 문서 사이트를 만듭니다. 프로젝트에 `package.json`이나 `node_modules`가 없습니다.
+
+## 필요 환경
+
+- Node.js 20 이상
+- pnpm 권장
 
 ## 프로젝트 생성
 
 ```bash
-npx barodoc create my-docs
+pnpm create barodoc my-docs
 cd my-docs
 ```
 
-## 개발 서버 실행
+Markdown과 설정만 있는 프로젝트가 생성됩니다. Astro 설정이나 의존성은 프로젝트 폴더에 없습니다.
+
+## 프로젝트 구조 (CLI / 제로 설정)
+
+생성 후 디렉터리 구조:
+
+```
+my-docs/
+├── docs/
+│   └── en/
+│       ├── introduction.md
+│       └── quickstart.md
+├── public/
+│   └── logo.svg
+├── barodoc.config.json
+└── .gitignore
+```
+
+- **docs/** – 로케일별 콘텐츠 (`en/`, `ko/` 등). 파일 경로 = URL 슬러그 (예: `en/introduction.md` → `/docs/introduction`).
+- **public/** – 정적 파일 (로고, 파비콘, 이미지).
+- **barodoc.config.json** – 사이트 이름, 네비게이션, 테마, i18n.
+
+이 모드에서는 `src/`, `package.json`, `astro.config.mjs`가 없습니다.
+
+## 개발 서버
 
 ```bash
-barodoc serve
+npx barodoc serve
 ```
 
-브라우저에서 `http://localhost:4321`을 열어 확인하세요.
+사이트가 실행됩니다 (예: `http://localhost:4321`). CLI가 `.barodoc/` 아래에 임시 Astro 프로젝트를 만들고 dev 서버를 띄웁니다. 수정하는 것은 `docs/`와 `barodoc.config.json`뿐입니다.
 
-## 문서 작성
-
-`docs/` 폴더에 Markdown 파일을 추가하세요:
-
-```markdown
----
-title: 내 첫 번째 문서
-description: 문서 설명
----
-
-# 제목
-
-문서 내용을 여기에 작성하세요.
-```
-
-## 프로덕션 빌드
+## 빌드
 
 ```bash
-barodoc build
+npx barodoc build
 ```
 
-`dist/` 폴더에 정적 파일이 생성됩니다. 이 파일들을 웹 서버나 GitHub Pages에 배포하세요.
+결과물은 `dist/`(또는 설정에서 지정한 경로)에 생성됩니다. 이 폴더를 GitHub Pages, Vercel, Netlify, Cloudflare Pages 등 정적 호스팅에 배포하면 됩니다.
+
+## 빌드 미리보기
+
+```bash
+npx barodoc preview
+```
+
+`dist/` 결과물을 로컬에서 띄워 프로덕션 빌드를 확인할 수 있습니다.
+
+## 페이지 추가하기
+
+1. `docs/en/` 아래에 파일 추가 (예: `docs/en/guides/installation.md`).
+2. `barodoc.config.json`의 `navigation`에 슬러그 추가:
+
+```json
+{
+  "navigation": [
+    { "group": "시작하기", "pages": ["introduction", "quickstart"] },
+    { "group": "가이드", "pages": ["guides/installation"] }
+  ]
+}
+```
+
+슬러그 = 로케일과 확장자를 뺀 경로: `guides/installation.md` → `guides/installation`.
+
+## 풀 커스텀 (Astro) 모드
+
+Astro 프로젝트 전체가 필요한 경우(커스텀 페이지, 다른 통합 등) [설치 → 수동 설치](/ko/docs/guides/installation#수동-설치-astro-통합)를 참고하세요. 그 방식은 `src/content/docs/`, `astro.config.mjs`를 사용하고 `pnpm dev` / `pnpm build`로 실행합니다. 이 저장소의 **docs/** 사이트가 그 예입니다.
 
 ## 다음 단계
 
-- [설치 가이드](/ko/docs/guides/installation) - 상세 설치 방법
-- [설정](/ko/docs/guides/configuration) - 사이트 설정 방법
-- [다국어](/ko/docs/guides/i18n) - 다국어 지원 설정
+- [설치](/ko/docs/guides/installation) – CLI vs 수동 설치
+- [설정](/ko/docs/guides/configuration) – 테마, 검색, i18n
+- [콘텐츠 구조](/ko/docs/guides/content-structure) – URL, frontmatter, MDX
+- [다국어](/ko/docs/guides/i18n) – 로케일 추가

--- a/packages/theme-docs/src/pages/404.astro
+++ b/packages/theme-docs/src/pages/404.astro
@@ -1,0 +1,32 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import config from "virtual:barodoc/config";
+
+const pathname = new URL(Astro.request.url).pathname;
+---
+
+<BaseLayout title={`${config.name} · Page not found`} description="The page you are looking for does not exist.">
+  <div class="min-h-screen flex flex-col items-center justify-center px-4">
+    <div class="text-center max-w-md">
+      <p class="text-8xl font-bold text-[var(--color-text-muted)] select-none" aria-hidden="true">404</p>
+      <h1 class="text-2xl font-semibold text-[var(--color-text)] mt-4">Page not found</h1>
+      <p class="text-[var(--color-text-secondary)] mt-2">
+        The page at <code class="text-sm bg-[var(--color-bg-secondary)] px-2 py-1 rounded break-all">{pathname}</code> does not exist.
+      </p>
+      <div class="flex flex-col sm:flex-row items-center justify-center gap-3 mt-8">
+        <a
+          href="/"
+          class="px-5 py-2.5 bg-primary-600 text-white rounded-xl hover:bg-primary-700 transition-colors font-medium"
+        >
+          Home
+        </a>
+        <a
+          href="/docs/introduction"
+          class="px-5 py-2.5 border border-[var(--color-border)] text-[var(--color-text)] rounded-xl hover:bg-[var(--color-bg-secondary)] transition-colors font-medium"
+        >
+          Documentation
+        </a>
+      </div>
+    </div>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
## 변경 사항
- **theme-docs**: `404.astro` 추가 (pathname 표시, Home/Documentation 링크)
- **Quick Start (en/ko)**: CLI(제로 설정) 기준으로 수정, 생성 구조·명령어 명시
- **Installation (en/ko)**: CLI(zero-config) vs Manual(Astro) 섹션 분리
- **Content structure (en/ko)**: `docs/` vs `src/content/docs/` 모드 설명
- **CONTRIBUTING.md**: create-barodoc 동작 확인 절차 추가
- changeset: `@barodoc/theme-docs` patch

Closes #20

Made with [Cursor](https://cursor.com)