### PR TITLE
fix: CodeGroup/CodeItem, line numbers, code block line spacing

### DIFF
--- a/docs/barodoc.config.json
+++ b/docs/barodoc.config.json
@@ -52,5 +52,6 @@
   ],
   "topbar": {
     "github": "https://github.com/barocss/barodoc"
-  }
+  },
+  "lineNumbers": true
 }

--- a/docs/src/content/docs/en/components/code-group.mdx
+++ b/docs/src/content/docs/en/components/code-group.mdx
@@ -3,23 +3,31 @@ title: Code Group
 description: Display multiple code blocks in a tabbed interface
 ---
 import CodeGroup from "@barodoc/theme-docs/components/mdx/CodeGroup.astro";
+import CodeItem from "@barodoc/theme-docs/components/mdx/CodeItem.astro";
 import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
 
-Code groups allow you to display multiple code examples in a tabbed interface, making it easy to show the same functionality in different languages.
+Code groups display multiple code examples in tabs. Put one fenced code block inside each CodeItem; Shiki handles syntax highlighting.
 
-## Basic Usage
+## Basic usage
 
-<CodeGroup titles={["JavaScript", "Python", "Go"]}>
+<CodeGroup>
+  <CodeItem title="JavaScript">
 
 ```javascript
 const greeting = "Hello, World!";
 console.log(greeting);
 ```
 
+  </CodeItem>
+  <CodeItem title="Python">
+
 ```python
 greeting = "Hello, World!"
 print(greeting)
 ```
+
+  </CodeItem>
+  <CodeItem title="Go">
 
 ```go
 package main
@@ -32,59 +40,49 @@ func main() {
 }
 ```
 
+  </CodeItem>
 </CodeGroup>
 
-```mdx
-<CodeGroup titles={["JavaScript", "Python", "Go"]}>
+## Package manager example
 
-\`\`\`javascript
-const greeting = "Hello, World!";
-console.log(greeting);
-\`\`\`
-
-\`\`\`python
-greeting = "Hello, World!"
-print(greeting)
-\`\`\`
-
-\`\`\`go
-package main
-import "fmt"
-func main() {
-    greeting := "Hello, World!"
-    fmt.Println(greeting)
-}
-\`\`\`
-
-</CodeGroup>
-```
-
-## Package Manager Example
-
-<CodeGroup titles={["npm", "pnpm", "yarn", "bun"]}>
+<CodeGroup>
+  <CodeItem title="npm">
 
 ```bash
 npm install @barodoc/core
 ```
 
+  </CodeItem>
+  <CodeItem title="pnpm">
+
 ```bash
 pnpm add @barodoc/core
 ```
+
+  </CodeItem>
+  <CodeItem title="yarn">
 
 ```bash
 yarn add @barodoc/core
 ```
 
+  </CodeItem>
+  <CodeItem title="bun">
+
 ```bash
 bun add @barodoc/core
 ```
 
+  </CodeItem>
 </CodeGroup>
 
 ## Props
 
 <ParamFieldGroup>
-  <ParamField name="titles" type="string[]">
-    Array of tab labels for each code block
+  <ParamField name="CodeItem — title" type="string">
+    Tab label for this code block.
+  </ParamField>
+  <ParamField name="CodeGroup — titles" type="string[]">
+    Optional. Fallback when CodeGroup has direct <code>pre</code> children (no CodeItem). Ignored when using CodeItem.
   </ParamField>
 </ParamFieldGroup>

--- a/docs/src/content/docs/ko/components/code-group.mdx
+++ b/docs/src/content/docs/ko/components/code-group.mdx
@@ -3,23 +3,31 @@ title: Code Group
 description: 여러 코드 블록을 탭 인터페이스로 표시
 ---
 import CodeGroup from "@barodoc/theme-docs/components/mdx/CodeGroup.astro";
+import CodeItem from "@barodoc/theme-docs/components/mdx/CodeItem.astro";
 import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
 
-코드 그룹을 사용하면 여러 코드 예제를 탭 인터페이스로 표시할 수 있어, 같은 기능을 다른 언어로 보여주기 쉽습니다.
+코드 그룹은 여러 코드 예제를 탭으로 보여줍니다. 각 CodeItem 안에 펜스드 코드 블록 하나를 넣으면 되고, 문법 강조는 Shiki가 처리합니다.
 
 ## 기본 사용법
 
