### PR TITLE
feat(core): barodoc.config.json plugins 연동

### DIFF
--- a/.changeset/core-plugins-wiring.md
+++ b/.changeset/core-plugins-wiring.md
@@ -1,0 +1,5 @@
+---
+"@barodoc/core": minor
+---
+
+Wire barodoc.config.json plugins into integration: load plugins, run config:loaded hook, merge plugin Astro integrations. Add plugins to config schema.

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -41,6 +41,11 @@ export const searchSchema = z.object({
   enabled: z.boolean().optional(),
 }).optional();
 
+export const pluginConfigSchema = z.union([
+  z.string(),
+  z.tuple([z.string(), z.record(z.unknown())]),
+]);
+
 export const barodocConfigSchema = z.object({
   name: z.string(),
   logo: z.string().optional(),
@@ -50,6 +55,7 @@ export const barodocConfigSchema = z.object({
   navigation: z.array(navItemSchema),
   topbar: topbarSchema,
   search: searchSchema,
+  plugins: z.array(pluginConfigSchema).optional(),
   customCss: z.array(z.string()).optional(),
 });
 


### PR DESCRIPTION
## 변경 사항
- **config 스키마**: `plugins` (string | [string, object][]) optional 추가
- **integration**: config 로드 후 `loadPlugins` → `runConfigHook`(config:loaded) → `getPluginIntegrations`로 theme와 함께 Astro integrations 병합
- **PluginContext**: `mode` (dev/build) 전달

## 테스트
- `pnpm build:packages`, `pnpm build`(docs) 통과
- docs에 `@barodoc/plugin-sitemap` 추가 후 빌드 시 "Loaded 1 plugin(s)", sitemap 생성 확인 후 revert

Closes #24

Made with [Cursor](https://cursor.com)