### PR TITLE
fix: add missing site/base properties to BarodocConfig type

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,6 +39,8 @@ export interface BarodocConfig {
   name: string;
   logo?: string;
   favicon?: string;
+  site?: string;
+  base?: string;
   
   theme?: BarodocThemeConfig;
   


### PR DESCRIPTION
Closes #37

`BarodocConfig` interface was missing `site` and `base` properties that the Zod schema already defined, causing TS2339 errors in `packages/barodoc` build.

Made with [Cursor](https://cursor.com)