### PR TITLE
fix: installation.mdx frontmatter description YAML quoting

### DIFF
--- a/docs/src/content/docs/en/guides/installation.mdx
+++ b/docs/src/content/docs/en/guides/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install Barodoc: CLI (zero-config) or manual Astro setup
+description: "Install Barodoc: CLI (zero-config) or manual Astro setup"
 ---
 
 Two ways to use Barodoc: **CLI (zero-config)** for a docs-only project, or **Manual (Astro)** for a full Astro app.

--- a/docs/src/content/docs/ko/guides/installation.mdx
+++ b/docs/src/content/docs/ko/guides/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: 설치
-description: Barodoc 설치: CLI(제로 설정) 또는 수동 Astro 설정
+description: "Barodoc 설치: CLI(제로 설정) 또는 수동 Astro 설정"
 ---
 
 Barodoc을 쓰는 방법은 두 가지입니다. **CLI(제로 설정)**은 문서 전용 프로젝트용이고, **수동(Astro)**은 Astro 앱 전체를 쓰는 경우입니다.


### PR DESCRIPTION
Quote `description` values that contain colons so js-yaml does not treat them as mapping keys. Fixes `bad indentation of a mapping entry` in `pnpm build` (docs).

Made with [Cursor](https://cursor.com)