### PR TITLE
fix: add missing dependencies to quick mode temporary project

### DIFF
--- a/.changeset/fix-quick-mode-deps.md
+++ b/.changeset/fix-quick-mode-deps.md
@@ -1,0 +1,7 @@
+---
+"barodoc": patch
+---
+
+Fix missing dependencies in quick mode temporary project
+
+Add @astrojs/mdx, @astrojs/react, @tailwindcss/vite, @tailwindcss/typography, and tailwindcss to the generated .barodoc/package.json so that `barodoc serve` and `barodoc build` work in zero-config mode.

--- a/packages/barodoc/src/runtime/project.ts
+++ b/packages/barodoc/src/runtime/project.ts
@@ -101,6 +101,11 @@ export async function createProject(options: ProjectOptions): Promise<string> {
       private: true,
       dependencies: {
         astro: "^5.0.0",
+        "@astrojs/mdx": "^4.0.0",
+        "@astrojs/react": "^4.0.0",
+        "@tailwindcss/typography": "^0.5.19",
+        "@tailwindcss/vite": "^4.0.0",
+        tailwindcss: "^4.0.0",
         "@barodoc/core": "^1.0.0",
         "@barodoc/theme-docs": "^1.0.0",
         react: "^19.0.0",


### PR DESCRIPTION
## Summary

- Add `@astrojs/mdx`, `@astrojs/react`, `@tailwindcss/vite`, `@tailwindcss/typography`, `tailwindcss` to the generated `.barodoc/package.json`
- These are required by `@barodoc/theme-docs` but only in its `devDependencies`, causing `Cannot find module` errors in zero-config mode

Closes #50

## Test plan

- [x] `barodoc serve` starts dev server without module errors
- [x] `barodoc build` completes successfully with 3 pages
- [x] `barodoc preview` serves the built site

Made with [Cursor](https://cursor.com)