-<CodeGroup titles={["JavaScript", "Python", "Go"]}>
+<CodeGroup>
+  <CodeItem title="JavaScript">
 
 ```javascript
 const greeting = "Hello, World!";
 console.log(greeting);
 ```
 
+  </CodeItem>
+  <CodeItem title="Python">
+
 ```python
 greeting = "Hello, World!"
 print(greeting)
 ```
+
+  </CodeItem>
+  <CodeItem title="Go">
 
 ```go
 package main
@@ -32,34 +40,49 @@ func main() {
 }
 ```
 
+  </CodeItem>
 </CodeGroup>
 
 ## 패키지 매니저 예제
 
-<CodeGroup titles={["npm", "pnpm", "yarn", "bun"]}>
+<CodeGroup>
+  <CodeItem title="npm">
 
 ```bash
 npm install @barodoc/core
 ```
 
+  </CodeItem>
+  <CodeItem title="pnpm">
+
 ```bash
 pnpm add @barodoc/core
 ```
+
+  </CodeItem>
+  <CodeItem title="yarn">
 
 ```bash
 yarn add @barodoc/core
 ```
 
+  </CodeItem>
+  <CodeItem title="bun">
+
 ```bash
 bun add @barodoc/core
 ```
 
+  </CodeItem>
 </CodeGroup>
 
 ## Props
 
 <ParamFieldGroup>
-  <ParamField name="titles" type="string[]">
-    각 코드 블록의 탭 레이블 배열
+  <ParamField name="CodeItem — title" type="string">
+    이 코드 블록의 탭 레이블.
+  </ParamField>
+  <ParamField name="CodeGroup — titles" type="string[]">
+    선택. CodeGroup에 CodeItem 없이 <code>pre</code>를 직접 넣을 때만 사용. CodeItem 사용 시 무시됨.
   </ParamField>
 </ParamFieldGroup>

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -41,6 +41,8 @@ export const searchSchema = z.object({
   enabled: z.boolean().optional(),
 }).optional();
 
