### PR TITLE
feat: content-site separation and AI agent data pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ pnpm-debug.log*
 # Pagefind
 public/pagefind/
 docs/public/pagefind/
+
+# Generated outputs (barodoc manifest / barodoc schema)
+docs-manifest.json
+docs-manifest-chunks.jsonl
+config-schema.json
+frontmatter-schema.json

--- a/docs/barodoc.config.json
+++ b/docs/barodoc.config.json
@@ -24,7 +24,7 @@
     {
       "group": "Guides",
       "group:ko": "가이드",
-      "pages": ["guides/installation", "guides/configuration", "guides/content-structure", "guides/deployment", "guides/i18n"]
+      "pages": ["guides/installation", "guides/configuration", "guides/content-structure", "guides/cli", "guides/overrides", "guides/deployment", "guides/i18n"]
     },
     {
       "group": "Components",

--- a/docs/overrides/components/CustomBanner.tsx
+++ b/docs/overrides/components/CustomBanner.tsx
@@ -1,0 +1,23 @@
+/**
+ * Example custom component override.
+ * Place .tsx/.astro files in overrides/components/ and they become
+ * available as <CustomBanner /> (or whatever the filename) in MDX.
+ *
+ * Import in MDX:
+ *   import CustomBanner from "@overrides/components/CustomBanner";
+ */
+export default function CustomBanner({ text }: { text: string }) {
+  return (
+    <div
+      style={{
+        padding: "1rem 1.5rem",
+        borderRadius: "0.5rem",
+        background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+        color: "#fff",
+        fontWeight: 600,
+      }}
+    >
+      {text}
+    </div>
+  );
+}

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -5,6 +5,12 @@ const docsCollection = defineCollection({
   schema: z.object({
     title: z.string(),
     description: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    related: z.array(z.string()).optional(),
+    category: z.string().optional(),
+    api_reference: z.boolean().optional(),
+    difficulty: z.enum(["beginner", "intermediate", "advanced"]).optional(),
+    lastUpdated: z.date().optional(),
   }),
 });
 

--- a/docs/src/content/docs/en/guides/cli.mdx
+++ b/docs/src/content/docs/en/guides/cli.mdx
@@ -1,0 +1,127 @@
+---
+title: CLI Commands
+description: Barodoc CLI reference — serve, build, check, manifest, and more
+tags: [cli, commands, tools]
+related: [guides/installation, guides/configuration]
+difficulty: beginner
+---
+
+Barodoc ships a CLI (`barodoc`) for developing, building, and validating your documentation.
+
+## serve
+
+Start a development server with hot reload:
+
+```bash
+barodoc serve [dir]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-p, --port <port>` | Port to listen on (default: `4321`) |
+| `-h, --host` | Expose to network |
+| `--open` | Open browser on start |
+| `--clean` | Force reinstall dependencies |
+| `-c, --config <file>` | Config file path |
+
+## build
+
+Build the site for production:
+
+```bash
+barodoc build [dir]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-o, --output <dir>` | Output directory (default: `dist`) |
+| `--clean` | Force reinstall dependencies |
+| `-c, --config <file>` | Config file path |
+
+## preview
+
+Preview a production build locally:
+
+```bash
+barodoc preview [dir]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-p, --port <port>` | Port to listen on (default: `4321`) |
+| `-o, --output <dir>` | Build output directory (default: `dist`) |
+
+## check
+
+Validate your documentation against the navigation config and frontmatter schema:
+
+```bash
+barodoc check [dir]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--fix` | Auto-fix missing files and orphan navigation entries |
+| `-c, --config <file>` | Config file path |
+
+**What it validates:**
+
+- Navigation entries that reference non-existent files
+- Files on disk that are not referenced in navigation (orphans)
+- Missing recommended frontmatter fields (`description`)
+- `related` frontmatter values that point to invalid slugs
+
+Example output:
+
+```
+  barodoc check
+
+  Missing files (1)
+  Navigation references files that don't exist on disk.
+
+  ✗ missing-page → docs/en/missing-page.md
+
+  Invalid related links (1)
+  Frontmatter 'related' references slugs not in navigation.
+
+  ⚠ quickstart → invalid: non-existent-page
+```
+
+## manifest
+
+Generate `docs-manifest.json` — a structured JSON file containing all document metadata, headings, code blocks, and navigation. Designed for AI agent consumption:
+
+```bash
+barodoc manifest [dir]
+```
+
+| Flag | Description |
+|------|-------------|
+| `-o, --output <file>` | Output file path (default: `docs-manifest.json`) |
+| `-c, --config <file>` | Config file path |
+
+The output includes per-page: `slug`, `title`, `description`, `tags`, `related`, `difficulty`, `headings`, `codeBlocks`, `wordCount`, and the full `navigation` tree.
+
+## init
+
+Initialize Barodoc in an existing directory:
+
+```bash
+barodoc init [dir]
+```
+
+## create
+
+Scaffold a new Barodoc project:
+
+```bash
+barodoc create <name>
+```
+
+## eject
+
+Eject from quick mode to a full Astro project:
+
+```bash
+barodoc eject [dir]
+```

--- a/docs/src/content/docs/en/guides/configuration.mdx
+++ b/docs/src/content/docs/en/guides/configuration.mdx
@@ -1,6 +1,9 @@
 ---
 title: Configuration
 description: Configure your Barodoc site
+tags: [config, setup, customization]
+related: [guides/installation, guides/content-structure]
+difficulty: intermediate
 ---
 
 Barodoc is configured through `barodoc.config.json`.
@@ -136,6 +139,73 @@ Paths to additional CSS files (relative to project root or from `public/`). They
 ```json
 {
   "customCss": ["./src/custom.css"]
+}
+```
+
+### site
+
+The full URL of your deployed site (e.g. `"https://docs.example.com"`). Used for canonical URLs and OG meta tags.
+
+### base
+
+Base path if the site is deployed under a subdirectory (e.g. `"/docs"`).
+
+### lineNumbers
+
+When `true`, code blocks render with line numbers.
+
+```json
+{
+  "lineNumbers": true
+}
+```
+
+### editLink
+
+Show an "Edit this page" link on each documentation page. `baseUrl` is the GitHub (or other host) edit URL prefix:
+
+```json
+{
+  "editLink": {
+    "baseUrl": "https://github.com/user/repo/edit/main/docs/src/content/docs/"
+  }
+}
+```
+
+### lastUpdated
+
+When `true`, shows a git-based "Last updated" timestamp in the page footer:
+
+```json
+{
+  "lastUpdated": true
+}
+```
+
+### announcement
+
+Top-of-page banner for site-wide notices. Optionally links somewhere and can be dismissed:
+
+```json
+{
+  "announcement": {
+    "text": "v2.0 is out!",
+    "link": "https://github.com/user/repo/releases",
+    "dismissible": true
+  }
+}
+```
+
+### feedback
+
+Page feedback widget ("Was this helpful?"). When `endpoint` is set, posts `{ page, helpful }` JSON to that URL:
+
+```json
+{
+  "feedback": {
+    "enabled": true,
+    "endpoint": "https://api.example.com/feedback"
+  }
 }
 ```
 

--- a/docs/src/content/docs/en/guides/content-structure.mdx
+++ b/docs/src/content/docs/en/guides/content-structure.mdx
@@ -1,6 +1,9 @@
 ---
 title: Content Structure
 description: Where to put content and how URLs are built
+tags: [content, structure, frontmatter]
+related: [guides/configuration, guides/i18n]
+difficulty: beginner
 ---
 
 Barodoc content is organized by locale; the folder structure becomes the URL path. In **CLI (zero-config)** mode, content lives under **`docs/`** (e.g. `docs/en/`, `docs/ko/`). In **manual Astro** mode, it lives under **`src/content/docs/`** (e.g. `src/content/docs/en/`). The rules below apply to both.
@@ -52,20 +55,33 @@ The same slug is used for all locales; each locale has its own file under its fo
 
 ## Frontmatter
 
-Every doc page should have a title (and optionally description) in frontmatter:
+Every doc page should have a title in frontmatter. Additional fields are available for classification, linking, and AI consumption:
 
 ```mdx
 ---
 title: Installation
 description: Install Barodoc in your project
+tags: [setup, cli]
+related: [quickstart, guides/configuration]
+category: guides
+difficulty: beginner
+api_reference: false
 ---
 
 # Installation
 ...
 ```
 
-- **title** – Shown in the browser tab, sidebar, and meta.
-- **description** – Used for meta description and previews.
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | `string` | Page title. Shown in browser tab, sidebar, and meta. |
+| `description` | `string` | Meta description and previews. |
+| `tags` | `string[]` | Classification tags for search and AI agent filtering. |
+| `related` | `string[]` | Slugs of related pages. `barodoc check` validates these point to real pages. |
+| `category` | `string` | Explicit category override. Auto-detected from navigation group if omitted. |
+| `difficulty` | `"beginner" \| "intermediate" \| "advanced"` | Content difficulty level. |
+| `api_reference` | `boolean` | Marks the page as API reference content. |
+| `lastUpdated` | `date` | Manual override for last-updated timestamp. |
 
 ## MDX and components
 

--- a/docs/src/content/docs/en/guides/deployment.mdx
+++ b/docs/src/content/docs/en/guides/deployment.mdx
@@ -1,6 +1,9 @@
 ---
 title: Deployment
 description: Deploy your Barodoc site to static hosting
+tags: [deployment, hosting, ci]
+related: [guides/installation, guides/configuration]
+difficulty: intermediate
 ---
 
 Barodoc builds to a static site. Deploy the `dist/` folder to any static host.

--- a/docs/src/content/docs/en/guides/i18n.mdx
+++ b/docs/src/content/docs/en/guides/i18n.mdx
@@ -1,6 +1,9 @@
 ---
 title: Internationalization
 description: Multi-language support in Barodoc
+tags: [i18n, localization, multi-language]
+related: [guides/configuration, guides/content-structure]
+difficulty: intermediate
 ---
 
 Barodoc supports multiple languages out of the box.

--- a/docs/src/content/docs/en/guides/installation.mdx
+++ b/docs/src/content/docs/en/guides/installation.mdx
@@ -1,6 +1,9 @@
 ---
 title: Installation
 description: "Install Barodoc: CLI (zero-config) or manual Astro setup"
+tags: [setup, cli, astro]
+related: [quickstart, guides/configuration]
+difficulty: beginner
 ---
 
 Two ways to use Barodoc: **CLI (zero-config)** for a docs-only project, or **Manual (Astro)** for a full Astro app.

--- a/docs/src/content/docs/en/guides/overrides.mdx
+++ b/docs/src/content/docs/en/guides/overrides.mdx
@@ -1,0 +1,88 @@
+---
+title: Overrides & Customization
+description: Customize components and layouts without ejecting from quick mode
+tags: [overrides, customization, components, layouts]
+related: [guides/configuration, guides/cli]
+difficulty: intermediate
+---
+
+Barodoc supports progressive customization. You can override theme components and layouts without ejecting to a full Astro project.
+
+## Customization levels
+
+| Level | What you add | Use case |
+|-------|-------------|----------|
+| **0 — Pure data** | `barodoc.config.json` + `docs/` | Content-only repository |
+| **1 — Component override** | `overrides/components/` | Add or replace MDX components |
+| **2 — Layout override** | `overrides/layouts/` | Replace page layouts (header, footer, sidebar) |
+| **3 — Full Astro** | `astro.config.mjs` + `package.json` | Complete control (`barodoc eject`) |
+
+## Directory structure
+
+```
+my-docs/
+├── barodoc.config.json
+├── docs/
+│   └── en/
+│       └── introduction.mdx
+├── overrides/                   # Optional
+│   ├── components/
+│   │   ├── CustomBanner.tsx     # New MDX component
+│   │   └── Callout.tsx          # Override built-in Callout
+│   └── layouts/
+│       └── DocsLayout.astro     # Override docs layout
+└── public/
+    └── logo.svg
+```
+
+## Component overrides
+
+Place `.tsx` or `.astro` files in `overrides/components/`. They are registered under the `@overrides/components` Vite alias.
+
+### Adding a custom component
+
+Create `overrides/components/CustomBanner.tsx`:
+
+```tsx
+export default function CustomBanner({ text }: { text: string }) {
+  return (
+    <div style={{
+      padding: "1rem 1.5rem",
+      borderRadius: "0.5rem",
+      background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+      color: "#fff",
+      fontWeight: 600,
+    }}>
+      {text}
+    </div>
+  );
+}
+```
+
+Use it in MDX:
+
+```mdx
+import CustomBanner from "@overrides/components/CustomBanner";
+
+<CustomBanner text="Welcome to our docs!" />
+```
+
+### Overriding a built-in component
+
+To override the built-in `Callout` component, create `overrides/components/Callout.tsx` (or `.astro`). Barodoc's Vite alias resolution prioritizes override paths.
+
+## Layout overrides
+
+Place `.astro` files in `overrides/layouts/`. These override the theme's default layouts using the `@overrides/layouts` Vite alias.
+
+For example, to customize the docs page layout, create `overrides/layouts/DocsLayout.astro`.
+
+## How it works
+
+1. When `barodoc serve` or `barodoc build` runs in quick mode, the CLI detects `overrides/` and symlinks it into the temporary `.barodoc/` project.
+2. `@barodoc/core` registers Vite aliases (`@overrides/components`, `@overrides/layouts`) pointing to the override directories.
+3. Theme components can import from these aliases. Override files take priority.
+
+## When to eject
+
+If your customizations grow beyond component/layout overrides — for example, adding custom Astro pages, API routes, or advanced integrations — run `barodoc eject` to convert to a full Astro project.

--- a/docs/src/content/docs/en/introduction.mdx
+++ b/docs/src/content/docs/en/introduction.mdx
@@ -1,6 +1,9 @@
 ---
 title: Introduction
 description: Barodoc - Documentation framework powered by Astro
+tags: [overview, getting-started]
+related: [quickstart]
+difficulty: beginner
 ---
 
 Barodoc is a documentation framework built on Astro, designed to create beautiful documentation sites with minimal configuration.

--- a/docs/src/content/docs/en/quickstart.mdx
+++ b/docs/src/content/docs/en/quickstart.mdx
@@ -1,6 +1,9 @@
 ---
 title: Quick Start
 description: Get started with Barodoc in under 5 minutes
+tags: [getting-started, cli, setup]
+related: [introduction, guides/installation]
+difficulty: beginner
 ---
 
 Create a new documentation site with the CLI (zero-config). No `package.json` or `node_modules` in your project.

--- a/docs/src/content/docs/ko/guides/cli.mdx
+++ b/docs/src/content/docs/ko/guides/cli.mdx
@@ -1,0 +1,111 @@
+---
+title: CLI 명령어
+description: Barodoc CLI 레퍼런스 — serve, build, check, manifest 등
+tags: [cli, commands, tools]
+related: [guides/installation, guides/configuration]
+difficulty: beginner
+---
+
+Barodoc CLI(`barodoc`)로 문서 사이트를 개발, 빌드, 검증할 수 있습니다.
+
+## serve
+
+핫 리로드 포함 개발 서버를 시작합니다:
+
+```bash
+barodoc serve [dir]
+```
+
+| 플래그 | 설명 |
+|--------|------|
+| `-p, --port <port>` | 리슨 포트 (기본: `4321`) |
+| `-h, --host` | 네트워크에 노출 |
+| `--open` | 시작 시 브라우저 열기 |
+| `--clean` | 의존성 강제 재설치 |
+| `-c, --config <file>` | 설정 파일 경로 |
+
+## build
+
+프로덕션 빌드:
+
+```bash
+barodoc build [dir]
+```
+
+| 플래그 | 설명 |
+|--------|------|
+| `-o, --output <dir>` | 출력 디렉토리 (기본: `dist`) |
+| `--clean` | 의존성 강제 재설치 |
+| `-c, --config <file>` | 설정 파일 경로 |
+
+## preview
+
+프로덕션 빌드를 로컬에서 미리보기:
+
+```bash
+barodoc preview [dir]
+```
+
+| 플래그 | 설명 |
+|--------|------|
+| `-p, --port <port>` | 리슨 포트 (기본: `4321`) |
+| `-o, --output <dir>` | 빌드 출력 디렉토리 (기본: `dist`) |
+
+## check
+
+문서를 navigation 설정과 frontmatter 스키마에 대해 검증합니다:
+
+```bash
+barodoc check [dir]
+```
+
+| 플래그 | 설명 |
+|--------|------|
+| `--fix` | 누락 파일 및 미참조 nav 항목 자동 수정 |
+| `-c, --config <file>` | 설정 파일 경로 |
+
+**검증 항목:**
+
+- navigation에 등록되었지만 파일이 없는 항목
+- 파일은 있지만 navigation에 등록되지 않은 항목(orphan)
+- 권장 frontmatter 필드 누락 (`description`)
+- `related` frontmatter 값이 유효하지 않은 slug를 참조하는 경우
+
+## manifest
+
+`docs-manifest.json` 생성 — 전체 문서 메타데이터, 헤딩, 코드 블록, navigation을 구조화된 JSON으로 추출합니다. AI 에이전트 소비에 최적화:
+
+```bash
+barodoc manifest [dir]
+```
+
+| 플래그 | 설명 |
+|--------|------|
+| `-o, --output <file>` | 출력 파일 경로 (기본: `docs-manifest.json`) |
+| `-c, --config <file>` | 설정 파일 경로 |
+
+출력에는 페이지별 `slug`, `title`, `description`, `tags`, `related`, `difficulty`, `headings`, `codeBlocks`, `wordCount`와 전체 `navigation` 트리가 포함됩니다.
+
+## init
+
+기존 디렉토리에서 Barodoc 초기화:
+
+```bash
+barodoc init [dir]
+```
+
+## create
+
+새 Barodoc 프로젝트 스캐폴드:
+
+```bash
+barodoc create <name>
+```
+
+## eject
+
+quick mode에서 전체 Astro 프로젝트로 전환:
+
+```bash
+barodoc eject [dir]
+```

--- a/docs/src/content/docs/ko/guides/configuration.mdx
+++ b/docs/src/content/docs/ko/guides/configuration.mdx
@@ -1,6 +1,9 @@
 ---
 title: 설정
 description: Barodoc 설정 가이드
+tags: [config, setup, customization]
+related: [guides/installation, guides/content-structure]
+difficulty: intermediate
 ---
 
 `barodoc.config.json` 파일로 사이트를 설정합니다.
@@ -98,6 +101,73 @@ Pagefind 검색을 켜거나 끕니다:
 ## theme.radius
 
 UI 요소의 border radius (예: `"0.5rem"`, `"8px"`).
+
+## site
+
+배포된 사이트의 전체 URL (예: `"https://docs.example.com"`). 정규 URL 및 OG 메타 태그에 사용.
+
+## base
+
+사이트가 서브디렉토리에 배포될 경우의 기본 경로 (예: `"/docs"`).
+
+## lineNumbers
+
+`true`로 설정하면 코드 블록에 줄 번호를 표시합니다:
+
+```json
+{
+  "lineNumbers": true
+}
+```
+
+## editLink
+
+각 문서 페이지에 "Edit this page" 링크를 표시합니다. `baseUrl`은 GitHub(또는 다른 호스트) 편집 URL 접두사입니다:
+
+```json
+{
+  "editLink": {
+    "baseUrl": "https://github.com/user/repo/edit/main/docs/src/content/docs/"
+  }
+}
+```
+
+## lastUpdated
+
+`true`로 설정하면 페이지 하단에 git 기반 "최종 수정일" 타임스탬프를 표시합니다:
+
+```json
+{
+  "lastUpdated": true
+}
+```
+
+## announcement
+
+사이트 상단에 공지 배너를 표시합니다. 링크와 닫기 기능을 옵션으로 설정할 수 있습니다:
+
+```json
+{
+  "announcement": {
+    "text": "v2.0 출시!",
+    "link": "https://github.com/user/repo/releases",
+    "dismissible": true
+  }
+}
+```
+
+## feedback
+
+페이지 피드백 위젯("도움이 되었나요?"). `endpoint` 설정 시 해당 URL로 `{ page, helpful }` JSON을 POST합니다:
+
+```json
+{
+  "feedback": {
+    "enabled": true,
+    "endpoint": "https://api.example.com/feedback"
+  }
+}
+```
 
 ## 플러그인
 

--- a/docs/src/content/docs/ko/guides/content-structure.mdx
+++ b/docs/src/content/docs/ko/guides/content-structure.mdx
@@ -1,6 +1,9 @@
 ---
 title: Content Structure
 description: 콘텐츠 위치와 URL 구조
+tags: [content, structure, frontmatter]
+related: [guides/configuration, guides/i18n]
+difficulty: beginner
 ---
 
 Barodoc 콘텐츠는 locale별로 정리되며, 폴더 구조가 URL 경로가 됩니다. **CLI(제로 설정)** 모드에서는 **`docs/`** 아래에 두고(예: `docs/en/`, `docs/ko/`), **수동 Astro** 모드에서는 **`src/content/docs/`** 아래에 둡니다(예: `src/content/docs/en/`). 아래 규칙은 두 방식 모두에 적용됩니다.
@@ -52,20 +55,33 @@ src/content/docs/
 
 ## Frontmatter
 
-각 문서 상단에 `title`(필수)과 필요 시 `description`을 둡니다:
+각 문서 상단에 `title`을 둡니다. 분류, 연관 문서 링크, AI 소비를 위한 추가 필드를 사용할 수 있습니다:
 
 ```mdx
 ---
 title: Installation
 description: Barodoc 설치 방법
+tags: [setup, cli]
+related: [quickstart, guides/configuration]
+category: guides
+difficulty: beginner
+api_reference: false
 ---
 
 # Installation
 ...
 ```
 
-- **title** – 브라우저 탭, 사이드바, 메타에 사용됩니다.
-- **description** – 메타 설명과 미리보기에 사용됩니다.
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `title` | `string` | 페이지 제목. 브라우저 탭, 사이드바, 메타에 사용. |
+| `description` | `string` | 메타 설명과 미리보기에 사용. |
+| `tags` | `string[]` | 검색 및 AI 에이전트 필터링용 분류 태그. |
+| `related` | `string[]` | 관련 페이지의 slug. `barodoc check`가 유효성을 검증. |
+| `category` | `string` | 카테고리 직접 지정. 생략 시 navigation 그룹에서 자동 감지. |
+| `difficulty` | `"beginner" \| "intermediate" \| "advanced"` | 콘텐츠 난이도. |
+| `api_reference` | `boolean` | API 레퍼런스 문서 표시. |
+| `lastUpdated` | `date` | 최종 수정일 수동 지정. |
 
 ## MDX와 컴포넌트
 

--- a/docs/src/content/docs/ko/guides/deployment.mdx
+++ b/docs/src/content/docs/ko/guides/deployment.mdx
@@ -1,6 +1,9 @@
 ---
 title: Deployment
 description: Barodoc 사이트를 정적 호스팅에 배포하기
+tags: [deployment, hosting, ci]
+related: [guides/installation, guides/configuration]
+difficulty: intermediate
 ---
 
 Barodoc은 정적 사이트로 빌드됩니다. `dist/` 폴더를 원하는 정적 호스팅에 배포하면 됩니다.

--- a/docs/src/content/docs/ko/guides/i18n.mdx
+++ b/docs/src/content/docs/ko/guides/i18n.mdx
@@ -1,6 +1,9 @@
 ---
 title: 다국어 지원
 description: Barodoc 다국어(i18n) 설정 가이드
+tags: [i18n, localization, multi-language]
+related: [guides/configuration, guides/content-structure]
+difficulty: intermediate
 ---
 
 Barodoc은 여러 언어로 문서를 작성할 수 있습니다.

--- a/docs/src/content/docs/ko/guides/installation.mdx
+++ b/docs/src/content/docs/ko/guides/installation.mdx
@@ -1,6 +1,9 @@
 ---
 title: 설치
 description: "Barodoc 설치: CLI(제로 설정) 또는 수동 Astro 설정"
+tags: [setup, cli, astro]
+related: [quickstart, guides/configuration]
+difficulty: beginner
 ---
 
 Barodoc을 쓰는 방법은 두 가지입니다. **CLI(제로 설정)**은 문서 전용 프로젝트용이고, **수동(Astro)**은 Astro 앱 전체를 쓰는 경우입니다.

--- a/docs/src/content/docs/ko/guides/overrides.mdx
+++ b/docs/src/content/docs/ko/guides/overrides.mdx
@@ -1,0 +1,88 @@
+---
+title: 오버라이드 & 커스터마이징
+description: quick mode에서 eject 없이 컴포넌트와 레이아웃을 커스터마이징
+tags: [overrides, customization, components, layouts]
+related: [guides/configuration, guides/cli]
+difficulty: intermediate
+---
+
+Barodoc은 점진적 커스터마이징을 지원합니다. 전체 Astro 프로젝트로 eject하지 않고도 테마 컴포넌트와 레이아웃을 오버라이드할 수 있습니다.
+
+## 커스터마이징 레벨
+
+| 레벨 | 추가 항목 | 사용 사례 |
+|------|----------|----------|
+| **0 — 순수 데이터** | `barodoc.config.json` + `docs/` | 콘텐츠 전용 리포지토리 |
+| **1 — 컴포넌트 오버라이드** | `overrides/components/` | MDX 컴포넌트 추가 또는 교체 |
+| **2 — 레이아웃 오버라이드** | `overrides/layouts/` | 페이지 레이아웃 교체 (헤더, 푸터, 사이드바) |
+| **3 — 전체 Astro** | `astro.config.mjs` + `package.json` | 완전한 제어 (`barodoc eject`) |
+
+## 디렉토리 구조
+
+```
+my-docs/
+├── barodoc.config.json
+├── docs/
+│   └── en/
+│       └── introduction.mdx
+├── overrides/                   # 선택사항
+│   ├── components/
+│   │   ├── CustomBanner.tsx     # 새 MDX 컴포넌트
+│   │   └── Callout.tsx          # 빌트인 Callout 오버라이드
+│   └── layouts/
+│       └── DocsLayout.astro     # 문서 레이아웃 오버라이드
+└── public/
+    └── logo.svg
+```
+
+## 컴포넌트 오버라이드
+
+`overrides/components/`에 `.tsx` 또는 `.astro` 파일을 놓으면 `@overrides/components` Vite alias로 등록됩니다.
+
+### 커스텀 컴포넌트 추가
+
+`overrides/components/CustomBanner.tsx` 생성:
+
+```tsx
+export default function CustomBanner({ text }: { text: string }) {
+  return (
+    <div style={{
+      padding: "1rem 1.5rem",
+      borderRadius: "0.5rem",
+      background: "linear-gradient(135deg, #667eea 0%, #764ba2 100%)",
+      color: "#fff",
+      fontWeight: 600,
+    }}>
+      {text}
+    </div>
+  );
+}
+```
+
+MDX에서 사용:
+
+```mdx
+import CustomBanner from "@overrides/components/CustomBanner";
+
+<CustomBanner text="문서에 오신 것을 환영합니다!" />
+```
+
+### 빌트인 컴포넌트 오버라이드
+
+빌트인 `Callout` 컴포넌트를 오버라이드하려면 `overrides/components/Callout.tsx` (또는 `.astro`)를 생성합니다. Barodoc의 Vite alias resolution이 override 경로를 우선 적용합니다.
+
+## 레이아웃 오버라이드
+
+`overrides/layouts/`에 `.astro` 파일을 놓으면 테마의 기본 레이아웃을 `@overrides/layouts` Vite alias로 오버라이드합니다.
+
+예를 들어, 문서 페이지 레이아웃을 커스터마이징하려면 `overrides/layouts/DocsLayout.astro`를 생성합니다.
+
+## 동작 원리
+
+1. `barodoc serve` 또는 `barodoc build` 실행 시 CLI가 `overrides/`를 감지하고 임시 `.barodoc/` 프로젝트에 symlink합니다.
+2. `@barodoc/core`가 Vite alias (`@overrides/components`, `@overrides/layouts`)를 override 디렉토리를 가리키도록 등록합니다.
+3. 테마 컴포넌트가 이 alias에서 import하며, override 파일이 우선 적용됩니다.
+
+## eject 시점
+
+커스터마이징이 컴포넌트/레이아웃 오버라이드를 넘어설 때 — 예를 들어, 커스텀 Astro 페이지, API 라우트, 고급 인테그레이션이 필요할 때 — `barodoc eject`로 전체 Astro 프로젝트로 전환합니다.

--- a/docs/src/content/docs/ko/introduction.mdx
+++ b/docs/src/content/docs/ko/introduction.mdx
@@ -1,6 +1,9 @@
 ---
 title: 소개
 description: Barodoc 문서화 프레임워크 소개
+tags: [overview, getting-started]
+related: [quickstart]
+difficulty: beginner
 ---
 
 Barodoc은 Astro 기반의 문서화 프레임워크입니다. Mintlify 스타일의 문서 사이트를 쉽게 만들 수 있습니다.

--- a/docs/src/content/docs/ko/quickstart.mdx
+++ b/docs/src/content/docs/ko/quickstart.mdx
@@ -1,6 +1,9 @@
 ---
 title: 빠른 시작
 description: 5분 안에 Barodoc 문서 사이트 만들기
+tags: [getting-started, cli, setup]
+related: [introduction, guides/installation]
+difficulty: beginner
 ---
 
 CLI(제로 설정)로 새 문서 사이트를 만듭니다. 프로젝트에 `package.json`이나 `node_modules`가 없습니다.

--- a/packages/barodoc/package.json
+++ b/packages/barodoc/package.json
@@ -29,7 +29,9 @@
     "execa": "^9.5.0",
     "fs-extra": "^11.2.0",
     "gray-matter": "^4.0.3",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "zod": "^3.24.0",
+    "zod-to-json-schema": "^3.25.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",

--- a/packages/barodoc/src/cli.ts
+++ b/packages/barodoc/src/cli.ts
@@ -10,6 +10,8 @@ import { preview } from "./commands/preview.js";
 import { init } from "./commands/init.js";
 import { eject } from "./commands/eject.js";
 import { check } from "./commands/check.js";
+import { manifest } from "./commands/manifest.js";
+import { schema } from "./commands/schema.js";
 
 const cli = cac("barodoc");
 
@@ -60,6 +62,23 @@ cli
   .option("-c, --config <file>", "Config file path")
   .action(async (dir: string = ".", options) => {
     await check(dir, options);
+  });
+
+cli
+  .command("manifest [dir]", "Generate docs-manifest.json for AI consumption")
+  .option("-o, --output <file>", "Output file path", { default: "docs-manifest.json" })
+  .option("--lite", "Metadata only (no sections/content)")
+  .option("--chunks", "Also generate JSONL chunks for RAG")
+  .option("-c, --config <file>", "Config file path")
+  .action(async (dir: string = ".", options) => {
+    await manifest(dir, options);
+  });
+
+cli
+  .command("schema [dir]", "Export JSON Schema for config and frontmatter")
+  .option("-o, --output <dir>", "Output directory")
+  .action(async (dir: string = ".", options) => {
+    await schema(dir, options);
   });
 
 cli

--- a/packages/barodoc/src/commands/check.ts
+++ b/packages/barodoc/src/commands/check.ts
@@ -15,10 +15,36 @@ interface CheckResult {
 }
 
 /**
+ * Recursively collect markdown/mdx slugs relative to baseDir.
+ */
+async function collectSlugs(baseDir: string, prefix: string = ""): Promise<string[]> {
+  const slugs: string[] = [];
+  if (!(await fs.pathExists(baseDir))) return slugs;
+  const entries = await fs.readdir(baseDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      slugs.push(...await collectSlugs(path.join(baseDir, entry.name), prefix ? `${prefix}/${entry.name}` : entry.name));
+    } else if (entry.name.endsWith(".md") || entry.name.endsWith(".mdx")) {
+      const slug = entry.name.replace(/\.(mdx?)$/, "");
+      slugs.push(prefix ? `${prefix}/${slug}` : slug);
+    }
+  }
+  return slugs;
+}
+
+/**
+ * Resolve docs directory — supports both quick mode (docs/) and custom mode (src/content/docs/).
+ */
+function resolveDocsDir(root: string): string {
+  const customMode = path.join(root, "src", "content", "docs");
+  if (fs.existsSync(customMode)) return customMode;
+  return path.join(root, "docs");
+}
+
+/**
  * Get all markdown files under docs/
  */
 async function scanDocsFiles(docsDir: string): Promise<Map<string, string[]>> {
-  // locale -> slugs
   const result = new Map<string, string[]>();
 
   if (!(await fs.pathExists(docsDir))) {
@@ -31,13 +57,7 @@ async function scanDocsFiles(docsDir: string): Promise<Map<string, string[]>> {
     const stat = await fs.stat(localeDir);
     if (!stat.isDirectory()) continue;
 
-    const slugs: string[] = [];
-    const files = await fs.readdir(localeDir);
-    for (const file of files) {
-      if (file.endsWith(".md") || file.endsWith(".mdx")) {
-        slugs.push(file.replace(/\.(mdx?)$/, ""));
-      }
-    }
+    const slugs = await collectSlugs(localeDir);
     result.set(locale, slugs);
   }
 
@@ -67,6 +87,33 @@ function getNavSlugs(config: any): Map<string, Set<string>> {
 }
 
 /**
+ * Parse YAML frontmatter from a markdown file (simple line-based parser).
+ */
+function parseFrontmatter(content: string): Record<string, unknown> | null {
+  if (!content.startsWith("---")) return null;
+  const end = content.indexOf("---", 3);
+  if (end === -1) return null;
+  const block = content.slice(3, end).trim();
+  const result: Record<string, unknown> = {};
+  for (const line of block.split("\n")) {
+    const match = line.match(/^(\w[\w_]*):\s*(.*)/);
+    if (!match) continue;
+    const [, key, raw] = match;
+    const value = raw.trim();
+    if (value.startsWith("[") && value.endsWith("]")) {
+      result[key] = value.slice(1, -1).split(",").map((s) => s.trim().replace(/^['"]|['"]$/g, ""));
+    } else if (value === "true") {
+      result[key] = true;
+    } else if (value === "false") {
+      result[key] = false;
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/**
  * Check frontmatter of a markdown file
  */
 async function checkFrontmatter(
@@ -75,23 +122,49 @@ async function checkFrontmatter(
   const content = await fs.readFile(filePath, "utf-8");
   const missing: string[] = [];
 
-  // Check if frontmatter exists at all
   if (!content.startsWith("---")) {
-    // No frontmatter - but not required for barodoc (title can come from # heading)
     return missing;
   }
 
-  const end = content.indexOf("---", 3);
-  if (end === -1) return missing;
+  const fm = parseFrontmatter(content);
+  if (!fm) return missing;
 
-  const frontmatter = content.slice(3, end);
-
-  // Check for description (recommended but not required)
-  if (!frontmatter.includes("description:")) {
-    missing.push("description");
-  }
+  if (!fm.description) missing.push("description");
 
   return missing;
+}
+
+/**
+ * Validate `related` links in frontmatter point to existing pages.
+ */
+async function checkRelatedLinks(
+  docsDir: string,
+  locales: string[],
+  defaultLocale: string,
+  navSlugs: Map<string, Set<string>>
+): Promise<Array<{ filePath: string; slug: string; invalidRelated: string[] }>> {
+  const issues: Array<{ filePath: string; slug: string; invalidRelated: string[] }> = [];
+  const allSlugs = navSlugs.get(defaultLocale) ?? new Set();
+
+  const defaultDir = path.join(docsDir, defaultLocale);
+  if (!(await fs.pathExists(defaultDir))) return issues;
+
+  const files = await fs.readdir(defaultDir);
+  for (const file of files) {
+    if (!file.endsWith(".md") && !file.endsWith(".mdx")) continue;
+    const slug = file.replace(/\.(mdx?)$/, "");
+    const filePath = path.join(defaultDir, file);
+    const content = await fs.readFile(filePath, "utf-8");
+    const fm = parseFrontmatter(content);
+    if (!fm || !Array.isArray(fm.related)) continue;
+
+    const invalid = (fm.related as string[]).filter((r) => !allSlugs.has(r));
+    if (invalid.length > 0) {
+      issues.push({ filePath: path.relative(path.dirname(docsDir), filePath), slug, invalidRelated: invalid });
+    }
+  }
+
+  return issues;
 }
 
 export async function check(dir: string, options: CheckOptions): Promise<void> {
@@ -102,7 +175,7 @@ export async function check(dir: string, options: CheckOptions): Promise<void> {
   console.log(pc.bold(pc.cyan("  barodoc check")));
   console.log();
 
-  const docsDir = path.join(root, "docs");
+  const docsDir = resolveDocsDir(root);
   const locales: string[] = (config as any).i18n?.locales ?? ["en"];
   const defaultLocale: string = (config as any).i18n?.defaultLocale ?? "en";
 
@@ -177,6 +250,9 @@ export async function check(dir: string, options: CheckOptions): Promise<void> {
     }
   }
 
+  // Check: related links point to valid slugs
+  const relatedIssues = await checkRelatedLinks(docsDir, locales, defaultLocale, navSlugs);
+
   // ── Report ────────────────────────────────────────────────────────────────
 
   let hasIssues = false;
@@ -220,6 +296,21 @@ export async function check(dir: string, options: CheckOptions): Promise<void> {
     for (const item of result.missingFrontmatter) {
       console.log(
         `  ${pc.dim("○")} ${item.filePath} ${pc.dim(`— missing: ${item.fields.join(", ")}`)}`
+      );
+    }
+    console.log();
+  }
+
+  // Invalid related links
+  if (relatedIssues.length > 0) {
+    hasIssues = true;
+    console.log(pc.bold(pc.yellow(`  Invalid related links (${relatedIssues.length})`)));
+    console.log(pc.dim("  Frontmatter 'related' references slugs not in navigation."));
+    console.log();
+
+    for (const item of relatedIssues) {
+      console.log(
+        `  ${pc.yellow("⚠")} ${pc.bold(item.slug)} ${pc.dim(`→ invalid: ${item.invalidRelated.join(", ")}`)}`
       );
     }
     console.log();

--- a/packages/barodoc/src/commands/manifest.ts
+++ b/packages/barodoc/src/commands/manifest.ts
@@ -1,0 +1,429 @@
+import path from "path";
+import pc from "picocolors";
+import fs from "fs-extra";
+import matter from "gray-matter";
+import { loadProjectConfig } from "../runtime/project.js";
+
+interface ManifestOptions {
+  config?: string;
+  output?: string;
+  lite?: boolean;
+  chunks?: boolean;
+}
+
+interface ManifestSection {
+  heading: string;
+  depth: number;
+  content: string;
+}
+
+interface CodeExample {
+  lang: string;
+  code: string;
+  section: string;
+}
+
+interface ComponentProp {
+  name: string;
+  type: string;
+  required: boolean;
+  description: string;
+  default?: string;
+}
+
+interface ComponentAPI {
+  name: string;
+  props: ComponentProp[];
+}
+
+interface ManifestPage {
+  slug: string;
+  title: string;
+  description: string;
+  summary: string;
+  category: string | null;
+  locale: string;
+  tags: string[];
+  related: string[];
+  difficulty: string | null;
+  api_reference: boolean;
+  headings: Array<{ depth: number; text: string }>;
+  codeBlocks: Array<{ lang: string; lines: number }>;
+  wordCount: number;
+  filePath: string;
+  sections?: ManifestSection[];
+  codeExamples?: CodeExample[];
+  componentAPI?: ComponentAPI;
+}
+
+interface DocsManifest {
+  name: string;
+  generatedAt: string;
+  locales: string[];
+  defaultLocale: string;
+  pages: ManifestPage[];
+  navigation: Array<{ group: string; pages: string[] }>;
+}
+
+interface Chunk {
+  id: string;
+  page_slug: string;
+  section: string;
+  locale: string;
+  content: string;
+  tokens_approx: number;
+  tags: string[];
+  difficulty: string | null;
+  type: string;
+}
+
+// ── Extraction helpers ───────────────────────────────────────────────────────
+
+function extractHeadings(content: string): Array<{ depth: number; text: string }> {
+  const headings: Array<{ depth: number; text: string }> = [];
+  const lines = content.split("\n");
+  let inCodeBlock = false;
+  for (const line of lines) {
+    if (line.startsWith("```")) { inCodeBlock = !inCodeBlock; continue; }
+    if (inCodeBlock) continue;
+    const match = line.match(/^(#{1,6})\s+(.+)/);
+    if (match) {
+      headings.push({ depth: match[1].length, text: match[2].trim() });
+    }
+  }
+  return headings;
+}
+
+function extractCodeBlocksFull(content: string): Array<{ lang: string; code: string; lines: number }> {
+  const blocks: Array<{ lang: string; code: string; lines: number }> = [];
+  const regex = /```(\w*)\n([\s\S]*?)```/g;
+  let m;
+  while ((m = regex.exec(content)) !== null) {
+    blocks.push({
+      lang: m[1] || "text",
+      code: m[2].trimEnd(),
+      lines: m[2].split("\n").length - (m[2].endsWith("\n") ? 1 : 0),
+    });
+  }
+  return blocks;
+}
+
+function extractSections(content: string): ManifestSection[] {
+  const sections: ManifestSection[] = [];
+  const lines = content.split("\n");
+  let current: ManifestSection | null = null;
+  let buffer: string[] = [];
+  let inCodeBlock = false;
+
+  function flush() {
+    if (current) {
+      current.content = buffer.join("\n").trim();
+      if (current.content) sections.push(current);
+    }
+  }
+
+  for (const line of lines) {
+    if (line.startsWith("```")) inCodeBlock = !inCodeBlock;
+
+    if (!inCodeBlock) {
+      const match = line.match(/^(#{2,3})\s+(.+)/);
+      if (match) {
+        flush();
+        current = { heading: match[2].trim(), depth: match[1].length, content: "" };
+        buffer = [];
+        continue;
+      }
+    }
+
+    if (current) {
+      buffer.push(line);
+    } else if (!sections.length) {
+      if (!current) {
+        current = { heading: "(intro)", depth: 0, content: "" };
+      }
+      buffer.push(line);
+    }
+  }
+  flush();
+  return sections;
+}
+
+function extractSummary(content: string, description: string): string {
+  if (description) return description;
+  const stripped = content
+    .replace(/^import\s+.*$/gm, "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/^#{1,6}\s+.*$/gm, "")
+    .trim();
+  const sentences = stripped.split(/(?<=[.!?])\s+/);
+  return sentences.slice(0, 2).join(" ").trim().slice(0, 300);
+}
+
+function extractComponentAPI(content: string, slug: string): ComponentAPI | undefined {
+  const props: ComponentProp[] = [];
+  const paramRegex = /<ParamField\s+([^>]*?)(?:\/>|>([\s\S]*?)<\/ParamField>)/g;
+  let m;
+  while ((m = paramRegex.exec(content)) !== null) {
+    const attrs = m[1];
+    const innerText = m[2]?.trim() || "";
+
+    const nameMatch = attrs.match(/name=["']([^"']+)["']/);
+    const typeMatch = attrs.match(/type=["']([^"']+)["']/);
+    const defaultMatch = attrs.match(/default=["']([^"']+)["']/);
+    const required = /\brequired\b/.test(attrs);
+
+    if (nameMatch) {
+      props.push({
+        name: nameMatch[1],
+        type: typeMatch?.[1] ?? "unknown",
+        required,
+        description: innerText.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim(),
+        ...(defaultMatch ? { default: defaultMatch[1] } : {}),
+      });
+    }
+  }
+
+  if (props.length === 0) return undefined;
+
+  const name = slug.split("/").pop()!
+    .split("-").map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join("");
+  return { name, props };
+}
+
+function labelCodeExamples(content: string): CodeExample[] {
+  const sections = extractSections(content);
+  const examples: CodeExample[] = [];
+
+  for (const section of sections) {
+    const regex = /```(\w*)\n([\s\S]*?)```/g;
+    let m;
+    while ((m = regex.exec(section.content)) !== null) {
+      examples.push({
+        lang: m[1] || "text",
+        code: m[2].trimEnd(),
+        section: section.heading,
+      });
+    }
+  }
+  return examples;
+}
+
+function countWords(content: string): number {
+  const stripped = content
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/^---[\s\S]*?---/m, "")
+    .replace(/[#*_~`\[\]()>|]/g, "");
+  return stripped.split(/\s+/).filter((w) => w.length > 0).length;
+}
+
+function findCategory(slug: string, navigation: Array<{ group: string; pages: string[] }>): string | null {
+  for (const group of navigation) {
+    if (group.pages.includes(slug)) return group.group;
+  }
+  return null;
+}
+
+function approxTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function slugToType(slug: string): string {
+  if (slug.startsWith("components/")) return "component";
+  if (slug.startsWith("guides/")) return "guide";
+  return "page";
+}
+
+// ── Directory scan ───────────────────────────────────────────────────────────
+
+async function scanDir(dir: string): Promise<string[]> {
+  if (!(await fs.pathExists(dir))) return [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  let results: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results = results.concat(await scanDir(full));
+    } else if (entry.name.endsWith(".md") || entry.name.endsWith(".mdx")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+// ── Chunk generation ─────────────────────────────────────────────────────────
+
+function generateChunks(pages: ManifestPage[]): Chunk[] {
+  const chunks: Chunk[] = [];
+
+  for (const page of pages) {
+    if (!page.sections) continue;
+
+    for (const section of page.sections) {
+      const sectionId = section.heading
+        .toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+      const id = `${page.locale}/${page.slug}#${sectionId}`;
+      const tokens = approxTokens(section.content);
+
+      if (tokens <= 500 || section.depth >= 3) {
+        chunks.push({
+          id,
+          page_slug: page.slug,
+          section: section.heading,
+          locale: page.locale,
+          content: section.content,
+          tokens_approx: tokens,
+          tags: page.tags,
+          difficulty: page.difficulty,
+          type: slugToType(page.slug),
+        });
+      } else {
+        const subSections = splitByH3(section.content, section.heading);
+        for (const sub of subSections) {
+          const subId = sub.heading
+            .toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+          chunks.push({
+            id: `${page.locale}/${page.slug}#${subId}`,
+            page_slug: page.slug,
+            section: sub.heading,
+            locale: page.locale,
+            content: sub.content,
+            tokens_approx: approxTokens(sub.content),
+            tags: page.tags,
+            difficulty: page.difficulty,
+            type: slugToType(page.slug),
+          });
+        }
+      }
+    }
+  }
+
+  return chunks;
+}
+
+function splitByH3(content: string, parentHeading: string): Array<{ heading: string; content: string }> {
+  const parts: Array<{ heading: string; content: string }> = [];
+  const lines = content.split("\n");
+  let current = { heading: parentHeading, content: "" };
+  let buffer: string[] = [];
+  let inCode = false;
+
+  function flush() {
+    current.content = buffer.join("\n").trim();
+    if (current.content) parts.push({ ...current });
+  }
+
+  for (const line of lines) {
+    if (line.startsWith("```")) inCode = !inCode;
+    if (!inCode) {
+      const match = line.match(/^###\s+(.+)/);
+      if (match) {
+        flush();
+        current = { heading: match[1].trim(), content: "" };
+        buffer = [];
+        continue;
+      }
+    }
+    buffer.push(line);
+  }
+  flush();
+  return parts;
+}
+
+// ── Main command ─────────────────────────────────────────────────────────────
+
+export async function manifest(dir: string, options: ManifestOptions): Promise<void> {
+  const root = path.resolve(process.cwd(), dir);
+  const { config } = await loadProjectConfig(root, options.config);
+  const isLite = options.lite === true;
+  const emitChunks = options.chunks === true;
+
+  console.log();
+  console.log(pc.bold(pc.cyan("  barodoc manifest")));
+  if (isLite) console.log(pc.dim("  (lite mode — metadata only)"));
+  console.log();
+
+  const customModeDir = path.join(root, "src", "content", "docs");
+  const quickModeDir = path.join(root, "docs");
+  const docsDir = fs.existsSync(customModeDir) ? customModeDir : quickModeDir;
+  const locales: string[] = (config as any).i18n?.locales ?? ["en"];
+  const defaultLocale: string = (config as any).i18n?.defaultLocale ?? "en";
+  const navigation: Array<{ group: string; pages: string[] }> = (config as any).navigation ?? [];
+
+  const pages: ManifestPage[] = [];
+
+  for (const locale of locales) {
+    const localeDir = path.join(docsDir, locale);
+    const files = await scanDir(localeDir);
+
+    for (const filePath of files) {
+      const raw = await fs.readFile(filePath, "utf-8");
+      const { data: fm, content } = matter(raw);
+
+      const relPath = path.relative(localeDir, filePath);
+      const slug = relPath.replace(/\.(mdx?)$/, "").replace(/\\/g, "/");
+
+      const title = fm.title
+        || extractHeadings(content).find((h) => h.depth === 1)?.text
+        || slug.split("/").pop()!.split("-").map((w: string) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+
+      const codeBlocksFull = extractCodeBlocksFull(content);
+
+      const page: ManifestPage = {
+        slug,
+        title,
+        description: fm.description ?? "",
+        summary: extractSummary(content, fm.description ?? ""),
+        category: fm.category ?? findCategory(slug, navigation),
+        locale,
+        tags: Array.isArray(fm.tags) ? fm.tags : [],
+        related: Array.isArray(fm.related) ? fm.related : [],
+        difficulty: fm.difficulty ?? null,
+        api_reference: fm.api_reference === true,
+        headings: extractHeadings(content),
+        codeBlocks: codeBlocksFull.map((b) => ({ lang: b.lang, lines: b.lines })),
+        wordCount: countWords(raw),
+        filePath: `${locale}/${relPath}`,
+      };
+
+      if (!isLite) {
+        page.sections = extractSections(content);
+        page.codeExamples = labelCodeExamples(content);
+        const api = extractComponentAPI(content, slug);
+        if (api) page.componentAPI = api;
+      }
+
+      pages.push(page);
+    }
+  }
+
+  const result: DocsManifest = {
+    name: (config as any).name ?? "Docs",
+    generatedAt: new Date().toISOString(),
+    locales,
+    defaultLocale,
+    pages,
+    navigation: navigation.map((g) => ({ group: g.group, pages: g.pages })),
+  };
+
+  const outPath = options.output
+    ? path.resolve(root, options.output)
+    : path.join(root, "docs-manifest.json");
+
+  await fs.writeJSON(outPath, result, { spaces: 2 });
+
+  console.log(pc.green(`  ✓ Generated ${path.relative(root, outPath)}`));
+  console.log(pc.dim(`    ${pages.length} pages across ${locales.length} locale(s)`));
+
+  if (emitChunks) {
+    const chunks = generateChunks(pages);
+    const chunksPath = outPath.replace(/\.json$/, "") + "-chunks.jsonl";
+    const jsonl = chunks.map((c) => JSON.stringify(c)).join("\n");
+    await fs.writeFile(chunksPath, jsonl, "utf-8");
+    console.log(pc.green(`  ✓ Generated ${path.relative(root, chunksPath)}`));
+    console.log(pc.dim(`    ${chunks.length} chunks`));
+  }
+
+  console.log();
+}

--- a/packages/barodoc/src/commands/schema.ts
+++ b/packages/barodoc/src/commands/schema.ts
@@ -1,0 +1,40 @@
+import path from "path";
+import pc from "picocolors";
+import fs from "fs-extra";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { barodocConfigSchema, docsFrontmatterSchema } from "@barodoc/core";
+
+interface SchemaOptions {
+  output?: string;
+}
+
+export async function schema(dir: string, options: SchemaOptions): Promise<void> {
+  const root = path.resolve(process.cwd(), dir);
+  const outDir = options.output ? path.resolve(root, options.output) : root;
+
+  console.log();
+  console.log(pc.bold(pc.cyan("  barodoc schema")));
+  console.log();
+
+  await fs.ensureDir(outDir);
+
+  const configSchema = zodToJsonSchema(barodocConfigSchema, {
+    name: "BarodocConfig",
+    $refStrategy: "none",
+  });
+
+  const fmSchema = zodToJsonSchema(docsFrontmatterSchema, {
+    name: "DocsFrontmatter",
+    $refStrategy: "none",
+  });
+
+  const configPath = path.join(outDir, "config-schema.json");
+  const fmPath = path.join(outDir, "frontmatter-schema.json");
+
+  await fs.writeJSON(configPath, configSchema, { spaces: 2 });
+  await fs.writeJSON(fmPath, fmSchema, { spaces: 2 });
+
+  console.log(pc.green(`  ✓ Generated ${path.relative(root, configPath)}`));
+  console.log(pc.green(`  ✓ Generated ${path.relative(root, fmPath)}`));
+  console.log();
+}

--- a/packages/barodoc/src/runtime/agentRules.ts
+++ b/packages/barodoc/src/runtime/agentRules.ts
@@ -18,16 +18,22 @@ markdown files that are fully compatible with barodoc.
 
 \`\`\`
 docs/
-  {locale}/          # e.g., en/, ko/, ja/
-    {slug}.md        # Markdown or MDX files
+  {locale}/              # e.g., en/, ko/, ja/
+    {slug}.md            # Markdown or MDX files
     {slug}.mdx
+    {category}/{slug}.mdx  # Nested paths (e.g., guides/installation.mdx)
 
-public/              # Static assets (images, logo, etc.)
-barodoc.config.json  # Site configuration
+overrides/               # Optional: component/layout overrides
+  components/            # Custom or overridden MDX components
+  layouts/               # Layout overrides
+
+public/                  # Static assets (images, logo, etc.)
+barodoc.config.json      # Site configuration
 \`\`\`
 
 - Each page is a single \`.md\` or \`.mdx\` file inside \`docs/{locale}/\`.
 - The filename (without extension) becomes the **slug** used in navigation.
+- Nested paths are supported: \`docs/en/guides/installation.mdx\` → slug \`guides/installation\`.
 - Use \`.mdx\` when you need to include interactive components (Callout, Steps, etc.).
 - Use \`.md\` for plain text-only pages.
 
@@ -41,11 +47,25 @@ Every page **should** include frontmatter at the top:
 ---
 title: Page Title
 description: A brief description shown in search results and meta tags.
+tags: [topic1, topic2]
+related: [other-page-slug, guides/related-guide]
+category: guides
+difficulty: beginner
 ---
 \`\`\`
 
-- \`title\` — Optional. If omitted, the first \`#\` heading is used.
-- \`description\` — Recommended. Used for SEO and search result snippets.
+| Field | Type | Description |
+|-------|------|-------------|
+| \`title\` | string | Optional. If omitted, the first \`#\` heading is used. |
+| \`description\` | string | Recommended. Used for SEO and search result snippets. |
+| \`tags\` | string[] | Classification tags for search and AI filtering. |
+| \`related\` | string[] | Slugs of related pages. Must be valid slugs in navigation. |
+| \`category\` | string | Explicit category. Auto-detected from navigation group if omitted. |
+| \`difficulty\` | \`"beginner"\` \| \`"intermediate"\` \| \`"advanced"\` | Content difficulty. |
+| \`api_reference\` | boolean | Marks the page as API reference content. |
+| \`lastUpdated\` | date | Manual override for last-updated timestamp. |
+
+**Rules for \`related\`:** Only use slugs that exist in \`barodoc.config.json\` navigation. \`barodoc check\` validates these.
 
 ---
 
@@ -204,21 +224,52 @@ If the project has multiple locales:
 
 - Use \`##\` for top-level sections within a page (the page \`#\` title is auto-rendered).
 - Keep descriptions concise (1–2 sentences for \`description\` frontmatter).
-- Use fenced code blocks with language identifiers for syntax highlighting.
+- **Always include a language identifier on fenced code blocks** (e.g., \\\`\\\`\\\`bash, \\\`\\\`\\\`json, \\\`\\\`\\\`typescript). This is required for syntax highlighting and AI code classification.
 - Prefer \`<Callout type="warning">\` over bold text for important notices.
 - Use \`<Steps>\` for any multi-step process (installation, setup, etc.).
 - Images go in \`public/\` and are referenced as \`/image.png\`.
+- When referencing other doc pages, use the slug (e.g., \`guides/configuration\`), not file paths.
 
 ---
 
-## Validation
+## Overrides (Custom Components)
+
+Place custom components in \`overrides/components/\` to extend or replace theme components:
+
+\`\`\`
+overrides/
+  components/
+    CustomBanner.tsx      # New component
+    Callout.tsx           # Overrides built-in Callout
+\`\`\`
+
+Import in MDX via the alias:
+
+\`\`\`mdx
+import CustomBanner from "@overrides/components/CustomBanner";
+
+<CustomBanner text="Hello" />
+\`\`\`
+
+---
+
+## CLI Commands
 
 \`\`\`bash
-# Check for issues (missing files, orphan pages, frontmatter)
+# Check for issues (missing files, orphan pages, frontmatter, invalid related links)
 barodoc check
 
 # Auto-fix navigation mismatches
 barodoc check --fix
+
+# Generate docs-manifest.json (structured metadata + content for AI agents)
+barodoc manifest
+
+# Generate RAG-optimized chunks
+barodoc manifest --chunks
+
+# Generate JSON Schema for config and frontmatter
+barodoc schema
 
 # Start dev server
 barodoc serve

--- a/packages/barodoc/src/runtime/project.ts
+++ b/packages/barodoc/src/runtime/project.ts
@@ -162,6 +162,15 @@ export async function createProject(options: ProjectOptions): Promise<string> {
     await fs.ensureDir(publicLink);
   }
 
+  // Symlink overrides directory if exists (for component/layout overrides)
+  const overridesDir = path.join(root, "overrides");
+  const overridesLink = path.join(projectDir, "overrides");
+
+  if (fs.existsSync(overridesDir)) {
+    await fs.symlink(overridesDir, overridesLink, "dir");
+    console.log(pc.dim("  Linked overrides/ directory"));
+  }
+
   return projectDir;
 }
 
@@ -249,6 +258,12 @@ const docsCollection = defineCollection({
   schema: z.object({
     title: z.string().optional(),
     description: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    related: z.array(z.string()).optional(),
+    category: z.string().optional(),
+    api_reference: z.boolean().optional(),
+    difficulty: z.enum(["beginner", "intermediate", "advanced"]).optional(),
+    lastUpdated: z.date().optional(),
   }),
 });
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,3 +1,3 @@
-export { barodocConfigSchema } from "./schema.js";
+export { barodocConfigSchema, docsFrontmatterSchema } from "./schema.js";
 export { loadConfig, getConfigDefaults } from "./loader.js";
-export type { BarodocConfigInput, BarodocConfigOutput } from "./schema.js";
+export type { BarodocConfigInput, BarodocConfigOutput, DocsFrontmatter } from "./schema.js";

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -58,6 +58,20 @@ export const feedbackSchema = z.object({
   endpoint: z.string().optional(),
 }).optional();
 
+/** Frontmatter schema for MDX/MD content files. Reusable across custom and quick mode. */
+export const docsFrontmatterSchema = z.object({
+  title: z.string().optional(),
+  description: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  related: z.array(z.string()).optional(),
+  category: z.string().optional(),
+  api_reference: z.boolean().optional(),
+  difficulty: z.enum(["beginner", "intermediate", "advanced"]).optional(),
+  lastUpdated: z.date().optional(),
+});
+
+export type DocsFrontmatter = z.infer<typeof docsFrontmatterSchema>;
+
 export const pluginConfigSchema = z.union([
   z.string(),
   z.tuple([z.string(), z.record(z.unknown())]),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export { default } from "./integration.js";
 export * from "./types.js";
-export { loadConfig, barodocConfigSchema } from "./config/index.js";
+export { loadConfig, barodocConfigSchema, docsFrontmatterSchema } from "./config/index.js";
+export type { DocsFrontmatter } from "./config/index.js";
 export {
   getLocaleFromPath,
   removeLocaleFromPath,

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -1,4 +1,6 @@
 import type { AstroIntegration } from "astro";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { loadConfig } from "./config/loader.js";
 import {
   loadPlugins,
@@ -103,9 +105,25 @@ export default function barodoc(options: BarodocOptions): AstroIntegration {
         const themeIntegration = options.theme.integration(resolvedConfig);
         const pluginIntegrations = getPluginIntegrations(plugins, pluginContext);
 
+        // Detect overrides directory for component/layout customization
+        const overridesDir = join(rootPath, "overrides");
+        const overridesAlias: Record<string, string> = {};
+
+        if (existsSync(join(overridesDir, "components"))) {
+          overridesAlias["@overrides/components"] = join(overridesDir, "components");
+          logger.info("Overrides: components/ detected");
+        }
+        if (existsSync(join(overridesDir, "layouts"))) {
+          overridesAlias["@overrides/layouts"] = join(overridesDir, "layouts");
+          logger.info("Overrides: layouts/ detected");
+        }
+
         updateConfig({
           vite: {
             plugins: [createVirtualModulesPlugin(resolvedConfig) as any],
+            resolve: Object.keys(overridesAlias).length > 0
+              ? { alias: overridesAlias }
+              : undefined,
           },
           integrations: [themeIntegration, ...pluginIntegrations],
         });

--- a/packages/plugin-llms-txt/src/index.ts
+++ b/packages/plugin-llms-txt/src/index.ts
@@ -65,20 +65,33 @@ function extractTitle(content: string): string {
 }
 
 /**
- * Convert markdown to plain text (minimal conversion for llms.txt)
+ * Clean markdown for AI consumption.
+ * Preserves code blocks (critical for AI agents). Strips MDX component tags.
  */
-function markdownToPlainText(md: string): string {
-  return md
-    .replace(/^#{1,6}\s+/gm, "")       // Remove heading markers
-    .replace(/\*\*(.+?)\*\*/g, "$1")    // Bold
-    .replace(/\*(.+?)\*/g, "$1")        // Italic
-    .replace(/`{3}[\s\S]*?`{3}/g, "")  // Code blocks
-    .replace(/`(.+?)`/g, "$1")          // Inline code
-    .replace(/\[(.+?)\]\(.+?\)/g, "$1") // Links
-    .replace(/^[-*+]\s+/gm, "- ")       // List items
-    .replace(/^\s*>\s+/gm, "")          // Blockquotes
-    .replace(/\n{3,}/g, "\n\n")         // Excess newlines
-    .trim();
+function cleanMarkdownForAI(md: string): string {
+  const codeBlocks: string[] = [];
+  let cleaned = md.replace(/```[\s\S]*?```/g, (match) => {
+    codeBlocks.push(match);
+    return `__CODE_BLOCK_${codeBlocks.length - 1}__`;
+  });
+
+  cleaned = cleaned
+    .replace(/<\/?(?:Callout|Steps|Step|Card|CardGroup|CodeGroup|CodeItem|ParamField|ParamFieldGroup|Tabs|Tab|Accordion|AccordionItem|Badge|Columns|Column|Expandable|Frame|FileTree|Tooltip|ResponseField|ApiReference|ApiEndpoint|ApiParams|ApiParam|ApiResponse|SimpleAccordion)[^>]*>/g, "")
+    .replace(/import\s+.*?from\s+["'].*?["'];?\s*\n?/g, "")
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/\*(.+?)\*/g, "$1")
+    .replace(/`(.+?)`/g, "$1")
+    .replace(/\[(.+?)\]\(.+?\)/g, "$1")
+    .replace(/^[-*+]\s+/gm, "- ")
+    .replace(/^\s*>\s+/gm, "")
+    .replace(/\n{3,}/g, "\n\n");
+
+  for (let i = 0; i < codeBlocks.length; i++) {
+    cleaned = cleaned.replace(`__CODE_BLOCK_${i}__`, codeBlocks[i]);
+  }
+
+  return cleaned.trim();
 }
 
 /**
@@ -218,7 +231,7 @@ function buildLlmsFullTxt(
       lines.push(`_${page.description}_`);
     }
     lines.push("");
-    lines.push(markdownToPlainText(page.content));
+    lines.push(cleanMarkdownForAI(page.content));
     lines.push("");
     lines.push("---");
     lines.push("");
@@ -245,7 +258,8 @@ export default definePlugin<LlmsTxtPluginOptions>((options = {}) => {
         const locales: string[] = (config as any).i18n?.locales ?? ["en"];
         const navigation = (config as any).navigation ?? [];
 
-        const docsDir = path.join(root, "docs");
+        const customModeDir = path.join(root, "src", "content", "docs");
+        const docsDir = fs.existsSync(customModeDir) ? customModeDir : path.join(root, "docs");
         const pages = scanDocs(docsDir, locales, defaultLocale, navigation);
 
         if (pages.length === 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,12 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.25.1
+        version: 3.25.1(zod@3.25.76)
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.4


### PR DESCRIPTION
## Summary

- Implement content-site separation architecture with progressive customization (`overrides/` directory) and Vite alias registration
- Build comprehensive AI agent data pipeline: enhanced manifest with sections/summary/codeExamples/componentAPI, RAG chunks (JSONL), JSON Schema export
- Fix `llms-full.txt` to preserve code blocks (previously stripped entirely)
- Standardize frontmatter schema (`tags`, `related`, `category`, `difficulty`) exported from `@barodoc/core`
- New CLI commands: `barodoc manifest` (with `--lite`, `--chunks`), `barodoc schema`
- Extend `barodoc check` with `related` link validation and recursive directory scanning
- New documentation: CLI Commands guide, Overrides & Customization guide (EN + KO)
- Update CLAUDE.md agent rules with new fields and commands

## Test plan

- [x] `pnpm build:packages` passes
- [x] `barodoc check docs` — no issues
- [x] `barodoc manifest docs` — 52 pages across 2 locales
- [x] `barodoc manifest docs --lite` — metadata only
- [x] `barodoc manifest docs --chunks` — 366 RAG chunks
- [x] `barodoc schema docs` — config-schema.json + frontmatter-schema.json generated

Closes #45

Made with [Cursor](https://cursor.com)