### PR TITLE
chore: add changeset for CodeGroup, line numbers, code block styles

### DIFF
--- a/.changeset/code-group-line-numbers.md
+++ b/.changeset/code-group-line-numbers.md
@@ -1,0 +1,6 @@
+---
+"@barodoc/core": patch
+"@barodoc/theme-docs": patch
+---
+
+CodeGroup/CodeItem refactor, line numbers option, and code block line spacing. Add `CodeItem` for tabbed code blocks with per-tab titles. Add `lineNumbers` to barodoc config; theme applies Shiki transformer and CSS when enabled. Code block CSS: tighter line-height, `code` as flex column, `span.line` without extra margin.


### PR DESCRIPTION
Closes #33

Adds `.changeset/code-group-line-numbers.md` for @barodoc/core and @barodoc/theme-docs (patch).

Made with [Cursor](https://cursor.com)