### PR TITLE
feat(theme-docs): CodeGroup Astro 전환 및 코드 영역 여백

### DIFF
--- a/docs/src/content/docs/en/components/code-group.mdx
+++ b/docs/src/content/docs/en/components/code-group.mdx
@@ -2,14 +2,14 @@
 title: Code Group
 description: Display multiple code blocks in a tabbed interface
 ---
-import { CodeGroup } from "@barodoc/theme-docs/components/mdx/CodeGroup.tsx";
+import CodeGroup from "@barodoc/theme-docs/components/mdx/CodeGroup.astro";
 import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
 
 Code groups allow you to display multiple code examples in a tabbed interface, making it easy to show the same functionality in different languages.
 
 ## Basic Usage
 
-<CodeGroup client:load titles={["JavaScript", "Python", "Go"]}>
+<CodeGroup titles={["JavaScript", "Python", "Go"]}>
 
 ```javascript
 const greeting = "Hello, World!";
@@ -35,7 +35,7 @@ func main() {
 </CodeGroup>
 
 ```mdx
-<CodeGroup client:load titles={["JavaScript", "Python", "Go"]}>
+<CodeGroup titles={["JavaScript", "Python", "Go"]}>
 
 \`\`\`javascript
 const greeting = "Hello, World!";
@@ -61,7 +61,7 @@ func main() {
 
 ## Package Manager Example
 
-<CodeGroup client:load titles={["npm", "pnpm", "yarn", "bun"]}>
+<CodeGroup titles={["npm", "pnpm", "yarn", "bun"]}>
 
 ```bash
 npm install @barodoc/core
@@ -86,8 +86,5 @@ bun add @barodoc/core
 <ParamFieldGroup>
   <ParamField name="titles" type="string[]">
     Array of tab labels for each code block
-  </ParamField>
-  <ParamField name="client:load" type="directive" required>
-    Required Astro directive for client-side interactivity
   </ParamField>
 </ParamFieldGroup>

--- a/docs/src/content/docs/ko/components/code-group.mdx
+++ b/docs/src/content/docs/ko/components/code-group.mdx
@@ -2,14 +2,14 @@
 title: Code Group
 description: 여러 코드 블록을 탭 인터페이스로 표시
 ---
-import { CodeGroup } from "@barodoc/theme-docs/components/mdx/CodeGroup.tsx";
+import CodeGroup from "@barodoc/theme-docs/components/mdx/CodeGroup.astro";
 import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
 
 코드 그룹을 사용하면 여러 코드 예제를 탭 인터페이스로 표시할 수 있어, 같은 기능을 다른 언어로 보여주기 쉽습니다.
 
 ## 기본 사용법
 
-<CodeGroup client:load titles={["JavaScript", "Python", "Go"]}>
+<CodeGroup titles={["JavaScript", "Python", "Go"]}>
 
 ```javascript
 const greeting = "Hello, World!";
@@ -36,7 +36,7 @@ func main() {
 
 ## 패키지 매니저 예제
 
-<CodeGroup client:load titles={["npm", "pnpm", "yarn", "bun"]}>
+<CodeGroup titles={["npm", "pnpm", "yarn", "bun"]}>
 
 ```bash
 npm install @barodoc/core
@@ -61,8 +61,5 @@ bun add @barodoc/core
 <ParamFieldGroup>
   <ParamField name="titles" type="string[]">
     각 코드 블록의 탭 레이블 배열
-  </ParamField>
-  <ParamField name="client:load" type="directive" required>
-    클라이언트 사이드 인터랙티브에 필요한 Astro 디렉티브
   </ParamField>
 </ParamFieldGroup>

--- a/packages/theme-docs/src/components/CodeCopy.astro
+++ b/packages/theme-docs/src/components/CodeCopy.astro
@@ -99,6 +99,14 @@
     border-radius: 0 !important;
     background: transparent !important;
   }