+export const lineNumbersSchema = z.boolean().optional();
+
 export const pluginConfigSchema = z.union([
   z.string(),
   z.tuple([z.string(), z.record(z.unknown())]),
@@ -55,6 +57,7 @@ export const barodocConfigSchema = z.object({
   navigation: z.array(navItemSchema),
   topbar: topbarSchema,
   search: searchSchema,
+  lineNumbers: lineNumbersSchema,
   plugins: z.array(pluginConfigSchema).optional(),
   customCss: z.array(z.string()).optional(),
 });

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -100,7 +100,7 @@ export default function barodoc(options: BarodocOptions): AstroIntegration {
         };
 
         // Theme + plugin integrations
-        const themeIntegration = options.theme.integration();
+        const themeIntegration = options.theme.integration(resolvedConfig);
         const pluginIntegrations = getPluginIntegrations(plugins, pluginContext);
 
         updateConfig({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -55,6 +55,9 @@ export interface BarodocConfig {
   search?: {
     enabled?: boolean;
   };
+
+  /** When true, code blocks render with line numbers. */
+  lineNumbers?: boolean;
   
   plugins?: PluginConfig[];
   
@@ -63,7 +66,7 @@ export interface BarodocConfig {
 
 export interface ThemeExport {
   name: string;
-  integration: () => AstroIntegration;
+  integration: (config: ResolvedBarodocConfig) => AstroIntegration;
   pages?: Record<string, () => Promise<unknown>>;
   layouts?: Record<string, () => Promise<unknown>>;
   components?: Record<string, () => Promise<unknown>>;

--- a/packages/theme-docs/src/components/CodeCopy.astro
+++ b/packages/theme-docs/src/components/CodeCopy.astro
@@ -100,13 +100,45 @@
     background: transparent !important;
   }
 
-  /* Inside CodeGroup: no extra border/background so the group is one unified block */
+  /* Inside CodeGroup: no extra border/background, add padding so code has internal spacing */
   .code-group .code-block-wrapper {
     margin: 0;
     border: none;
     border-radius: 0;
     background: transparent;
+    /* padding: 1rem 1.25rem; */
   }
+
+  .code-group .code-block-wrapper pre {
+    padding: 0 !important;
+  }
+
+  /* pre not wrapped by CodeCopy (direct child of code-group-content) */
+  .code-group .code-group-content > pre {
+    padding: 1rem 1.25rem !important;
+  }
+
+  /* CodeItem: one code block per tab; only the code area is visible, no extra wrapper space */
+  .code-group .code-item {
+    margin: 0;
+    padding: 0;
+    display: block;
+  }
+
+  .code-group .code-item:not(:first-child) {
+    display: none; /* toggled by CodeGroup script */
+  }
+
+  /* .code-group .code-item .code-block-wrapper,
+  .code-group .code-item > pre {
+    margin: 0 !important;
+    border: none !important;
+    padding: 0.25rem 0rem !important;
+  } */
+
+  /* .code-group .code-item .code-block-wrapper pre {
+    padding: 0 !important;
+  } */
   
   .code-block-header {
     display: flex;

--- a/packages/theme-docs/src/components/mdx/CodeGroup.astro
+++ b/packages/theme-docs/src/components/mdx/CodeGroup.astro
@@ -1,5 +1,7 @@
 ---
-// CodeGroup component for tabbed code blocks
+// CodeGroup component for tabbed code blocks.
+// When using CodeItem children, each CodeItem's title is used for the tab label.
+// Optional titles array is only used when not using CodeItem (direct pre children).
 interface Props {
   titles?: string[];
 }
@@ -9,7 +11,7 @@ const { titles = [] } = Astro.props;
 
 <div class="code-group not-prose my-4 rounded-lg border border-[var(--color-border)] overflow-hidden" data-titles={JSON.stringify(titles)}>
   <div class="code-group-tabs flex flex-wrap gap-0 border-b border-[var(--color-border)] bg-[var(--color-bg-tertiary)]"></div>
-  <div class="code-group-content bg-[var(--color-bg-secondary)] px-5 py-4">
+  <div class="code-group-content bg-[var(--color-bg-secondary)]">
     <slot />
   </div>
 </div>
@@ -19,16 +21,29 @@ const { titles = [] } = Astro.props;
     document.querySelectorAll('.code-group').forEach((group) => {
       const tabsContainer = group.querySelector('.code-group-tabs');
       const contentContainer = group.querySelector('.code-group-content');
-      const titles = JSON.parse(group.getAttribute('data-titles') || '[]');
-      const codeBlocks = contentContainer?.querySelectorAll('pre');
+      const fallbackTitles = JSON.parse(group.getAttribute('data-titles') || '[]');
 
-      if (!tabsContainer || !contentContainer || !codeBlocks?.length) return;
+      const codeItems = contentContainer?.querySelectorAll(':scope > .code-item');
+      const directPres = contentContainer?.querySelectorAll(':scope > pre');
 
-      // Create tabs
-      codeBlocks.forEach((block, index) => {
+      // When CodeItem children exist: use them for tabs (titles from data-title), one tab per .code-item
+      const useCodeItems = (codeItems?.length ?? 0) > 0;
+      const tabPanels = useCodeItems
+        ? Array.from(codeItems!)
+        : Array.from(directPres || []);
+      const titles = useCodeItems && codeItems?.length
+        ? Array.from(codeItems!).map((el) => (el as HTMLElement).getAttribute('data-title') ?? '')
+        : fallbackTitles;
+      const numTabs = tabPanels.length;
+
+      if (!tabsContainer || !contentContainer || numTabs === 0) return;
+
+      // Create tabs from titles; show/hide tabPanels
+      tabPanels.forEach((_panel, index) => {
         const tab = document.createElement('button');
         tab.className = 'shrink-0 px-4 py-2 text-sm font-medium transition-colors whitespace-nowrap text-[var(--color-text-muted)] hover:text-[var(--color-text)]';
-        tab.textContent = titles[index] || `Tab ${index + 1}`;
+        tab.textContent = titles[index]?.trim() || `Tab ${index + 1}`;
+        const panel = tabPanels[index] as HTMLElement;
         tab.addEventListener('click', () => {
           tabsContainer.querySelectorAll('button').forEach((t, i) => {
             if (i === index) {
@@ -39,8 +54,8 @@ const { titles = [] } = Astro.props;
               t.classList.add('text-[var(--color-text-muted)]');
             }
           });
-          codeBlocks.forEach((b, i) => {
-            (b as HTMLElement).style.display = i === index ? 'block' : 'none';
+          tabPanels.forEach((p, i) => {
+            (p as HTMLElement).style.display = i === index ? 'block' : 'none';
           });
         });
         tabsContainer.appendChild(tab);
@@ -49,7 +64,7 @@ const { titles = [] } = Astro.props;
           tab.classList.add('border-b-2', 'border-primary-500', 'text-[var(--color-text)]', '-mb-px');
           tab.classList.remove('text-[var(--color-text-muted)]');
         } else {
-          (block as HTMLElement).style.display = 'none';
+          panel.style.display = 'none';
         }
       });
     });

--- a/packages/theme-docs/src/components/mdx/CodeItem.astro
+++ b/packages/theme-docs/src/components/mdx/CodeItem.astro
@@ -1,0 +1,13 @@
+---
+// Wraps a single code block inside CodeGroup. Use one CodeItem per tab.
+// Put one fenced code block (```lang ... ```) inside; MDX/Shiki handle syntax highlighting.
+interface Props {
+  title?: string;
+}
+
+const { title = "" } = Astro.props;
+---
+
+<div class="code-item" data-title={title}>
+  <slot />
+</div>

--- a/packages/theme-docs/src/index.ts
+++ b/packages/theme-docs/src/index.ts
@@ -1,5 +1,5 @@
 import type { AstroIntegration } from "astro";
-import type { ThemeExport } from "@barodoc/core";
+import type { ThemeExport, ResolvedBarodocConfig } from "@barodoc/core";
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import tailwindcss from "@tailwindcss/vite";
@@ -8,7 +8,60 @@ export interface DocsThemeOptions {
   customCss?: string[];
 }
 
-function createThemeIntegration(options?: DocsThemeOptions): AstroIntegration {
+/** HAST node with optional children and properties */
+interface HastNode {
+  type: string;
+  children?: HastNode[];
+  properties?: Record<string, unknown>;
+  tagName?: string;
+  value?: string;
+}
+
+function getTextContent(node: HastNode): string {
+  if (node.type === "text") return node.value ?? "";
+  if (node.children?.length) return node.children.map(getTextContent).join("");
+  return "";
+}
+
+function isEmptyLine(node: HastNode): boolean {
+  if (node.type !== "element" || node.tagName !== "span") return false;
+  const cls = node.properties?.className;
+  const isLine =
+    Array.isArray(cls) && cls.some((c) => c === "line" || (typeof c === "string" && c.includes("line")));
+  if (!isLine) return false;
+  return /^\s*$/.test(getTextContent(node));
+}
+
+/** Removes leading and trailing empty span.line so only the code area is visible. */
+function createTrimEmptyLinesTransformer() {
+  return {
+    name: "barodoc-trim-empty-lines",
+    code(node: HastNode) {
+      const lines = node.children;
+      if (!lines?.length) return;
+      let start = 0;
+      let end = lines.length;
+      while (start < end && isEmptyLine(lines[start])) start++;
+      while (end > start && isEmptyLine(lines[end - 1])) end--;
+      node.children = lines.slice(start, end);
+    },
+  };
+}
+
+function createLineNumbersTransformer() {
+  return {
+    name: "barodoc-line-numbers",
+    pre(node: { properties?: Record<string, unknown> }) {
+      (this as { addClassToHast: (node: unknown, cls: string) => void }).addClassToHast(node, "line-numbers");
+    },
+  };
+}
+
+function createThemeIntegration(
+  config: ResolvedBarodocConfig,
+  options?: DocsThemeOptions
+): AstroIntegration {
+  const lineNumbers = config?.lineNumbers === true;
   return {
     name: "@barodoc/theme-docs",
     hooks: {
@@ -41,6 +94,10 @@ function createThemeIntegration(options?: DocsThemeOptions): AstroIntegration {
                 light: "github-light",
                 dark: "github-dark",
               },
+              transformers: [
+                createTrimEmptyLinesTransformer(),
+                ...(lineNumbers ? [createLineNumbersTransformer()] : []),
+              ],
             },
           },
         });
@@ -54,7 +111,7 @@ function createThemeIntegration(options?: DocsThemeOptions): AstroIntegration {
 export default function docsTheme(options?: DocsThemeOptions): ThemeExport {
   return {
     name: "@barodoc/theme-docs",
-    integration: () => createThemeIntegration(options),
+    integration: (config) => createThemeIntegration(config, options),
     styles: options?.customCss || [],
   };
 }

--- a/packages/theme-docs/src/styles/global.css
+++ b/packages/theme-docs/src/styles/global.css
@@ -77,29 +77,29 @@
   }
 }
 
-/* Prose styling for MDX content - Mintlify style */
+/* Prose styling for MDX content -  */
 .prose {
   --tw-prose-body: var(--color-text);
   --tw-prose-headings: var(--color-text);
   --tw-prose-links: var(--color-primary-600);
   --tw-prose-code: var(--color-text);
   --tw-prose-pre-bg: var(--color-bg-secondary);
-  font-size: 0.875rem !important;
-  line-height: 1.6 !important;
+  /* font-size: 0.875rem !important; */
+  /* line-height: 1.6 !important; */
 }
 
 .dark .prose {
   --tw-prose-links: var(--color-primary-400);
 }
 
-/* Headings - Mintlify style */
+/* Headings -  */
 .prose :where(h1):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   font-size: 1.75rem !important;
   font-weight: 700 !important;
   letter-spacing: -0.025em !important;
   margin-top: 0 !important;
   margin-bottom: 0.375rem !important;
-  line-height: 1.25 !important;
+  /* line-height: 1.25 !important; */
 }
 
 .prose :where(h2):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
@@ -143,14 +143,14 @@
   text-underline-offset: 2px !important;
 }
 
-/* Code block styling - Mintlify style */
+/* Code block styling -  */
 .prose :where(pre):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   background-color: var(--color-bg) !important;
   border: 1px solid var(--color-border) !important;
   border-radius: 0.5rem !important;
   padding: 0.75rem 1rem !important;
   font-size: 0.8125rem !important;
-  line-height: 1.5 !important;
+  line-height: 1.45 !important;
   overflow-x: auto !important;
   margin: 0.75rem 0 !important;
 }
@@ -185,7 +185,7 @@
   color: var(--color-text-muted) !important;
 }
 
-/* Blockquotes - Mintlify style */
+/* Blockquotes -  */
 .prose :where(blockquote):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
   border-left: 3px solid var(--color-primary-500) !important;
   background-color: var(--color-bg-secondary) !important;
@@ -241,12 +241,48 @@
 .astro-code {
   background-color: var(--color-bg) !important;
   border-radius: 0.5rem;
+  line-height: 1.45;
+}
+
+.astro-code code {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Tighter line spacing: Shiki outputs each line as span.line */
+.astro-code span.line {
+  display: block;
+  line-height: 1.45;
+  margin: 0;
+  padding: 0;
 }
 
 .dark .astro-code,
 .dark .astro-code span {
   color: var(--shiki-dark) !important;
   background-color: var(--shiki-dark-bg) !important;
+}
+
+/* Line numbers: applied when barodoc.config.json has "lineNumbers": true */
+.astro-code.line-numbers {
+  counter-reset: line;
+}
+
+.astro-code.line-numbers span.line {
+  display: block;
+  counter-increment: line;
+}
+
+.astro-code.line-numbers span.line::before {
+  content: counter(line);
+  display: inline-block;
+  min-width: 2.5rem;
+  margin-right: 1rem;
+  padding-right: 0.5rem;
+  text-align: right;
+  color: var(--color-text-muted);
+  user-select: none;
+  border-right: 1px solid var(--color-border);
 }
 
 /* Pagefind search styling */


### PR DESCRIPTION
Closes #31

- CodeItem.astro; CodeGroup uses CodeItem per tab with title
- lineNumbers config (schema, types, theme); Shiki transformers
- Code block CSS: line-height 1.45, code flex column, span.line no margin
- Docs: code-group.mdx, barodoc.config lineNumbers

Made with [Cursor](https://cursor.com)