+
+  /* Inside CodeGroup: no extra border/background so the group is one unified block */
+  .code-group .code-block-wrapper {
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+  }
   
   .code-block-header {
     display: flex;

--- a/packages/theme-docs/src/components/mdx/CodeGroup.astro
+++ b/packages/theme-docs/src/components/mdx/CodeGroup.astro
@@ -7,9 +7,9 @@ interface Props {
 const { titles = [] } = Astro.props;
 ---
 
-<div class="not-prose my-4 code-group" data-titles={JSON.stringify(titles)}>
-  <div class="code-group-tabs flex border-b border-[var(--color-border)] bg-[var(--color-bg-secondary)] rounded-t-lg"></div>
-  <div class="code-group-content">
+<div class="code-group not-prose my-4 rounded-lg border border-[var(--color-border)] overflow-hidden" data-titles={JSON.stringify(titles)}>
+  <div class="code-group-tabs flex flex-wrap gap-0 border-b border-[var(--color-border)] bg-[var(--color-bg-tertiary)]"></div>
+  <div class="code-group-content bg-[var(--color-bg-secondary)] px-5 py-4">
     <slot />
   </div>
 </div>
@@ -27,30 +27,27 @@ const { titles = [] } = Astro.props;
       // Create tabs
       codeBlocks.forEach((block, index) => {
         const tab = document.createElement('button');
-        tab.className = 'px-4 py-2 text-sm font-medium transition-colors text-[var(--color-text-secondary)] hover:text-[var(--color-text)]';
+        tab.className = 'shrink-0 px-4 py-2 text-sm font-medium transition-colors whitespace-nowrap text-[var(--color-text-muted)] hover:text-[var(--color-text)]';
         tab.textContent = titles[index] || `Tab ${index + 1}`;
         tab.addEventListener('click', () => {
-          // Update tabs
           tabsContainer.querySelectorAll('button').forEach((t, i) => {
             if (i === index) {
-              t.classList.add('border-b-2', 'border-primary-600', 'text-primary-600');
-              t.classList.remove('text-[var(--color-text-secondary)]');
+              t.classList.add('border-b-2', 'border-primary-500', 'text-[var(--color-text)]', '-mb-px');
+              t.classList.remove('text-[var(--color-text-muted)]');
             } else {
-              t.classList.remove('border-b-2', 'border-primary-600', 'text-primary-600');
-              t.classList.add('text-[var(--color-text-secondary)]');
+              t.classList.remove('border-b-2', 'border-primary-500', 'text-[var(--color-text)]', '-mb-px');
+              t.classList.add('text-[var(--color-text-muted)]');
             }
           });
-          // Update content
           codeBlocks.forEach((b, i) => {
             (b as HTMLElement).style.display = i === index ? 'block' : 'none';
           });
         });
         tabsContainer.appendChild(tab);
 
-        // Hide all but first
         if (index === 0) {
-          tab.classList.add('border-b-2', 'border-primary-600', 'text-primary-600');
-          tab.classList.remove('text-[var(--color-text-secondary)]');
+          tab.classList.add('border-b-2', 'border-primary-500', 'text-[var(--color-text)]', '-mb-px');
+          tab.classList.remove('text-[var(--color-text-muted)]');
         } else {
           (block as HTMLElement).style.display = 'none';
         }

--- a/packages/theme-docs/src/components/mdx/CodeGroup.tsx
+++ b/packages/theme-docs/src/components/mdx/CodeGroup.tsx
@@ -5,25 +5,91 @@ interface CodeGroupProps {
   titles?: string[];
 }
 
+function isCodeBlockLike(el: React.ReactElement): boolean {
+  if (el.type === "pre") return true;
+  const className =
+    typeof el.props?.className === "string" ? el.props.className : "";
+  if (
+    className.includes("language-") ||
+    className.includes("astro-code") ||
+    className.includes("code-block")
+  )
+    return true;
+  return false;
+}
+
+function collectCodeBlocks(node: React.ReactNode): React.ReactElement[] {
+  const result: React.ReactElement[] = [];
+  React.Children.forEach(node, (child) => {
+    if (!React.isValidElement(child)) return;
+    if (child.type === React.Fragment && child.props?.children != null) {
+      result.push(...collectCodeBlocks(child.props.children));
+      return;
+    }
+    if (child.type === "pre" || isCodeBlockLike(child)) {
+      result.push(child);
+      return;
+    }
+    if (child.props?.children != null) {
+      result.push(...collectCodeBlocks(child.props.children));
+    }
+  });
+  return result;
+}
+
 export function CodeGroup({ children, titles = [] }: CodeGroupProps) {
   const [activeIndex, setActiveIndex] = React.useState(0);
-  
-  // Extract code blocks from children
-  const codeBlocks = React.Children.toArray(children);
-  
+
+  const codeBlocks = React.useMemo(() => {
+    let blocks = collectCodeBlocks(children);
+    if (blocks.length > 0) return blocks;
+    const direct = React.Children.toArray(children).filter(
+      (c): c is React.ReactElement => React.isValidElement(c) && c.type != null
+    );
+    if (direct.length > 1) return direct;
+    if (
+      direct.length === 1 &&
+      direct[0].props?.children != null
+    ) {
+      const inner = React.Children.toArray(direct[0].props.children).filter(
+        (c): c is React.ReactElement =>
+          React.isValidElement(c) && c.type != null
+      );
+      if (inner.length > 0) return inner;
+    }
+    return direct;
+  }, [children]);
+
+  const tabTitles =
+    titles.length >= codeBlocks.length
+      ? titles.slice(0, codeBlocks.length)
+      : [
+          ...titles,
+          ...codeBlocks
+            .slice(titles.length)
+            .map((_, i) => `Tab ${titles.length + i + 1}`),
+        ];
+
+  if (codeBlocks.length === 0) {
+    return (
+      <div className="code-group not-prose my-4 rounded-lg border border-[var(--color-border)] overflow-hidden p-4 text-[var(--color-text-muted)] text-sm">
+        No code blocks found inside CodeGroup.
+      </div>
+    );
+  }
+
   return (
-    <div className="not-prose my-4 rounded-lg border border-[var(--color-border)] overflow-hidden">
+    <div className="code-group not-prose my-4 rounded-lg border border-[var(--color-border)] overflow-hidden">
       {/* Tabs */}
-      <div className="flex bg-[var(--color-bg-tertiary)] border-b border-[var(--color-border)]">
-        {codeBlocks.map((_, index) => {
+      <div className="flex flex-wrap gap-0 bg-[var(--color-bg-tertiary)] border-b border-[var(--color-border)]">
+        {tabTitles.map((title, index) => {
           const isActive = activeIndex === index;
-          const title = titles[index] || `Tab ${index + 1}`;
           return (
             <button
               key={index}
               type="button"
               onClick={() => setActiveIndex(index)}
-              className={`px-4 py-2 text-sm font-medium transition-colors ${
+              className={`shrink-0 px-4 py-2 text-sm font-medium transition-colors whitespace-nowrap ${
                 isActive
                   ? "bg-[var(--color-bg-secondary)] text-[var(--color-text)] border-b-2 border-primary-500 -mb-px"
                   : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
@@ -34,7 +100,7 @@ export function CodeGroup({ children, titles = [] }: CodeGroupProps) {
           );
         })}
       </div>
-      
+
       {/* Content */}
       <div className="bg-[var(--color-bg-secondary)]">
         {codeBlocks.map((block, index) => (


### PR DESCRIPTION
## 변경 사항
- **MDX**: React CodeGroup → Astro CodeGroup (슬롯/DOM 기반 탭, children 미전달 이슈 해소)
- **CodeCopy**: .code-group 내 .code-block-wrapper border/배경 제거
- **CodeGroup.astro**: 스타일 정리, 코드 영역 px-5 py-4 여백
- **CodeGroup.tsx**: collectCodeBlocks·Fragment·fallback 유지
- **docs** (en/ko): Astro import, client:load 제거

Made with [Cursor](https://cursor.com)