### PR TITLE
feat: overhaul theme design system with OKLCH palette and fix MDX components

### DIFF
--- a/.changeset/theme-design-system-overhaul.md
+++ b/.changeset/theme-design-system-overhaul.md
@@ -1,0 +1,20 @@
+---
+"@barodoc/core": minor
+"@barodoc/theme-docs": minor
+---
+
+Overhaul theme color system and fix MDX component issues
+
+**@barodoc/core**
+- Replace `theme.colors.primary` with `accent` / `gray` configuration
+- Add OKLCH-based 50–950 palette generation from a single hex value
+- Support light/dark mode separate accent colors
+- Add gray scale presets: zinc, slate, neutral, stone, gray
+
+**@barodoc/theme-docs**
+- Migrate all components from hardcoded Tailwind classes to CSS custom properties (`--bd-*`)
+- Fix CodeGroup duplicate tabs on `astro:page-load` re-execution
+- Fix Mermaid `dayjs` CJS/ESM interop error via `vite.optimizeDeps.include`
+- Redesign Steps component with CSS counters for automatic numbering and grid-based layout
+- Add Tooltip component using Radix UI Portal rendered to `document.body`
+- Update global.css with full design token system

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -20,7 +20,7 @@ export default defineConfig({
   ],
   vite: {
     optimizeDeps: {
-      // Exclude native modules and workspace packages from dependency optimization
+      include: ["mermaid"],
       exclude: [
         "fsevents",
         "lightningcss",

--- a/docs/src/content/docs/en/guides/configuration.mdx
+++ b/docs/src/content/docs/en/guides/configuration.mdx
@@ -17,7 +17,8 @@ Barodoc is configured through `barodoc.config.json`.
   "favicon": "/favicon.ico",
   "theme": {
     "colors": {
-      "primary": "#0070f3"
+      "accent": "#2563eb",
+      "gray": "zinc"
     }
   },
   "i18n": {
@@ -58,13 +59,34 @@ Path to the favicon in the `public/` directory.
 
 ### theme.colors
 
-Customize the primary color theme:
+Customize the accent (primary) color and gray scale. Barodoc generates a full OKLCH-based 50–950 color palette from a single hex value.
 
 ```json
 {
   "theme": {
     "colors": {
-      "primary": "#0070f3"
+      "accent": "#2563eb",
+      "gray": "zinc"
+    }
+  }
+}
+```
+
+**accent** — A hex color used to generate the primary/accent palette (links, buttons, active states). Defaults to `#2563eb` (blue).
+
+**gray** — The neutral gray scale used for backgrounds, text, and borders. Accepts a preset name (`zinc`, `slate`, `neutral`, `stone`, `gray`) or a custom hex. Defaults to `zinc`.
+
+You can also specify separate accent colors for light and dark modes:
+
+```json
+{
+  "theme": {
+    "colors": {
+      "accent": "#2563eb",
+      "gray": "slate",
+      "dark": {
+        "accent": "#60a5fa"
+      }
     }
   }
 }

--- a/docs/src/content/docs/ko/guides/configuration.mdx
+++ b/docs/src/content/docs/ko/guides/configuration.mdx
@@ -26,17 +26,48 @@ difficulty: intermediate
 
 ## 테마 설정
 
-색상과 폰트를 커스터마이징할 수 있습니다:
+강조색(accent)과 회색(gray) 스케일을 설정합니다. 하나의 hex 값으로 OKLCH 기반 50~950 팔레트가 자동 생성됩니다.
 
 ```json
 {
   "theme": {
     "colors": {
-      "primary": "#0070f3"
-    },
+      "accent": "#2563eb",
+      "gray": "zinc"
+    }
+  }
+}
+```
+
+**accent** — 링크, 버튼, 활성 상태에 사용되는 강조색 hex 값. 기본값: `#2563eb` (파란색).
+
+**gray** — 배경, 텍스트, 보더에 사용되는 회색 스케일. 프리셋명(`zinc`, `slate`, `neutral`, `stone`, `gray`) 또는 커스텀 hex. 기본값: `zinc`.
+
+라이트/다크 모드별 다른 강조색을 지정할 수 있습니다:
+
+```json
+{
+  "theme": {
+    "colors": {
+      "accent": "#2563eb",
+      "gray": "slate",
+      "dark": {
+        "accent": "#60a5fa"
+      }
+    }
+  }
+}
+```
+
+폰트도 커스터마이징할 수 있습니다:
+
+```json
+{
+  "theme": {
     "fonts": {
       "heading": "Pretendard, sans-serif",
-      "body": "Pretendard, sans-serif"
+      "body": "Pretendard, sans-serif",
+      "code": "JetBrains Mono, monospace"
     }
   }
 }

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -59,7 +59,8 @@ export function getConfigDefaults(): Partial<BarodocConfig> {
     },
     theme: {
       colors: {
-        primary: "#0070f3",
+        accent: "#2563eb",
+        gray: "zinc",
       },
     },
   };

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -11,14 +11,24 @@ export const i18nConfigSchema = z.object({
   labels: z.record(z.string()).optional(),
 }).optional();
 
+export const grayPresets = [
+  "zinc", "slate", "neutral", "stone", "gray",
+] as const;
+
+export type GrayPreset = (typeof grayPresets)[number];
+
 export const themeColorsSchema = z.object({
-  primary: z.string().optional(),
-  background: z.string().optional(),
-  backgroundDark: z.string().optional(),
-  text: z.string().optional(),
-  textDark: z.string().optional(),
-  border: z.string().optional(),
-  borderDark: z.string().optional(),
+  accent: z.string().optional(),
+  gray: z.union([
+    z.enum(grayPresets),
+    z.string(),
+  ]).optional(),
+  light: z.object({
+    accent: z.string().optional(),
+  }).optional(),
+  dark: z.object({
+    accent: z.string().optional(),
+  }).optional(),
 }).optional();
 
 export const themeConfigSchema = z.object({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,11 @@ export {
   getLocaleLabel,
 } from "./i18n/index.js";
 
+// Theme utilities
+export { generateThemeCSS, generateAccentScale, getGrayScale } from "./theme/colors.js";
+export { grayPresets } from "./config/schema.js";
+export type { GrayPreset } from "./config/schema.js";
+
 // Plugin system
 export {
   definePlugin,

--- a/packages/core/src/theme/colors.ts
+++ b/packages/core/src/theme/colors.ts
@@ -1,0 +1,126 @@
+const GRAY_PRESETS: Record<string, Record<string, string>> = {
+  zinc: {
+    "50": "#fafafa",  "100": "#f4f4f5", "200": "#e4e4e7",
+    "300": "#d4d4d8", "400": "#a1a1aa", "500": "#71717a",
+    "600": "#52525b", "700": "#3f3f46", "800": "#27272a",
+    "900": "#18181b", "950": "#09090b",
+  },
+  slate: {
+    "50": "#f8fafc",  "100": "#f1f5f9", "200": "#e2e8f0",
+    "300": "#cbd5e1", "400": "#94a3b8", "500": "#64748b",
+    "600": "#475569", "700": "#334155", "800": "#1e293b",
+    "900": "#0f172a", "950": "#020617",
+  },
+  neutral: {
+    "50": "#fafafa",  "100": "#f5f5f5", "200": "#e5e5e5",
+    "300": "#d4d4d4", "400": "#a3a3a3", "500": "#737373",
+    "600": "#525252", "700": "#404040", "800": "#262626",
+    "900": "#171717", "950": "#0a0a0a",
+  },
+  stone: {
+    "50": "#fafaf9",  "100": "#f5f5f4", "200": "#e7e5e4",
+    "300": "#d6d3d1", "400": "#a8a29e", "500": "#78716c",
+    "600": "#57534e", "700": "#44403c", "800": "#292524",
+    "900": "#1c1917", "950": "#0c0a09",
+  },
+  gray: {
+    "50": "#f9fafb",  "100": "#f3f4f6", "200": "#e5e7eb",
+    "300": "#d1d5db", "400": "#9ca3af", "500": "#6b7280",
+    "600": "#4b5563", "700": "#374151", "800": "#1f2937",
+    "900": "#111827", "950": "#030712",
+  },
+};
+
+const SCALE_STEPS = ["50", "100", "200", "300", "400", "500", "600", "700", "800", "900", "950"] as const;
+
+function hexToLinear(c: number): number {
+  return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function hexToOklchHue(hex: string): number {
+  const h = hex.replace("#", "");
+  const [r, g, b] = [
+    parseInt(h.slice(0, 2), 16) / 255,
+    parseInt(h.slice(2, 4), 16) / 255,
+    parseInt(h.slice(4, 6), 16) / 255,
+  ].map(hexToLinear);
+
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+
+  const a = 1.9779984951 * l - 2.4285922050 * m + 0.4505937099 * s;
+  const bVal = 0.0259040371 * l + 0.7827717662 * m - 0.8086757660 * s;
+
+  let hue = (Math.atan2(bVal, a) * 180) / Math.PI;
+  if (hue < 0) hue += 360;
+  return Math.round(hue * 10) / 10;
+}
+
+const ACCENT_L: Record<string, number> = {
+  "50": 0.97, "100": 0.94, "200": 0.88, "300": 0.78, "400": 0.68,
+  "500": 0.58, "600": 0.50, "700": 0.42, "800": 0.35, "900": 0.28, "950": 0.20,
+};
+
+const ACCENT_C: Record<string, number> = {
+  "50": 0.02, "100": 0.04, "200": 0.08, "300": 0.12, "400": 0.16,
+  "500": 0.18, "600": 0.18, "700": 0.16, "800": 0.12, "900": 0.08, "950": 0.04,
+};
+
+export function generateAccentScale(hex: string): Record<string, string> {
+  const h = hexToOklchHue(hex);
+  const scale: Record<string, string> = {};
+  for (const step of SCALE_STEPS) {
+    scale[step] = `oklch(${ACCENT_L[step]} ${ACCENT_C[step]} ${h})`;
+  }
+  return scale;
+}
+
+export function getGrayScale(preset: string): Record<string, string> | null {
+  return GRAY_PRESETS[preset] ?? null;
+}
+
+/**
+ * Generate CSS overrides from theme.colors config.
+ * Outputs gray scale variables (--bd-gray-*) and/or accent overrides (--color-primary-*).
+ * Semantic tokens don't need to change — they already reference --bd-gray-* via var().
+ */
+export function generateThemeCSS(themeColors: {
+  accent?: string;
+  gray?: string;
+  light?: { accent?: string };
+  dark?: { accent?: string };
+}): string {
+  const rootLines: string[] = [];
+  const darkLines: string[] = [];
+
+  if (themeColors.gray) {
+    const grayScale = getGrayScale(themeColors.gray);
+    if (grayScale) {
+      for (const step of SCALE_STEPS) {
+        rootLines.push(`  --bd-gray-${step}: ${grayScale[step]};`);
+      }
+    }
+  }
+
+  if (themeColors.accent) {
+    const scale = generateAccentScale(themeColors.accent);
+    for (const step of SCALE_STEPS) {
+      rootLines.push(`  --color-primary-${step}: ${scale[step]};`);
+    }
+  }
+
+  if (themeColors.dark?.accent) {
+    const darkScale = generateAccentScale(themeColors.dark.accent);
+    for (const step of SCALE_STEPS) {
+      darkLines.push(`  --color-primary-${step}: ${darkScale[step]};`);
+    }
+  }
+
+  if (rootLines.length === 0 && darkLines.length === 0) return "";
+
+  let css = "";
+  if (rootLines.length > 0) css += `:root {\n${rootLines.join("\n")}\n}\n`;
+  if (darkLines.length > 0) css += `.dark {\n${darkLines.join("\n")}\n}\n`;
+  return css;
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,13 +16,14 @@ export interface BarodocI18nConfig {
 }
 
 export interface BarodocThemeColors {
-  primary?: string;
-  background?: string;
-  backgroundDark?: string;
-  text?: string;
-  textDark?: string;
-  border?: string;
-  borderDark?: string;
+  accent?: string;
+  gray?: string;
+  light?: {
+    accent?: string;
+  };
+  dark?: {
+    accent?: string;
+  };
 }
 
 export interface BarodocThemeConfig {

--- a/packages/theme-docs/src/components/Breadcrumb.astro
+++ b/packages/theme-docs/src/components/Breadcrumb.astro
@@ -11,20 +11,20 @@ interface Props {
 const { items } = Astro.props;
 ---
 
-<nav aria-label="Breadcrumb" class="mb-3">
-  <ol class="flex flex-wrap items-center gap-1 text-xs text-[var(--color-text-muted)]">
-    <li class="flex items-center gap-1">
-      <a href="/docs" class="hover:text-[var(--color-text-secondary)] transition-colors">Docs</a>
+<nav aria-label="Breadcrumb" class="mb-4">
+  <ol class="flex flex-wrap items-center gap-1.5 text-[13px] text-[var(--bd-text-muted)]">
+    <li class="flex items-center gap-1.5">
+      <a href="/docs" class="hover:text-[var(--bd-text)] transition-colors">Docs</a>
     </li>
     {items.map((item, i) => (
-      <li class="flex items-center gap-1">
-        <svg class="w-3 h-3 text-[var(--color-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <li class="flex items-center gap-1.5">
+        <svg class="w-3 h-3 text-[var(--bd-text-muted)] opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
         </svg>
         {item.href && i < items.length - 1 ? (
-          <a href={item.href} class="hover:text-[var(--color-text-secondary)] transition-colors">{item.label}</a>
+          <a href={item.href} class="hover:text-[var(--bd-text)] transition-colors">{item.label}</a>
         ) : (
-          <span class="text-[var(--color-text-secondary)]">{item.label}</span>
+          <span class="text-[var(--bd-text-secondary)] font-medium">{item.label}</span>
         )}
       </li>
     ))}

--- a/packages/theme-docs/src/components/CodeCopy.astro
+++ b/packages/theme-docs/src/components/CodeCopy.astro
@@ -25,12 +25,13 @@
       const wrapper = document.createElement('div');
       wrapper.className = 'code-block-wrapper';
       
-      // Create header if filename exists
-      if (filename) {
+      // Create header for filename or language label
+      const displayLabel = filename || lang;
+      if (displayLabel) {
         const header = document.createElement('div');
         header.className = 'code-block-header';
         header.innerHTML = `
-          <span class="code-block-filename">${filename}</span>
+          <span class="code-block-filename">${displayLabel}</span>
         `;
         wrapper.appendChild(header);
       }
@@ -89,8 +90,8 @@
     margin: 1rem 0;
     border-radius: 0.5rem;
     overflow: hidden;
-    background: var(--color-bg-secondary);
-    border: 1px solid var(--color-border);
+    background: var(--bd-bg-subtle);
+    border: 1px solid var(--bd-border);
   }
   
   .code-block-wrapper pre {
@@ -145,14 +146,14 @@
     align-items: center;
     justify-content: space-between;
     padding: 0.5rem 1rem;
-    background: var(--color-bg-tertiary);
-    border-bottom: 1px solid var(--color-border);
+    background: var(--bd-bg-muted);
+    border-bottom: 1px solid var(--bd-border);
   }
   
   .code-block-filename {
     font-size: 0.8125rem;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    color: var(--color-text-secondary);
+    color: var(--bd-text-secondary);
   }
   
   .copy-button {
@@ -165,13 +166,13 @@
     padding: 0.375rem 0.625rem;
     font-size: 0.75rem;
     font-weight: 500;
-    background: var(--color-bg);
-    border: 1px solid var(--color-border);
+    background: var(--bd-bg);
+    border: 1px solid var(--bd-border);
     border-radius: 0.375rem;
     cursor: pointer;
     opacity: 0;
     transition: opacity 150ms ease, background 150ms ease;
-    color: var(--color-text-muted);
+    color: var(--bd-text-muted);
     z-index: 10;
   }
   
@@ -180,8 +181,8 @@
   }
   
   .copy-button:hover {
-    background: var(--color-bg-secondary);
-    color: var(--color-text);
+    background: var(--bd-bg-subtle);
+    color: var(--bd-text);
   }
   
   .copy-button .copy-icon,

--- a/packages/theme-docs/src/components/DocHeader.tsx
+++ b/packages/theme-docs/src/components/DocHeader.tsx
@@ -90,32 +90,32 @@ export function DocHeader({
 
   return (
     <TooltipProvider>
-      <header className="sticky top-0 z-50 w-full min-w-0 border-b border-[var(--color-border)] bg-[var(--color-bg)]/95 backdrop-blur-md supports-[backdrop-filter]:bg-[var(--color-bg)]/80">
-        <div className="flex h-14 items-center justify-between gap-2 px-3 sm:px-4 max-w-[1120px] mx-auto min-w-0">
+      <header className="sticky top-0 z-50 w-full min-w-0 border-b border-[var(--bd-border)] bg-[var(--bd-bg)]/95 backdrop-blur-md supports-[backdrop-filter]:bg-[var(--bd-bg)]/80">
+        <div className="flex h-14 items-center justify-between gap-2 px-4 sm:px-6 max-w-[1280px] mx-auto min-w-0">
           {/* Logo */}
           <div className="flex items-center gap-6 min-w-0 shrink">
             <a
               href="/"
-              className="flex items-center gap-2 min-w-0 shrink overflow-hidden font-semibold text-[var(--color-text)] hover:opacity-80 transition-opacity"
+              className="flex items-center gap-2.5 min-w-0 shrink overflow-hidden font-semibold text-[var(--bd-text-heading)] hover:opacity-80 transition-opacity"
             >
               {logo && <img src={logo} alt={siteName} className="h-7 w-7 shrink-0" />}
-              <span className="text-lg truncate">{siteName}</span>
+              <span className="text-[15px] tracking-tight truncate">{siteName}</span>
             </a>
           </div>
 
           {/* Right side actions */}
-          <div className="flex items-center gap-1 shrink-0">
+          <div className="flex items-center gap-1.5 shrink-0">
             {/* Search button */}
             <Button
               variant="outline"
-              className="hidden md:flex items-center gap-3 px-4 py-2 h-10 min-w-[200px] justify-start rounded-xl"
+              className="hidden md:flex items-center gap-3 px-3 py-1.5 h-9 min-w-[220px] justify-start rounded-lg border-[var(--bd-border)]"
               onClick={openSearch}
             >
-              <Search className="h-4 w-4 shrink-0 text-[var(--color-text-muted)]" />
-              <span className="flex-1 text-left text-[var(--color-text-muted)]">
+              <Search className="h-4 w-4 shrink-0 text-[var(--bd-text-muted)]" />
+              <span className="flex-1 text-left text-sm text-[var(--bd-text-muted)]">
                 Search...
               </span>
-              <kbd className="hidden lg:inline-flex items-center gap-0.5 px-2 py-1 text-xs font-medium bg-[var(--color-bg)] border border-[var(--color-border)] rounded-md text-[var(--color-text-muted)]">
+              <kbd className="hidden lg:inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium bg-[var(--bd-bg-subtle)] border border-[var(--bd-border)] rounded text-[var(--bd-text-muted)]">
                 <span>⌘</span>K
               </kbd>
             </Button>
@@ -126,7 +126,7 @@ export function DocHeader({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="md:hidden rounded-xl"
+                  className="md:hidden"
                   onClick={openSearch}
                 >
                   <Search className="h-5 w-5" />
@@ -137,7 +137,7 @@ export function DocHeader({
             </Tooltip>
 
             {/* Divider */}
-            <Separator orientation="vertical" className="hidden md:block h-6 mx-2" />
+            <Separator orientation="vertical" className="hidden md:block h-5 mx-1.5" />
 
             {/* GitHub link */}
             {githubUrl && (
@@ -146,7 +146,7 @@ export function DocHeader({
                   <Button
                     variant="ghost"
                     size="icon"
-                    className="rounded-xl"
+                    className="h-8 w-8 text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)]"
                     asChild
                   >
                     <a
@@ -154,7 +154,7 @@ export function DocHeader({
                       target="_blank"
                       rel="noopener noreferrer"
                     >
-                      <Github className="h-5 w-5" />
+                      <Github className="h-[18px] w-[18px]" />
                       <span className="sr-only">GitHub</span>
                     </a>
                   </Button>
@@ -166,20 +166,20 @@ export function DocHeader({
             {/* Language switcher */}
             {hasMultipleLocales && locales.length > 0 && (
               <>
-                <Separator orientation="vertical" className="hidden md:block h-6 mx-2" />
+                <Separator orientation="vertical" className="hidden md:block h-5 mx-1" />
                 <div className="relative" ref={langRef}>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
                         variant="ghost"
-                        className="rounded-xl gap-1 px-2"
+                        className="h-8 gap-1 px-2 text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)]"
                         onClick={(e) => {
                           e.stopPropagation();
                           setLangOpen((o) => !o);
                         }}
                       >
                         <Globe className="h-4 w-4" />
-                        <span className="text-sm hidden sm:inline">
+                        <span className="text-[13px] hidden sm:inline">
                           {localeLabels[currentLocale] ?? currentLocale}
                         </span>
                         <ChevronDown className="h-3 w-3" />
@@ -190,7 +190,7 @@ export function DocHeader({
                   </Tooltip>
                   {langOpen && (
                     <div
-                      className="absolute right-0 mt-1 py-1 min-w-[8rem] rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] shadow-lg z-50"
+                      className="absolute right-0 mt-1 py-1 min-w-[8rem] rounded-lg border border-[var(--bd-border)] bg-[var(--bd-bg)] shadow-[var(--bd-shadow-lg)] z-50"
                       role="menu"
                     >
                       {locales.map((locale) => (
@@ -198,10 +198,10 @@ export function DocHeader({
                           key={locale}
                           href={getLocalizedUrl(currentPath, locale, defaultLocale)}
                           className={cn(
-                            "block px-3 py-2 text-sm transition-colors",
+                            "block px-3 py-1.5 text-[13px] transition-colors",
                             locale === currentLocale
-                              ? "bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300"
-                              : "text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)]"
+                              ? "bg-primary-50 dark:bg-primary-950/50 text-primary-600 dark:text-primary-400 font-medium"
+                              : "text-[var(--bd-text)] hover:bg-[var(--bd-bg-subtle)]"
                           )}
                           role="menuitem"
                         >
@@ -220,13 +220,13 @@ export function DocHeader({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="rounded-xl"
+                  className="h-8 w-8 text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)]"
                   onClick={toggleTheme}
                 >
                   {theme === "light" ? (
-                    <Moon className="h-5 w-5" />
+                    <Moon className="h-[18px] w-[18px]" />
                   ) : (
-                    <Sun className="h-5 w-5" />
+                    <Sun className="h-[18px] w-[18px]" />
                   )}
                   <span className="sr-only">Toggle theme</span>
                 </Button>
@@ -240,7 +240,7 @@ export function DocHeader({
             <Button
               variant="ghost"
               size="icon"
-              className="lg:hidden rounded-xl"
+              className="lg:hidden h-8 w-8 text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)]"
               onClick={openMobileNav}
             >
               <Menu className="h-5 w-5" />

--- a/packages/theme-docs/src/components/DocsSidebar.tsx
+++ b/packages/theme-docs/src/components/DocsSidebar.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { ChevronRight } from "lucide-react";
 import { cn } from "../lib/utils";
-import { ScrollArea } from "./ui/scroll-area";
 import {
   Collapsible,
   CollapsibleContent,
@@ -27,33 +26,30 @@ interface DocsSidebarProps {
 
 export function DocsSidebar({ groups, className }: DocsSidebarProps) {
   return (
-    <ScrollArea className={cn("h-full", className)}>
-      <nav className="space-y-4">
-        {groups.map((group, index) => (
-          <SidebarGroup key={index} group={group} />
-        ))}
-      </nav>
-    </ScrollArea>
+    <nav className={cn("space-y-5", className)}>
+      {groups.map((group, index) => (
+        <SidebarGroup key={index} group={group} />
+      ))}
+    </nav>
   );
 }
 
 function SidebarGroup({ group }: { group: NavGroup }) {
   const [isOpen, setIsOpen] = React.useState(group.defaultOpen ?? true);
-  const hasActiveItem = group.items.some((item) => item.isActive);
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <CollapsibleTrigger className="group flex w-full items-center gap-1.5 py-1 text-xs font-semibold uppercase tracking-wide text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors">
+      <CollapsibleTrigger className="group flex w-full items-center gap-1.5 py-1.5 text-[13px] font-semibold text-[var(--bd-text)] hover:text-[var(--bd-text-heading)] transition-colors">
         <ChevronRight
           className={cn(
-            "h-3 w-3 transition-transform duration-200",
+            "h-3.5 w-3.5 text-[var(--bd-text-muted)] transition-transform duration-200",
             isOpen && "rotate-90"
           )}
         />
         {group.title}
       </CollapsibleTrigger>
       <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
-        <ul className="mt-1 space-y-0.5 border-l border-[var(--color-border)] ml-1.5">
+        <ul className="mt-1 space-y-px border-l border-[var(--bd-border)] ml-2">
           {group.items.map((item, index) => (
             <SidebarItem key={index} item={item} />
           ))}
@@ -69,10 +65,10 @@ function SidebarItem({ item }: { item: NavItem }) {
       <a
         href={item.href}
         className={cn(
-          "block pl-4 pr-2 py-1.5 text-sm transition-all duration-150 -ml-px border-l-2",
+          "block pl-4 pr-2 py-1.5 text-[13px] rounded-r-md transition-all duration-150 -ml-px border-l-2",
           item.isActive
-            ? "border-primary-500 text-primary-600 dark:text-primary-400 font-medium bg-primary-50/50 dark:bg-primary-950/30"
-            : "border-transparent text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:border-[var(--color-border)]"
+            ? "border-[var(--bd-sidebar-active-border)] text-[var(--bd-sidebar-active-text)] font-medium bg-[var(--bd-sidebar-active-bg)]"
+            : "border-transparent text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] hover:border-[var(--bd-text-muted)]"
         )}
       >
         <span className="truncate">{item.title}</span>

--- a/packages/theme-docs/src/components/LanguageSwitcher.astro
+++ b/packages/theme-docs/src/components/LanguageSwitcher.astro
@@ -32,7 +32,7 @@ function getLocalizedUrl(locale: string): string {
 <div class="relative">
   <button
     id="lang-switcher-btn"
-    class="flex items-center gap-1 px-2 py-1.5 text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] rounded-lg hover:bg-[var(--color-bg-secondary)] transition-colors"
+    class="flex items-center gap-1 px-2 py-1.5 text-sm text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] rounded-lg hover:bg-[var(--bd-bg-subtle)] transition-colors"
     aria-label="Select language"
   >
     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -46,7 +46,7 @@ function getLocalizedUrl(locale: string): string {
   
   <div
     id="lang-switcher-menu"
-    class="hidden absolute right-0 mt-1 py-1 w-32 bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg shadow-lg z-50"
+    class="hidden absolute right-0 mt-1 py-1 w-32 bg-[var(--bd-bg)] border border-[var(--bd-border)] rounded-lg shadow-lg z-50"
   >
     {locales.map((locale) => (
       <a
@@ -55,7 +55,7 @@ function getLocalizedUrl(locale: string): string {
           "block px-3 py-1.5 text-sm transition-colors",
           locale === currentLocale
             ? "bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300"
-            : "text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)]"
+            : "text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] hover:bg-[var(--bd-bg-subtle)]"
         ]}
       >
         {getLocaleLabel(locale, i18n?.labels)}

--- a/packages/theme-docs/src/components/MobileNavSheet.tsx
+++ b/packages/theme-docs/src/components/MobileNavSheet.tsx
@@ -54,7 +54,7 @@ export function MobileNavSheet({ groups, siteName, logo }: MobileNavSheetProps) 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetContent side="left" className="w-80 p-0">
-        <SheetHeader className="px-6 py-4 border-b border-[var(--color-border)]">
+        <SheetHeader className="px-6 py-4 border-b border-[var(--bd-border)]">
           <SheetTitle className="flex items-center gap-2">
             {logo && <img src={logo} alt={siteName} className="h-6 w-6" />}
             <span>{siteName}</span>

--- a/packages/theme-docs/src/components/Search.tsx
+++ b/packages/theme-docs/src/components/Search.tsx
@@ -133,10 +133,10 @@ export function Search() {
     >
       <div className="fixed inset-0 bg-black/50" aria-hidden="true" />
       <div className="fixed inset-x-4 top-[15%] md:inset-x-auto md:left-1/2 md:-translate-x-1/2 md:w-full md:max-w-lg">
-        <div className="bg-[var(--color-bg)] rounded-xl shadow-2xl border border-[var(--color-border)] overflow-hidden">
-          <div className="flex items-center px-4 border-b border-[var(--color-border)]">
+        <div className="bg-[var(--bd-bg)] rounded-xl shadow-2xl border border-[var(--bd-border)] overflow-hidden">
+          <div className="flex items-center px-4 border-b border-[var(--bd-border)]">
             <svg
-              className="w-5 h-5 text-[var(--color-text-secondary)]"
+              className="w-5 h-5 text-[var(--bd-text-secondary)]"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -155,11 +155,11 @@ export function Search() {
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="Search documentation..."
-              className="flex-1 px-4 py-4 bg-transparent text-[var(--color-text)] placeholder-[var(--color-text-secondary)] focus:outline-none"
+              className="flex-1 px-4 py-4 bg-transparent text-[var(--bd-text)] placeholder-[var(--bd-text-secondary)] focus:outline-none"
             />
             <button
               onClick={() => setIsOpen(false)}
-              className="px-2 py-1 text-xs text-[var(--color-text-secondary)] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded"
+              className="px-2 py-1 text-xs text-[var(--bd-text-secondary)] bg-[var(--bd-bg-subtle)] border border-[var(--bd-border)] rounded"
             >
               ESC
             </button>
@@ -168,7 +168,7 @@ export function Search() {
           {query.trim() && (
             <div className="max-h-[60vh] overflow-y-auto">
               {results.length === 0 ? (
-                <div className="px-4 py-8 text-center text-[var(--color-text-secondary)]">
+                <div className="px-4 py-8 text-center text-[var(--bd-text-secondary)]">
                   {pagefind ? "No results found" : "Search index not available"}
                 </div>
               ) : (
@@ -180,14 +180,14 @@ export function Search() {
                         className={`block px-4 py-3 transition-colors ${
                           index === selectedIndex
                             ? "bg-primary-50 dark:bg-primary-900/30"
-                            : "hover:bg-[var(--color-bg-secondary)]"
+                            : "hover:bg-[var(--bd-bg-subtle)]"
                         }`}
                       >
-                        <div className="font-medium text-[var(--color-text)]">
+                        <div className="font-medium text-[var(--bd-text)]">
                           {result.meta.title}
                         </div>
                         <div
-                          className="text-sm text-[var(--color-text-secondary)] line-clamp-2 mt-0.5"
+                          className="text-sm text-[var(--bd-text-secondary)] line-clamp-2 mt-0.5"
                           dangerouslySetInnerHTML={{ __html: result.excerpt }}
                         />
                       </a>
@@ -199,7 +199,7 @@ export function Search() {
           )}
 
           {!query.trim() && (
-            <div className="px-4 py-6 text-center text-[var(--color-text-secondary)] text-sm">
+            <div className="px-4 py-6 text-center text-[var(--bd-text-secondary)] text-sm">
               Start typing to search...
             </div>
           )}

--- a/packages/theme-docs/src/components/SearchDialog.tsx
+++ b/packages/theme-docs/src/components/SearchDialog.tsx
@@ -43,19 +43,19 @@ export function SearchDialog({ className }: SearchDialogProps) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent className={cn("sm:max-w-2xl p-0 gap-0", className)}>
-        <DialogHeader className="px-4 py-3 border-b border-[var(--color-border)]">
+        <DialogHeader className="px-4 py-3 border-b border-[var(--bd-border)]">
           <DialogTitle className="sr-only">Search documentation</DialogTitle>
           <div className="flex items-center gap-3">
-            <SearchIcon className="h-5 w-5 text-[var(--color-text-muted)]" />
+            <SearchIcon className="h-5 w-5 text-[var(--bd-text-muted)]" />
             <input
               type="text"
               placeholder="Search documentation..."
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              className="flex-1 bg-transparent text-base outline-none placeholder:text-[var(--color-text-muted)]"
+              className="flex-1 bg-transparent text-base outline-none placeholder:text-[var(--bd-text-muted)]"
               autoFocus
             />
-            <kbd className="hidden sm:inline-flex items-center gap-1 px-2 py-1 text-xs font-medium bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded text-[var(--color-text-muted)]">
+            <kbd className="hidden sm:inline-flex items-center gap-1 px-2 py-1 text-xs font-medium bg-[var(--bd-bg-subtle)] border border-[var(--bd-border)] rounded text-[var(--bd-text-muted)]">
               Esc
             </kbd>
           </div>
@@ -65,12 +65,12 @@ export function SearchDialog({ className }: SearchDialogProps) {
             <div id="pagefind-results" className="pagefind-ui" />
           ) : (
             <div className="flex flex-col items-center justify-center h-full py-12 text-center">
-              <SearchIcon className="h-12 w-12 text-[var(--color-text-muted)] mb-4" />
-              <p className="text-sm text-[var(--color-text-secondary)]">
+              <SearchIcon className="h-12 w-12 text-[var(--bd-text-muted)] mb-4" />
+              <p className="text-sm text-[var(--bd-text-secondary)]">
                 Start typing to search the documentation
               </p>
-              <p className="text-xs text-[var(--color-text-muted)] mt-2">
-                Press <kbd className="px-1.5 py-0.5 bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded text-xs">⌘K</kbd> to open search
+              <p className="text-xs text-[var(--bd-text-muted)] mt-2">
+                Press <kbd className="px-1.5 py-0.5 bg-[var(--bd-bg-subtle)] border border-[var(--bd-border)] rounded text-xs">⌘K</kbd> to open search
               </p>
             </div>
           )}

--- a/packages/theme-docs/src/components/TableOfContents.astro
+++ b/packages/theme-docs/src/components/TableOfContents.astro
@@ -17,19 +17,19 @@ const filteredHeadings = headings.filter(h => h.depth >= 2 && h.depth <= 3);
 
 {filteredHeadings.length > 0 && (
   <div class="toc-container">
-    <h4 class="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-4">
+    <h4 class="text-[11px] font-semibold uppercase tracking-widest text-[var(--bd-text-muted)] mb-3">
       On this page
     </h4>
     <nav class="relative">
-      <div class="absolute left-0 top-0 bottom-0 w-px bg-[var(--color-border)]"></div>
-      <ul class="space-y-1">
+      <div class="absolute left-0 top-0 bottom-0 w-px bg-[var(--bd-border)]"></div>
+      <ul class="space-y-0.5">
         {filteredHeadings.map((heading) => (
           <li class="relative">
             <a
               href={`#${heading.slug}`}
               class:list={[
-                "toc-link block text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-all duration-150",
-                heading.depth === 2 ? "py-1.5 pl-4" : "py-1 pl-6 text-xs"
+                "toc-link block text-[var(--bd-text-muted)] hover:text-[var(--bd-text)] transition-all duration-150",
+                heading.depth === 2 ? "py-1 pl-3.5 text-[13px]" : "py-0.5 pl-6 text-xs"
               ]}
               data-heading={heading.slug}
             >

--- a/packages/theme-docs/src/components/ThemeToggle.tsx
+++ b/packages/theme-docs/src/components/ThemeToggle.tsx
@@ -33,7 +33,7 @@ export function ThemeToggle() {
   if (!mounted) {
     return (
       <button
-        className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        className="p-2 rounded-lg hover:bg-[var(--bd-bg-hover)] transition-colors"
         aria-label="Toggle theme"
       >
         <div className="w-5 h-5" />
@@ -44,13 +44,13 @@ export function ThemeToggle() {
   return (
     <button
       onClick={toggleTheme}
-      className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      className="p-2 rounded-lg hover:bg-[var(--bd-bg-hover)] transition-colors"
       aria-label={theme === "light" ? "Switch to dark mode" : "Switch to light mode"}
     >
       {theme === "light" ? (
-        <Moon className="w-5 h-5 text-gray-600" />
+        <Moon className="w-5 h-5 text-[var(--bd-text-secondary)]" />
       ) : (
-        <Sun className="w-5 h-5 text-gray-300" />
+        <Sun className="w-5 h-5 text-[var(--bd-text-secondary)]" />
       )}
     </button>
   );

--- a/packages/theme-docs/src/components/api/ApiEndpoint.astro
+++ b/packages/theme-docs/src/components/api/ApiEndpoint.astro
@@ -16,17 +16,17 @@ const methodColors = {
 };
 ---
 
-<div class="not-prose my-6 rounded-lg border border-[var(--color-border)] overflow-hidden">
-  <div class="flex items-center gap-3 px-4 py-3 bg-[var(--color-bg-secondary)] border-b border-[var(--color-border)]">
+<div class="not-prose my-6 rounded-lg border border-[var(--bd-border)] overflow-hidden">
+  <div class="flex items-center gap-3 px-4 py-3 bg-[var(--bd-bg-subtle)] border-b border-[var(--bd-border)]">
     <span class:list={["px-2 py-1 text-xs font-bold rounded uppercase", methodColors[method]]}>
       {method}
     </span>
-    <code class="text-sm font-mono text-[var(--color-text)]">{path}</code>
+    <code class="text-sm font-mono text-[var(--bd-text)]">{path}</code>
   </div>
   
   {description && (
-    <div class="px-4 py-3 border-b border-[var(--color-border)]">
-      <p class="text-sm text-[var(--color-text-secondary)]">{description}</p>
+    <div class="px-4 py-3 border-b border-[var(--bd-border)]">
+      <p class="text-sm text-[var(--bd-text-secondary)]">{description}</p>
     </div>
   )}
   

--- a/packages/theme-docs/src/components/api/ApiParam.astro
+++ b/packages/theme-docs/src/components/api/ApiParam.astro
@@ -9,10 +9,10 @@ interface Props {
 const { name, type, required = false, description } = Astro.props;
 ---
 
-<div class="flex flex-col gap-1 py-3 border-b border-[var(--color-border)] last:border-b-0">
+<div class="flex flex-col gap-1 py-3 border-b border-[var(--bd-border)] last:border-b-0">
   <div class="flex items-center gap-2">
-    <code class="text-sm font-semibold text-[var(--color-text)]">{name}</code>
-    <span class="text-xs text-[var(--color-text-secondary)]">{type}</span>
+    <code class="text-sm font-semibold text-[var(--bd-text)]">{name}</code>
+    <span class="text-xs text-[var(--bd-text-secondary)]">{type}</span>
     {required && (
       <span class="px-1.5 py-0.5 text-xs font-medium text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/30 rounded">
         required
@@ -20,7 +20,7 @@ const { name, type, required = false, description } = Astro.props;
     )}
   </div>
   {description && (
-    <p class="text-sm text-[var(--color-text-secondary)]">{description}</p>
+    <p class="text-sm text-[var(--bd-text-secondary)]">{description}</p>
   )}
   <slot />
 </div>

--- a/packages/theme-docs/src/components/api/ApiParams.astro
+++ b/packages/theme-docs/src/components/api/ApiParams.astro
@@ -7,9 +7,9 @@ const { title = "Parameters" } = Astro.props;
 ---
 
 <div class="my-4 px-2">
-  <h4 class="text-sm font-semibold text-[var(--color-text)] mb-2">{title}</h4>
-  <div class="border border-[var(--color-border)] rounded-lg overflow-hidden">
-    <div class="divide-y divide-[var(--color-border)] px-4">
+  <h4 class="text-sm font-semibold text-[var(--bd-text)] mb-2">{title}</h4>
+  <div class="border border-[var(--bd-border)] rounded-lg overflow-hidden">
+    <div class="divide-y divide-[var(--bd-border)] px-4">
       <slot />
     </div>
   </div>

--- a/packages/theme-docs/src/components/api/ApiResponse.astro
+++ b/packages/theme-docs/src/components/api/ApiResponse.astro
@@ -26,10 +26,10 @@ const statusColor = statusColors[status] || "bg-gray-100 dark:bg-gray-900/30 tex
       {status}
     </span>
     {description && (
-      <span class="text-sm text-[var(--color-text-secondary)]">{description}</span>
+      <span class="text-sm text-[var(--bd-text-secondary)]">{description}</span>
     )}
   </div>
-  <div class="border border-[var(--color-border)] rounded-lg overflow-hidden px-2">
+  <div class="border border-[var(--bd-border)] rounded-lg overflow-hidden px-2">
     <slot />
   </div>
 </div>

--- a/packages/theme-docs/src/components/mdx/Accordion.tsx
+++ b/packages/theme-docs/src/components/mdx/Accordion.tsx
@@ -11,21 +11,21 @@ export function Accordion({ title, icon, defaultOpen = false, children }: Accord
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   return (
-    <div className="accordion-item border border-[var(--color-border)] rounded-xl overflow-hidden bg-[var(--color-bg)] my-3">
+    <div className="accordion-item border border-[var(--bd-border)] rounded-xl overflow-hidden bg-[var(--bd-bg)] my-3">
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center gap-3 px-5 py-4 text-left hover:bg-[var(--color-bg-secondary)] transition-colors"
+        className="w-full flex items-center gap-3 px-5 py-4 text-left hover:bg-[var(--bd-bg-subtle)] transition-colors"
         aria-expanded={isOpen}
       >
         {icon && (
-          <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-[var(--color-bg-secondary)] text-lg shrink-0">
+          <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-[var(--bd-bg-subtle)] text-lg shrink-0">
             {icon}
           </span>
         )}
-        <span className="flex-1 font-medium text-[var(--color-text)]">{title}</span>
+        <span className="flex-1 font-medium text-[var(--bd-text)]">{title}</span>
         <svg
-          className={`w-5 h-5 text-[var(--color-text-secondary)] transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+          className={`w-5 h-5 text-[var(--bd-text-secondary)] transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -38,7 +38,7 @@ export function Accordion({ title, icon, defaultOpen = false, children }: Accord
           isOpen ? "max-h-[1000px] opacity-100" : "max-h-0 opacity-0"
         }`}
       >
-        <div className="px-5 pb-5 pt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        <div className="px-5 pb-5 pt-1 text-sm text-[var(--bd-text-secondary)] leading-relaxed">
           {children}
         </div>
       </div>

--- a/packages/theme-docs/src/components/mdx/Badge.tsx
+++ b/packages/theme-docs/src/components/mdx/Badge.tsx
@@ -13,7 +13,7 @@ const badgeVariants = cva(
         warning: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300",
         error: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
         info: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
-        outline: "border border-[var(--color-border)] text-[var(--color-text-secondary)]",
+        outline: "border border-[var(--bd-border)] text-[var(--bd-text-secondary)]",
       },
     },
     defaultVariants: {

--- a/packages/theme-docs/src/components/mdx/Callout.astro
+++ b/packages/theme-docs/src/components/mdx/Callout.astro
@@ -8,34 +8,34 @@ const { type = "info", title } = Astro.props;
 
 const styles = {
   info: {
-    container: "bg-blue-50/70 dark:bg-blue-950/30 border-l-blue-500",
-    iconBg: "bg-blue-100 dark:bg-blue-900/50",
+    container: "bg-blue-50/70 dark:bg-blue-500/10 border-l-blue-500",
+    iconBg: "bg-blue-100 dark:bg-blue-500/20",
     icon: "text-blue-600 dark:text-blue-400",
-    title: "text-blue-900 dark:text-blue-100",
+    title: "text-blue-900 dark:text-blue-200",
   },
   note: {
-    container: "bg-gray-50/70 dark:bg-gray-950/30 border-l-gray-400",
-    iconBg: "bg-gray-100 dark:bg-gray-900/50",
+    container: "bg-gray-50/70 dark:bg-gray-500/10 border-l-gray-400",
+    iconBg: "bg-gray-100 dark:bg-gray-500/20",
     icon: "text-gray-600 dark:text-gray-400",
-    title: "text-gray-900 dark:text-gray-100",
+    title: "text-gray-900 dark:text-gray-200",
   },
   warning: {
-    container: "bg-orange-50/70 dark:bg-orange-950/30 border-l-orange-500",
-    iconBg: "bg-orange-100 dark:bg-orange-900/50",
+    container: "bg-orange-50/70 dark:bg-orange-500/10 border-l-orange-500",
+    iconBg: "bg-orange-100 dark:bg-orange-500/20",
     icon: "text-orange-600 dark:text-orange-400",
-    title: "text-orange-900 dark:text-orange-100",
+    title: "text-orange-900 dark:text-orange-200",
   },
   tip: {
-    container: "bg-green-50/70 dark:bg-green-950/30 border-l-green-500",
-    iconBg: "bg-green-100 dark:bg-green-900/50",
+    container: "bg-green-50/70 dark:bg-green-500/10 border-l-green-500",
+    iconBg: "bg-green-100 dark:bg-green-500/20",
     icon: "text-green-600 dark:text-green-400",
-    title: "text-green-900 dark:text-green-100",
+    title: "text-green-900 dark:text-green-200",
   },
   danger: {
-    container: "bg-red-50/70 dark:bg-red-950/30 border-l-red-500",
-    iconBg: "bg-red-100 dark:bg-red-900/50",
+    container: "bg-red-50/70 dark:bg-red-500/10 border-l-red-500",
+    iconBg: "bg-red-100 dark:bg-red-500/20",
     icon: "text-red-600 dark:text-red-400",
-    title: "text-red-900 dark:text-red-100",
+    title: "text-red-900 dark:text-red-200",
   },
 };
 
@@ -60,17 +60,17 @@ const icon = icons[type];
 const displayTitle = title || defaultTitles[type];
 ---
 
-<div class:list={["not-prose my-4 rounded-md border-l-4 overflow-hidden", style.container]}>
-  <div class="p-3">
+<div class:list={["not-prose my-5 rounded-lg border-l-4 overflow-hidden", style.container]}>
+  <div class="px-4 py-3.5">
     <div class="flex items-start gap-3">
-      <div class:list={["shrink-0 flex items-center justify-center w-6 h-6 rounded", style.iconBg]}>
+      <div class:list={["shrink-0 flex items-center justify-center w-6 h-6 rounded-md", style.iconBg]}>
         <div class:list={[style.icon]} set:html={icon} />
       </div>
       <div class="flex-1 min-w-0">
         {displayTitle && (
-          <p class:list={["font-semibold text-sm mb-1", style.title]}>{displayTitle}</p>
+          <p class:list={["font-semibold text-[13px] mb-1", style.title]}>{displayTitle}</p>
         )}
-        <div class="text-sm text-[var(--color-text-secondary)] leading-relaxed [&>p]:m-0 [&>p+p]:mt-1">
+        <div class="text-[13px] text-zinc-700 dark:text-zinc-300 leading-relaxed [&>p]:m-0 [&>p+p]:mt-1.5">
           <slot />
         </div>
       </div>

--- a/packages/theme-docs/src/components/mdx/Card.astro
+++ b/packages/theme-docs/src/components/mdx/Card.astro
@@ -13,27 +13,27 @@ const Tag = href ? "a" : "div";
 <Tag
   href={href}
   class:list={[
-    "card-component not-prose group block p-4 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] no-underline",
+    "card-component not-prose group block p-4 rounded-lg border border-[var(--bd-border)] bg-[var(--bd-bg)] no-underline",
     href && "cursor-pointer hover:border-primary-300 dark:hover:border-primary-600 hover:shadow-md transition-all duration-200"
   ]}
   style={href ? "cursor: pointer;" : ""}
 >
   <div class="flex flex-col gap-3">
     {icon && (
-      <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-[var(--color-bg-secondary)] group-hover:bg-primary-50 dark:group-hover:bg-primary-950/50 transition-colors">
+      <div class="flex items-center justify-center w-10 h-10 rounded-lg bg-[var(--bd-bg-subtle)] group-hover:bg-primary-50 dark:group-hover:bg-primary-950/50 transition-colors">
         <span class="text-xl">{icon}</span>
       </div>
     )}
     <div class="flex-1 min-w-0">
       <div class="flex items-center gap-2">
-        <h3 class="font-semibold text-[var(--color-text)] group-hover:text-primary-700 dark:group-hover:text-primary-300 transition-colors">{title}</h3>
+        <h3 class="font-semibold text-[var(--bd-text)] group-hover:text-primary-700 dark:group-hover:text-primary-300 transition-colors">{title}</h3>
         {href && (
-          <svg class="w-4 h-4 text-[var(--color-text-muted)] opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg class="w-4 h-4 text-[var(--bd-text-muted)] opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
           </svg>
         )}
       </div>
-      <div class="mt-1 text-sm text-[var(--color-text-secondary)] group-hover:text-[var(--color-text)] leading-relaxed transition-colors">
+      <div class="mt-1 text-sm text-[var(--bd-text-secondary)] group-hover:text-[var(--bd-text)] leading-relaxed transition-colors">
         <slot />
       </div>
     </div>

--- a/packages/theme-docs/src/components/mdx/CodeGroup.astro
+++ b/packages/theme-docs/src/components/mdx/CodeGroup.astro
@@ -9,9 +9,9 @@ interface Props {
 const { titles = [] } = Astro.props;
 ---
 
-<div class="code-group not-prose my-4 rounded-lg border border-[var(--color-border)] overflow-hidden" data-titles={JSON.stringify(titles)}>
-  <div class="code-group-tabs flex flex-wrap gap-0 border-b border-[var(--color-border)] bg-[var(--color-bg-tertiary)]"></div>
-  <div class="code-group-content bg-[var(--color-bg-secondary)]">
+<div class="code-group not-prose my-4 rounded-lg border border-[var(--bd-border)] overflow-hidden" data-titles={JSON.stringify(titles)}>
+  <div class="code-group-tabs flex flex-wrap gap-0 border-b border-[var(--bd-border)] bg-[var(--bd-bg-muted)]"></div>
+  <div class="code-group-content bg-[var(--bd-bg-subtle)]">
     <slot />
   </div>
 </div>
@@ -21,37 +21,40 @@ const { titles = [] } = Astro.props;
     document.querySelectorAll('.code-group').forEach((group) => {
       const tabsContainer = group.querySelector('.code-group-tabs');
       const contentContainer = group.querySelector('.code-group-content');
+      if (!tabsContainer || !contentContainer) return;
+
+      tabsContainer.innerHTML = '';
+
       const fallbackTitles = JSON.parse(group.getAttribute('data-titles') || '[]');
 
-      const codeItems = contentContainer?.querySelectorAll(':scope > .code-item');
-      const directPres = contentContainer?.querySelectorAll(':scope > pre');
+      const codeItems = contentContainer.querySelectorAll(':scope > .code-item');
+      const directPres = contentContainer.querySelectorAll(':scope > pre');
 
-      // When CodeItem children exist: use them for tabs (titles from data-title), one tab per .code-item
-      const useCodeItems = (codeItems?.length ?? 0) > 0;
+      const useCodeItems = codeItems.length > 0;
       const tabPanels = useCodeItems
-        ? Array.from(codeItems!)
-        : Array.from(directPres || []);
-      const titles = useCodeItems && codeItems?.length
-        ? Array.from(codeItems!).map((el) => (el as HTMLElement).getAttribute('data-title') ?? '')
+        ? Array.from(codeItems)
+        : Array.from(directPres);
+      const titles = useCodeItems
+        ? Array.from(codeItems).map((el) => (el as HTMLElement).getAttribute('data-title') ?? '')
         : fallbackTitles;
       const numTabs = tabPanels.length;
 
-      if (!tabsContainer || !contentContainer || numTabs === 0) return;
+      if (numTabs === 0) return;
 
       // Create tabs from titles; show/hide tabPanels
       tabPanels.forEach((_panel, index) => {
         const tab = document.createElement('button');
-        tab.className = 'shrink-0 px-4 py-2 text-sm font-medium transition-colors whitespace-nowrap text-[var(--color-text-muted)] hover:text-[var(--color-text)]';
+        tab.className = 'shrink-0 px-4 py-2 text-sm font-medium transition-colors whitespace-nowrap text-[var(--bd-text-muted)] hover:text-[var(--bd-text)]';
         tab.textContent = titles[index]?.trim() || `Tab ${index + 1}`;
         const panel = tabPanels[index] as HTMLElement;
         tab.addEventListener('click', () => {
           tabsContainer.querySelectorAll('button').forEach((t, i) => {
             if (i === index) {
-              t.classList.add('border-b-2', 'border-primary-500', 'text-[var(--color-text)]', '-mb-px');
-              t.classList.remove('text-[var(--color-text-muted)]');
+              t.classList.add('border-b-2', 'border-primary-500', 'text-[var(--bd-text)]', '-mb-px');
+              t.classList.remove('text-[var(--bd-text-muted)]');
             } else {
-              t.classList.remove('border-b-2', 'border-primary-500', 'text-[var(--color-text)]', '-mb-px');
-              t.classList.add('text-[var(--color-text-muted)]');
+              t.classList.remove('border-b-2', 'border-primary-500', 'text-[var(--bd-text)]', '-mb-px');
+              t.classList.add('text-[var(--bd-text-muted)]');
             }
           });
           tabPanels.forEach((p, i) => {
@@ -61,8 +64,8 @@ const { titles = [] } = Astro.props;
         tabsContainer.appendChild(tab);
 
         if (index === 0) {
-          tab.classList.add('border-b-2', 'border-primary-500', 'text-[var(--color-text)]', '-mb-px');
-          tab.classList.remove('text-[var(--color-text-muted)]');
+          tab.classList.add('border-b-2', 'border-primary-500', 'text-[var(--bd-text)]', '-mb-px');
+          tab.classList.remove('text-[var(--bd-text-muted)]');
         } else {
           panel.style.display = 'none';
         }
@@ -70,6 +73,6 @@ const { titles = [] } = Astro.props;
     });
   }
 
-  initCodeGroups();
   document.addEventListener('astro:page-load', initCodeGroups);
+  if (document.readyState === 'complete') initCodeGroups();
 </script>

--- a/packages/theme-docs/src/components/mdx/CodeGroup.tsx
+++ b/packages/theme-docs/src/components/mdx/CodeGroup.tsx
@@ -72,16 +72,16 @@ export function CodeGroup({ children, titles = [] }: CodeGroupProps) {
 
   if (codeBlocks.length === 0) {
     return (
-      <div className="code-group not-prose my-4 rounded-lg border border-[var(--color-border)] overflow-hidden p-4 text-[var(--color-text-muted)] text-sm">
+      <div className="code-group not-prose my-4 rounded-lg border border-[var(--bd-border)] overflow-hidden p-4 text-[var(--bd-text-muted)] text-sm">
         No code blocks found inside CodeGroup.
       </div>
     );
   }
 
   return (
-    <div className="code-group not-prose my-4 rounded-lg border border-[var(--color-border)] overflow-hidden">
+    <div className="code-group not-prose my-4 rounded-lg border border-[var(--bd-border)] overflow-hidden">
       {/* Tabs */}
-      <div className="flex flex-wrap gap-0 bg-[var(--color-bg-tertiary)] border-b border-[var(--color-border)]">
+      <div className="flex flex-wrap gap-0 bg-[var(--bd-bg-muted)] border-b border-[var(--bd-border)]">
         {tabTitles.map((title, index) => {
           const isActive = activeIndex === index;
           return (
@@ -91,8 +91,8 @@ export function CodeGroup({ children, titles = [] }: CodeGroupProps) {
               onClick={() => setActiveIndex(index)}
               className={`shrink-0 px-4 py-2 text-sm font-medium transition-colors whitespace-nowrap ${
                 isActive
-                  ? "bg-[var(--color-bg-secondary)] text-[var(--color-text)] border-b-2 border-primary-500 -mb-px"
-                  : "text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+                  ? "bg-[var(--bd-bg-subtle)] text-[var(--bd-text)] border-b-2 border-primary-500 -mb-px"
+                  : "text-[var(--bd-text-muted)] hover:text-[var(--bd-text)]"
               }`}
             >
               {title}
@@ -102,7 +102,7 @@ export function CodeGroup({ children, titles = [] }: CodeGroupProps) {
       </div>
 
       {/* Content */}
-      <div className="bg-[var(--color-bg-secondary)]">
+      <div className="bg-[var(--bd-bg-subtle)]">
         {codeBlocks.map((block, index) => (
           <div
             key={index}

--- a/packages/theme-docs/src/components/mdx/DocAccordion.tsx
+++ b/packages/theme-docs/src/components/mdx/DocAccordion.tsx
@@ -36,11 +36,11 @@ export function DocAccordion({
         <AccordionItem 
           key={value} 
           value={value}
-          className="border-b border-[var(--color-border)] last:border-b-0"
+          className="border-b border-[var(--bd-border)] last:border-b-0"
         >
           <div className="flex items-start gap-3 px-4">
             {item.icon && (
-              <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-[var(--color-bg-secondary)] text-lg shrink-0 mt-3">
+              <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-[var(--bd-bg-subtle)] text-lg shrink-0 mt-3">
                 {item.icon}
               </span>
             )}
@@ -48,7 +48,7 @@ export function DocAccordion({
               <AccordionTrigger className="text-left">
                 {item.title}
               </AccordionTrigger>
-              <AccordionContent className="text-[var(--color-text-secondary)]">
+              <AccordionContent className="text-[var(--bd-text-secondary)]">
                 {item.content}
               </AccordionContent>
             </div>
@@ -63,7 +63,7 @@ export function DocAccordion({
         type="single" 
         collapsible={collapsible}
         defaultValue={defaultValue as string}
-        className={cn("not-prose my-6 rounded-xl border border-[var(--color-border)] overflow-hidden", className)}
+        className={cn("not-prose my-6 rounded-xl border border-[var(--bd-border)] overflow-hidden", className)}
       >
         {renderItems()}
       </Accordion>
@@ -74,7 +74,7 @@ export function DocAccordion({
     <Accordion 
       type="multiple" 
       defaultValue={defaultValue as string[]}
-      className={cn("not-prose my-6 rounded-xl border border-[var(--color-border)] overflow-hidden", className)}
+      className={cn("not-prose my-6 rounded-xl border border-[var(--bd-border)] overflow-hidden", className)}
     >
       {renderItems()}
     </Accordion>

--- a/packages/theme-docs/src/components/mdx/DocCard.tsx
+++ b/packages/theme-docs/src/components/mdx/DocCard.tsx
@@ -24,7 +24,7 @@ export function DocCard({ title, icon, href, children }: DocCardProps) {
         <div className="absolute inset-0 bg-gradient-to-br from-primary-50/50 to-transparent dark:from-primary-950/30 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none" />
         <CardHeader className="relative">
           {icon && (
-            <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-[var(--color-bg-secondary)] group-hover:bg-primary-50 dark:group-hover:bg-primary-950/50 mb-3 transition-colors">
+            <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-[var(--bd-bg-subtle)] group-hover:bg-primary-50 dark:group-hover:bg-primary-950/50 mb-3 transition-colors">
               <span className="text-xl">{icon}</span>
             </div>
           )}
@@ -33,7 +33,7 @@ export function DocCard({ title, icon, href, children }: DocCardProps) {
               {title}
             </CardTitle>
             {href && (
-              <ChevronRight className="h-4 w-4 text-[var(--color-text-muted)] opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200" />
+              <ChevronRight className="h-4 w-4 text-[var(--bd-text-muted)] opacity-0 -translate-x-2 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200" />
             )}
           </div>
           {children && (

--- a/packages/theme-docs/src/components/mdx/DocTabs.tsx
+++ b/packages/theme-docs/src/components/mdx/DocTabs.tsx
@@ -19,12 +19,12 @@ export function DocTabs({ items, defaultValue, className }: DocTabsProps) {
 
   return (
     <Tabs defaultValue={defaultTab} className={cn("not-prose my-6", className)}>
-      <TabsList className="w-full justify-start bg-[var(--color-bg-secondary)] rounded-lg p-1">
+      <TabsList className="w-full justify-start bg-[var(--bd-bg-subtle)] rounded-lg p-1">
         {items.map((item) => (
           <TabsTrigger 
             key={item.value} 
             value={item.value}
-            className="data-[state=active]:bg-[var(--color-bg)] data-[state=active]:shadow-sm"
+            className="data-[state=active]:bg-[var(--bd-bg)] data-[state=active]:shadow-sm"
           >
             {item.label}
           </TabsTrigger>
@@ -34,7 +34,7 @@ export function DocTabs({ items, defaultValue, className }: DocTabsProps) {
         <TabsContent 
           key={item.value} 
           value={item.value}
-          className="mt-4 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-4"
+          className="mt-4 rounded-lg border border-[var(--bd-border)] bg-[var(--bd-bg-subtle)] p-4"
         >
           <div className="text-sm">
             {item.children}

--- a/packages/theme-docs/src/components/mdx/Expandable.tsx
+++ b/packages/theme-docs/src/components/mdx/Expandable.tsx
@@ -20,27 +20,27 @@ export function Expandable({
   return (
     <div
       className={cn(
-        "not-prose border border-[var(--color-border)] rounded-lg overflow-hidden my-4",
+        "not-prose border border-[var(--bd-border)] rounded-lg overflow-hidden my-4",
         className
       )}
     >
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="flex w-full items-center justify-between px-4 py-3 bg-[var(--color-bg-secondary)] hover:bg-[var(--color-bg-tertiary)] transition-colors text-left"
+        className="flex w-full items-center justify-between px-4 py-3 bg-[var(--bd-bg-subtle)] hover:bg-[var(--bd-bg-muted)] transition-colors text-left"
       >
-        <span className="text-sm font-medium text-[var(--color-text)]">
+        <span className="text-sm font-medium text-[var(--bd-text)]">
           {title}
         </span>
         <ChevronDown
           className={cn(
-            "h-4 w-4 text-[var(--color-text-muted)] transition-transform",
+            "h-4 w-4 text-[var(--bd-text-muted)] transition-transform",
             isOpen && "rotate-180"
           )}
         />
       </button>
       {isOpen && (
-        <div className="px-4 py-3 bg-[var(--color-bg)] border-t border-[var(--color-border)] text-sm text-[var(--color-text-secondary)]">
+        <div className="px-4 py-3 bg-[var(--bd-bg)] border-t border-[var(--bd-border)] text-sm text-[var(--bd-text-secondary)]">
           {children}
         </div>
       )}
@@ -77,28 +77,28 @@ export function ExpandableItem({
   const [isOpen, setIsOpen] = React.useState(defaultOpen);
 
   return (
-    <div className="not-prose border-l-2 border-[var(--color-border)] pl-4">
+    <div className="not-prose border-l-2 border-[var(--bd-border)] pl-4">
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center gap-2 text-left group"
       >
         {isOpen ? (
-          <Minus className="h-3 w-3 text-[var(--color-text-muted)]" />
+          <Minus className="h-3 w-3 text-[var(--bd-text-muted)]" />
         ) : (
-          <Plus className="h-3 w-3 text-[var(--color-text-muted)]" />
+          <Plus className="h-3 w-3 text-[var(--bd-text-muted)]" />
         )}
-        <code className="font-mono text-sm text-[var(--color-text)] group-hover:text-primary-600 dark:group-hover:text-primary-400">
+        <code className="font-mono text-sm text-[var(--bd-text)] group-hover:text-primary-600 dark:group-hover:text-primary-400">
           {title}
         </code>
         {type && (
-          <span className="font-mono text-xs text-[var(--color-text-muted)]">
+          <span className="font-mono text-xs text-[var(--bd-text-muted)]">
             {type}
           </span>
         )}
       </button>
       {isOpen && (
-        <div className="mt-2 ml-5 text-sm text-[var(--color-text-secondary)]">
+        <div className="mt-2 ml-5 text-sm text-[var(--bd-text-secondary)]">
           {children}
         </div>
       )}

--- a/packages/theme-docs/src/components/mdx/FileTree.tsx
+++ b/packages/theme-docs/src/components/mdx/FileTree.tsx
@@ -9,7 +9,7 @@ interface FileTreeProps {
 
 export function FileTree({ children, className }: FileTreeProps) {
   return (
-    <div className={cn("not-prose my-4 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-4 font-mono text-sm", className)}>
+    <div className={cn("not-prose my-4 rounded-lg border border-[var(--bd-border)] bg-[var(--bd-bg-subtle)] p-4 font-mono text-sm", className)}>
       <ul className="space-y-1">{children}</ul>
     </div>
   );
@@ -22,8 +22,8 @@ interface FileProps {
 
 export function TreeFile({ name, icon }: FileProps) {
   return (
-    <li className="flex items-center gap-2 py-0.5 text-[var(--color-text-secondary)]">
-      {icon || <File className="h-4 w-4 text-[var(--color-text-muted)]" />}
+    <li className="flex items-center gap-2 py-0.5 text-[var(--bd-text-secondary)]">
+      {icon || <File className="h-4 w-4 text-[var(--bd-text-muted)]" />}
       <span>{name}</span>
     </li>
   );
@@ -44,12 +44,12 @@ export function TreeFolder({ name, children, defaultOpen = false }: FolderProps)
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="flex w-full items-center gap-1 py-0.5 text-[var(--color-text)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+        className="flex w-full items-center gap-1 py-0.5 text-[var(--bd-text)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
       >
         {hasChildren && (
           <ChevronRight
             className={cn(
-              "h-3 w-3 text-[var(--color-text-muted)] transition-transform",
+              "h-3 w-3 text-[var(--bd-text-muted)] transition-transform",
               isOpen && "rotate-90"
             )}
           />
@@ -63,7 +63,7 @@ export function TreeFolder({ name, children, defaultOpen = false }: FolderProps)
         <span className="font-medium">{name}</span>
       </button>
       {isOpen && hasChildren && (
-        <ul className="ml-4 border-l border-[var(--color-border)] pl-3 mt-1 space-y-1">
+        <ul className="ml-4 border-l border-[var(--bd-border)] pl-3 mt-1 space-y-1">
           {children}
         </ul>
       )}

--- a/packages/theme-docs/src/components/mdx/Frame.tsx
+++ b/packages/theme-docs/src/components/mdx/Frame.tsx
@@ -10,11 +10,11 @@ interface FrameProps {
 export function Frame({ children, caption, className }: FrameProps) {
   return (
     <figure className={cn("not-prose my-6", className)}>
-      <div className="overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-secondary)]">
+      <div className="overflow-hidden rounded-lg border border-[var(--bd-border)] bg-[var(--bd-bg-subtle)]">
         {children}
       </div>
       {caption && (
-        <figcaption className="mt-2 text-center text-sm text-[var(--color-text-muted)]">
+        <figcaption className="mt-2 text-center text-sm text-[var(--bd-text-muted)]">
           {caption}
         </figcaption>
       )}

--- a/packages/theme-docs/src/components/mdx/Mermaid.tsx
+++ b/packages/theme-docs/src/components/mdx/Mermaid.tsx
@@ -78,8 +78,8 @@ export function Mermaid({ chart, className }: MermaidProps) {
 
   if (!svg) {
     return (
-      <div className={cn("not-prose my-4 flex items-center justify-center p-8 bg-[var(--color-bg-secondary)] rounded-lg", className)}>
-        <div className="text-sm text-[var(--color-text-muted)]">Loading diagram...</div>
+      <div className={cn("not-prose my-4 flex items-center justify-center p-8 bg-[var(--bd-bg-subtle)] rounded-lg", className)}>
+        <div className="text-sm text-[var(--bd-text-muted)]">Loading diagram...</div>
       </div>
     );
   }
@@ -87,7 +87,7 @@ export function Mermaid({ chart, className }: MermaidProps) {
   return (
     <div
       ref={containerRef}
-      className={cn("not-prose my-4 flex justify-center overflow-x-auto rounded-lg bg-[var(--color-bg)] p-4", className)}
+      className={cn("not-prose my-4 flex justify-center overflow-x-auto rounded-lg bg-[var(--bd-bg)] p-4", className)}
       dangerouslySetInnerHTML={{ __html: svg }}
     />
   );

--- a/packages/theme-docs/src/components/mdx/ParamField.tsx
+++ b/packages/theme-docs/src/components/mdx/ParamField.tsx
@@ -21,16 +21,16 @@ export function ParamField({
   return (
     <div
       className={cn(
-        "not-prose border-b border-[var(--color-border)] py-4 last:border-b-0",
+        "not-prose border-b border-[var(--bd-border)] py-4 last:border-b-0",
         className
       )}
     >
       <div className="flex flex-wrap items-baseline gap-2">
-        <code className="font-mono text-sm font-semibold text-[var(--color-text)]">
+        <code className="font-mono text-sm font-semibold text-[var(--bd-text)]">
           {name}
         </code>
         {type && (
-          <span className="font-mono text-xs text-[var(--color-text-muted)]">
+          <span className="font-mono text-xs text-[var(--bd-text-muted)]">
             {type}
           </span>
         )}
@@ -40,13 +40,13 @@ export function ParamField({
           </span>
         )}
         {defaultValue && (
-          <span className="text-xs text-[var(--color-text-muted)]">
+          <span className="text-xs text-[var(--bd-text-muted)]">
             default: <code className="font-mono">{defaultValue}</code>
           </span>
         )}
       </div>
       {children && (
-        <div className="mt-2 text-sm text-[var(--color-text-secondary)] prose prose-sm dark:prose-invert max-w-none">
+        <div className="mt-2 text-sm text-[var(--bd-text-secondary)] prose prose-sm dark:prose-invert max-w-none">
           {children}
         </div>
       )}
@@ -64,11 +64,11 @@ export function ParamFieldGroup({ children, title, className }: ParamFieldGroupP
   return (
     <div className={cn("my-6", className)}>
       {title && (
-        <h4 className="text-sm font-semibold text-[var(--color-text)] mb-4 uppercase tracking-wide">
+        <h4 className="text-sm font-semibold text-[var(--bd-text)] mb-4 uppercase tracking-wide">
           {title}
         </h4>
       )}
-      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-4">
+      <div className="rounded-lg border border-[var(--bd-border)] bg-[var(--bd-bg)] px-4">
         {children}
       </div>
     </div>

--- a/packages/theme-docs/src/components/mdx/ResponseField.tsx
+++ b/packages/theme-docs/src/components/mdx/ResponseField.tsx
@@ -17,22 +17,22 @@ export function ResponseField({
   return (
     <div
       className={cn(
-        "not-prose border-b border-[var(--color-border)] py-4 first:pt-0 last:border-b-0",
+        "not-prose border-b border-[var(--bd-border)] py-4 first:pt-0 last:border-b-0",
         className
       )}
     >
       <div className="flex flex-wrap items-baseline gap-2">
-        <code className="font-mono text-sm font-semibold text-[var(--color-text)]">
+        <code className="font-mono text-sm font-semibold text-[var(--bd-text)]">
           {name}
         </code>
         {type && (
-          <span className="font-mono text-xs text-[var(--color-text-muted)]">
+          <span className="font-mono text-xs text-[var(--bd-text-muted)]">
             {type}
           </span>
         )}
       </div>
       {children && (
-        <div className="mt-2 text-sm text-[var(--color-text-secondary)] prose prose-sm dark:prose-invert max-w-none">
+        <div className="mt-2 text-sm text-[var(--bd-text-secondary)] prose prose-sm dark:prose-invert max-w-none">
           {children}
         </div>
       )}
@@ -50,11 +50,11 @@ export function ResponseFieldGroup({ children, title, className }: ResponseField
   return (
     <div className={cn("my-6", className)}>
       {title && (
-        <h4 className="text-sm font-semibold text-[var(--color-text)] mb-4 uppercase tracking-wide">
+        <h4 className="text-sm font-semibold text-[var(--bd-text)] mb-4 uppercase tracking-wide">
           {title}
         </h4>
       )}
-      <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-4">
+      <div className="rounded-lg border border-[var(--bd-border)] bg-[var(--bd-bg)] px-4">
         {children}
       </div>
     </div>

--- a/packages/theme-docs/src/components/mdx/Step.astro
+++ b/packages/theme-docs/src/components/mdx/Step.astro
@@ -7,8 +7,8 @@ const { title } = Astro.props;
 ---
 
 <div class="relative">
-  <h3 class="font-semibold text-[var(--color-text)] mb-2">{title}</h3>
-  <div class="text-sm text-[var(--color-text-secondary)]">
+  <h3 class="font-semibold text-[var(--bd-text)] mb-2">{title}</h3>
+  <div class="text-sm text-[var(--bd-text-secondary)]">
     <slot />
   </div>
 </div>

--- a/packages/theme-docs/src/components/mdx/Steps.astro
+++ b/packages/theme-docs/src/components/mdx/Steps.astro
@@ -2,7 +2,7 @@
 // Steps component for step-by-step guides
 ---
 
-<div class="not-prose my-6 space-y-4 border-l-2 border-[var(--color-border)] pl-6 ml-2">
+<div class="not-prose my-6 space-y-4 border-l-2 border-[var(--bd-border)] pl-6 ml-2">
   <slot />
 </div>
 
@@ -23,8 +23,8 @@
     height: 1.5rem;
     font-size: 0.75rem;
     font-weight: 600;
-    background-color: var(--color-bg);
-    border: 2px solid var(--color-border);
+    background-color: var(--bd-bg);
+    border: 2px solid var(--bd-border);
     border-radius: 9999px;
   }
 </style>

--- a/packages/theme-docs/src/components/mdx/Steps.tsx
+++ b/packages/theme-docs/src/components/mdx/Steps.tsx
@@ -8,15 +8,8 @@ interface StepsProps {
 
 export function Steps({ children, className }: StepsProps) {
   return (
-    <div className={cn("not-prose my-6 ml-4 border-l-2 border-[var(--color-border)] pl-6 space-y-6", className)}>
-      {React.Children.map(children, (child, index) => {
-        if (React.isValidElement(child)) {
-          return React.cloneElement(child as React.ReactElement<StepProps>, {
-            stepNumber: index + 1,
-          });
-        }
-        return child;
-      })}
+    <div className={cn("bd-steps", className)}>
+      {children}
     </div>
   );
 }
@@ -24,22 +17,20 @@ export function Steps({ children, className }: StepsProps) {
 interface StepProps {
   title: string;
   children?: React.ReactNode;
-  stepNumber?: number;
   className?: string;
 }
 
-export function Step({ title, children, stepNumber = 1, className }: StepProps) {
+export function Step({ title, children, className }: StepProps) {
   return (
-    <div className={cn("relative", className)}>
-      {/* Step number circle */}
-      <div className="absolute -left-[2.125rem] flex h-6 w-6 items-center justify-center rounded-full border-2 border-[var(--color-border)] bg-[var(--color-bg)] text-xs font-semibold text-[var(--color-text-muted)]">
-        {stepNumber}
+    <div className={cn("bd-step", className)}>
+      <div className="bd-step-indicator">
+        <span className="bd-step-number" />
+        <div className="bd-step-connector" />
       </div>
-      {/* Content */}
-      <div>
-        <h3 className="font-semibold text-[var(--color-text)] mb-2">{title}</h3>
+      <div className="bd-step-content">
+        <h3 className="bd-step-title">{title}</h3>
         {children && (
-          <div className="text-sm text-[var(--color-text-secondary)] prose prose-sm dark:prose-invert max-w-none">
+          <div className="bd-step-body prose prose-sm dark:prose-invert max-w-none">
             {children}
           </div>
         )}

--- a/packages/theme-docs/src/components/mdx/Tabs.tsx
+++ b/packages/theme-docs/src/components/mdx/Tabs.tsx
@@ -16,22 +16,19 @@ export function Tabs({ items, defaultValue }: TabsProps) {
 
   return (
     <div className="not-prose my-4">
-      <div className="flex border-b border-[var(--color-border)]">
+      <div className="flex border-b border-[var(--bd-border)]">
         {items.map((item) => {
           const isActive = activeTab === item.value;
           return (
             <button
               key={item.value}
               type="button"
-              onClick={() => {
-                console.log('Tab clicked:', item.value);
-                setActiveTab(item.value);
-              }}
+              onClick={() => setActiveTab(item.value)}
               style={{ cursor: 'pointer' }}
               className={`px-4 py-2 text-sm font-medium transition-colors ${
                 isActive
-                  ? "border-b-2 border-blue-600 text-blue-600 -mb-px"
-                  : "text-gray-500 hover:text-gray-900"
+                  ? "border-b-2 border-primary-500 text-primary-600 dark:text-primary-400 -mb-px"
+                  : "text-[var(--bd-text-muted)] hover:text-[var(--bd-text)]"
               }`}
             >
               {item.label}
@@ -45,7 +42,7 @@ export function Tabs({ items, defaultValue }: TabsProps) {
           if (!isActive) return null;
           return (
             <div key={item.value}>
-              <pre className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-md p-3 text-sm overflow-x-auto">
+              <pre className="bg-[var(--bd-bg-code)] border border-[var(--bd-border)] rounded-md p-3 text-sm overflow-x-auto">
                 <code>{item.children}</code>
               </pre>
             </div>

--- a/packages/theme-docs/src/components/mdx/Tooltip.tsx
+++ b/packages/theme-docs/src/components/mdx/Tooltip.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import { cn } from "../../lib/utils.js";
 
 interface TooltipProps {
   children: React.ReactNode;
@@ -8,28 +7,30 @@ interface TooltipProps {
 }
 
 export function Tooltip({ children, tip }: TooltipProps) {
+  const [container, setContainer] = React.useState<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    setContainer(document.body);
+  }, []);
+
   return (
-    <TooltipPrimitive.Provider delayDuration={200}>
+    <TooltipPrimitive.Provider delayDuration={150}>
       <TooltipPrimitive.Root>
         <TooltipPrimitive.Trigger asChild>
-          <span className="cursor-help border-b border-dashed border-[var(--color-text-muted)] text-[var(--color-text)]">
-            {children}
-          </span>
+          <span className="bd-tooltip-trigger">{children}</span>
         </TooltipPrimitive.Trigger>
-        <TooltipPrimitive.Portal>
-          <TooltipPrimitive.Content
-            className={cn(
-              "z-50 overflow-hidden rounded-md bg-[var(--color-bg-tertiary)] px-3 py-1.5 text-sm text-[var(--color-text)] shadow-md",
-              "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
-              "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-              "max-w-xs"
-            )}
-            sideOffset={4}
-          >
-            {tip}
-            <TooltipPrimitive.Arrow className="fill-[var(--color-bg-tertiary)]" />
-          </TooltipPrimitive.Content>
-        </TooltipPrimitive.Portal>
+        {container && (
+          <TooltipPrimitive.Portal container={container}>
+            <TooltipPrimitive.Content
+              className="bd-tooltip-content"
+              sideOffset={6}
+              style={{ zIndex: 99999 }}
+            >
+              {tip}
+              <TooltipPrimitive.Arrow className="bd-tooltip-arrow" />
+            </TooltipPrimitive.Content>
+          </TooltipPrimitive.Portal>
+        )}
       </TooltipPrimitive.Root>
     </TooltipPrimitive.Provider>
   );

--- a/packages/theme-docs/src/components/ui/accordion.tsx
+++ b/packages/theme-docs/src/components/ui/accordion.tsx
@@ -11,7 +11,7 @@ const AccordionItem = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AccordionPrimitive.Item
     ref={ref}
-    className={cn("border-b border-[var(--color-border)]", className)}
+    className={cn("border-b border-[var(--bd-border)]", className)}
     {...props}
   />
 ));
@@ -31,7 +31,7 @@ const AccordionTrigger = React.forwardRef<
       {...props}
     >
       {children}
-      <ChevronDown className="h-4 w-4 shrink-0 text-[var(--color-text-secondary)] transition-transform duration-200" />
+      <ChevronDown className="h-4 w-4 shrink-0 text-[var(--bd-text-secondary)] transition-transform duration-200" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ));

--- a/packages/theme-docs/src/components/ui/alert.tsx
+++ b/packages/theme-docs/src/components/ui/alert.tsx
@@ -7,7 +7,7 @@ const alertVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-[var(--color-bg-secondary)] border-l-[var(--color-border)] text-[var(--color-text)]",
+        default: "bg-[var(--bd-bg-subtle)] border-l-[var(--bd-border)] text-[var(--bd-text)]",
         info: "bg-blue-50/70 dark:bg-blue-950/30 border-l-blue-500 text-blue-900 dark:text-blue-100 [&>svg]:text-blue-600",
         warning: "bg-orange-50/70 dark:bg-orange-950/30 border-l-orange-500 text-orange-900 dark:text-orange-100 [&>svg]:text-orange-600",
         success: "bg-green-50/70 dark:bg-green-950/30 border-l-green-500 text-green-900 dark:text-green-100 [&>svg]:text-green-600",

--- a/packages/theme-docs/src/components/ui/button.tsx
+++ b/packages/theme-docs/src/components/ui/button.tsx
@@ -13,11 +13,11 @@ const buttonVariants = cva(
         destructive:
           "bg-red-600 text-white shadow-sm hover:bg-red-700",
         outline:
-          "border border-[var(--color-border)] bg-transparent shadow-sm hover:bg-[var(--color-bg-secondary)] hover:text-[var(--color-text)]",
+          "border border-[var(--bd-border)] bg-transparent shadow-sm hover:bg-[var(--bd-bg-subtle)] hover:text-[var(--bd-text)]",
         secondary:
-          "bg-[var(--color-bg-secondary)] text-[var(--color-text)] shadow-sm hover:bg-[var(--color-bg-tertiary)]",
+          "bg-[var(--bd-bg-subtle)] text-[var(--bd-text)] shadow-sm hover:bg-[var(--bd-bg-muted)]",
         ghost:
-          "hover:bg-[var(--color-bg-secondary)] hover:text-[var(--color-text)]",
+          "hover:bg-[var(--bd-bg-subtle)] hover:text-[var(--bd-text)]",
         link: "text-primary-600 underline-offset-4 hover:underline",
       },
       size: {

--- a/packages/theme-docs/src/components/ui/card.tsx
+++ b/packages/theme-docs/src/components/ui/card.tsx
@@ -8,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border border-[var(--color-border)] bg-[var(--color-bg)] text-[var(--color-text)] shadow-sm",
+      "rounded-xl border border-[var(--bd-border)] bg-[var(--bd-bg)] text-[var(--bd-text)] shadow-sm",
       className
     )}
     {...props}
@@ -46,7 +46,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm text-[var(--color-text-secondary)]", className)}
+    className={cn("text-sm text-[var(--bd-text-secondary)]", className)}
     {...props}
   />
 ));

--- a/packages/theme-docs/src/components/ui/dialog.tsx
+++ b/packages/theme-docs/src/components/ui/dialog.tsx
@@ -35,7 +35,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-[var(--color-border)] bg-[var(--color-bg)] p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-[var(--bd-border)] bg-[var(--bd-bg)] p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}
@@ -99,7 +99,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-[var(--color-text-secondary)]", className)}
+    className={cn("text-sm text-[var(--bd-text-secondary)]", className)}
     {...props}
   />
 ));

--- a/packages/theme-docs/src/components/ui/scroll-area.tsx
+++ b/packages/theme-docs/src/components/ui/scroll-area.tsx
@@ -37,7 +37,7 @@ const ScrollBar = React.forwardRef<
     )}
     {...props}
   >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-[var(--color-border)]" />
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-[var(--bd-border)]" />
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
 ));
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;

--- a/packages/theme-docs/src/components/ui/separator.tsx
+++ b/packages/theme-docs/src/components/ui/separator.tsx
@@ -15,7 +15,7 @@ const Separator = React.forwardRef<
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-[var(--color-border)]",
+        "shrink-0 bg-[var(--bd-border)]",
         orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
         className
       )}

--- a/packages/theme-docs/src/components/ui/sheet.tsx
+++ b/packages/theme-docs/src/components/ui/sheet.tsx
@@ -28,7 +28,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-[var(--color-bg)] p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  "fixed z-50 gap-4 bg-[var(--bd-bg)] p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
   {
     variants: {
       side: {
@@ -105,7 +105,7 @@ const SheetTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold text-[var(--color-text)]", className)}
+    className={cn("text-lg font-semibold text-[var(--bd-text)]", className)}
     {...props}
   />
 ));
@@ -117,7 +117,7 @@ const SheetDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-[var(--color-text-secondary)]", className)}
+    className={cn("text-sm text-[var(--bd-text-secondary)]", className)}
     {...props}
   />
 ));

--- a/packages/theme-docs/src/components/ui/tabs.tsx
+++ b/packages/theme-docs/src/components/ui/tabs.tsx
@@ -11,7 +11,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-lg bg-[var(--color-bg-secondary)] p-1 text-[var(--color-text-secondary)]",
+      "inline-flex h-10 items-center justify-center rounded-lg bg-[var(--bd-bg-subtle)] p-1 text-[var(--bd-text-secondary)]",
       className
     )}
     {...props}
@@ -26,7 +26,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-[var(--color-bg)] data-[state=active]:text-[var(--color-text)] data-[state=active]:shadow",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-[var(--bd-bg)] data-[state=active]:text-[var(--bd-text)] data-[state=active]:shadow",
       className
     )}
     {...props}

--- a/packages/theme-docs/src/components/ui/tooltip.tsx
+++ b/packages/theme-docs/src/components/ui/tooltip.tsx
@@ -17,7 +17,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md bg-[var(--color-text)] px-3 py-1.5 text-xs text-[var(--color-bg)] animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 overflow-hidden rounded-md bg-[var(--bd-text)] px-3 py-1.5 text-xs text-[var(--bd-bg)] animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/packages/theme-docs/src/index.ts
+++ b/packages/theme-docs/src/index.ts
@@ -84,6 +84,12 @@ function createThemeIntegration(
           integrations: [mdx(), react()],
           vite: {
             plugins: [tailwindcss()],
+            optimizeDeps: {
+              include: ["mermaid"],
+            },
+            ssr: {
+              noExternal: [],
+            },
             resolve: {
               dedupe: ["react", "react-dom"],
             },

--- a/packages/theme-docs/src/layouts/BaseLayout.astro
+++ b/packages/theme-docs/src/layouts/BaseLayout.astro
@@ -1,7 +1,9 @@
 ---
 import ThemeScript from "../components/ThemeScript.astro";
 import { SearchDialog } from "../components/SearchDialog";
+import { ClientRouter } from "astro:transitions";
 import config from "virtual:barodoc/config";
+import { generateThemeCSS } from "@barodoc/core";
 import "@barodoc/theme-docs/styles/global.css";
 
 interface Props {
@@ -16,6 +18,8 @@ const canonicalUrl = config.site ? new URL(Astro.url.pathname, config.site).href
 const ogImageUrl = ogImage
   ? (config.site ? new URL(ogImage, config.site).href : ogImage)
   : undefined;
+
+const themeCSS = config.theme?.colors ? generateThemeCSS(config.theme.colors) : "";
 ---
 
 <!doctype html>
@@ -43,8 +47,10 @@ const ogImageUrl = ogImage
 
     <title>{title}</title>
     <ThemeScript />
+    <ClientRouter />
+    {themeCSS && <style set:html={themeCSS} />}
   </head>
-  <body class="min-h-screen bg-[var(--color-bg)] text-[var(--color-text)] antialiased">
+  <body class="min-h-screen bg-[var(--bd-bg)] text-[var(--bd-text)] antialiased">
     <slot />
     <SearchDialog client:load />
   </body>

--- a/packages/theme-docs/src/layouts/DocsLayout.astro
+++ b/packages/theme-docs/src/layouts/DocsLayout.astro
@@ -48,18 +48,18 @@ const feedbackEndpoint = config.feedback?.endpoint;
   <Header currentLocale={currentLocale} currentPath={currentPath} />
   
   <!-- Centered container for docs layout -->
-  <div class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex justify-center overflow-x-hidden">
-    <div class="flex w-full max-w-[1120px] min-w-0">
+  <div class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex justify-center overflow-x-clip">
+    <div class="flex w-full max-w-[1280px] min-w-0">
       <!-- Desktop Sidebar -->
-      <aside class="hidden lg:block w-[220px] shrink-0">
-        <div class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto py-6 pr-4">
+      <aside class="hidden lg:block w-[240px] shrink-0 border-r border-[var(--bd-border)]">
+        <div class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto overscroll-contain pt-2 pb-8 px-4 sidebar-scroll">
           <Sidebar currentPath={currentPath} currentLocale={currentLocale} />
         </div>
       </aside>
 
-      <!-- Main Content: no min-width on mobile to avoid horizontal scroll -->
-      <main class="flex-1 min-w-0 lg:min-w-[650px] max-w-[720px]">
-        <div class="px-4 py-6 sm:px-6 sm:py-8 lg:px-8 lg:py-8">
+      <!-- Main Content -->
+      <main class="flex-1 min-w-0 max-w-[768px]">
+        <div class="px-4 py-8 sm:px-6 sm:py-10 lg:px-10 lg:py-10">
           {breadcrumbs.length > 0 && <Breadcrumb items={breadcrumbs} />}
           <article class="prose prose-gray dark:prose-invert max-w-none min-w-0 overflow-x-auto">
             <slot />
@@ -67,21 +67,21 @@ const feedbackEndpoint = config.feedback?.endpoint;
           
           <!-- Page Navigation -->
           {(prevPage || nextPage) && (
-            <nav class="mt-8 pt-6 border-t border-[var(--color-border)]" aria-label="Page navigation">
+            <nav class="mt-12 pt-8 border-t border-[var(--bd-border)]" aria-label="Page navigation">
               <div class="grid grid-cols-2 gap-4">
                 <div class="col-span-1">
                   {prevPage && (
                     <a 
                       href={prevPage.href}
-                      class="group flex flex-col gap-1 p-3 rounded-lg border border-[var(--color-border)] hover:border-primary-300 dark:hover:border-primary-700 hover:bg-[var(--color-bg-secondary)] transition-all"
+                      class="group flex flex-col gap-1.5 p-4 rounded-lg border border-[var(--bd-border)] hover:border-primary-400/50 dark:hover:border-primary-500/40 hover:shadow-[var(--bd-shadow-sm)] transition-all"
                     >
-                      <span class="text-xs text-[var(--color-text-muted)] flex items-center gap-1">
+                      <span class="text-xs font-medium text-[var(--bd-text-muted)] flex items-center gap-1">
                         <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
                         </svg>
                         Previous
                       </span>
-                      <span class="text-sm font-medium text-[var(--color-text)] group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+                      <span class="text-sm font-medium text-[var(--bd-text)] group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
                         {prevPage.title}
                       </span>
                     </a>
@@ -91,15 +91,15 @@ const feedbackEndpoint = config.feedback?.endpoint;
                   {nextPage && (
                     <a 
                       href={nextPage.href}
-                      class="group flex flex-col gap-1 p-3 rounded-lg border border-[var(--color-border)] hover:border-primary-300 dark:hover:border-primary-700 hover:bg-[var(--color-bg-secondary)] transition-all text-right"
+                      class="group flex flex-col gap-1.5 p-4 rounded-lg border border-[var(--bd-border)] hover:border-primary-400/50 dark:hover:border-primary-500/40 hover:shadow-[var(--bd-shadow-sm)] transition-all text-right"
                     >
-                      <span class="text-xs text-[var(--color-text-muted)] flex items-center gap-1 justify-end">
+                      <span class="text-xs font-medium text-[var(--bd-text-muted)] flex items-center gap-1 justify-end">
                         Next
                         <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                         </svg>
                       </span>
-                      <span class="text-sm font-medium text-[var(--color-text)] group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+                      <span class="text-sm font-medium text-[var(--bd-text)] group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
                         {nextPage.title}
                       </span>
                     </a>
@@ -110,8 +110,8 @@ const feedbackEndpoint = config.feedback?.endpoint;
           )}
 
           <!-- Page footer -->
-          <footer class="mt-6 pt-4 border-t border-[var(--color-border-light)] flex flex-col gap-3">
-            <div class="flex flex-wrap items-center justify-between gap-2 text-sm text-[var(--color-text-muted)]">
+          <footer class="mt-8 pt-6 border-t border-[var(--bd-border-subtle)] flex flex-col gap-3">
+            <div class="flex flex-wrap items-center justify-between gap-2 text-[13px] text-[var(--bd-text-muted)]">
               {lastUpdated && (
                 <span>
                   Last updated: <time datetime={lastUpdated.toISOString()}>
@@ -124,7 +124,7 @@ const feedbackEndpoint = config.feedback?.endpoint;
                   href={editUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="inline-flex items-center gap-1 text-primary-600 dark:text-primary-400 hover:underline"
+                  class="inline-flex items-center gap-1.5 text-[var(--bd-text-secondary)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
                 >
                   <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
@@ -134,12 +134,12 @@ const feedbackEndpoint = config.feedback?.endpoint;
               )}
             </div>
             {hasFeedback && (
-              <div class="doc-feedback flex items-center gap-3 text-sm text-[var(--color-text-muted)]" data-endpoint={feedbackEndpoint}>
+              <div class="doc-feedback flex items-center gap-3 text-sm text-[var(--bd-text-muted)]" data-endpoint={feedbackEndpoint}>
                 <span>Was this page helpful?</span>
-                <button type="button" class="feedback-btn inline-flex items-center gap-1 px-2 py-1 rounded border border-[var(--color-border)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-value="yes" aria-label="Yes">
+                <button type="button" class="feedback-btn inline-flex items-center gap-1 px-2 py-1 rounded border border-[var(--bd-border)] hover:bg-[var(--bd-bg-subtle)] transition-colors" data-value="yes" aria-label="Yes">
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 9V5a3 3 0 00-3-3l-4 9v11h11.28a2 2 0 002-1.7l1.38-9a2 2 0 00-2-2.3H14z" /></svg>
                 </button>
-                <button type="button" class="feedback-btn inline-flex items-center gap-1 px-2 py-1 rounded border border-[var(--color-border)] hover:bg-[var(--color-bg-secondary)] transition-colors" data-value="no" aria-label="No">
+                <button type="button" class="feedback-btn inline-flex items-center gap-1 px-2 py-1 rounded border border-[var(--bd-border)] hover:bg-[var(--bd-bg-subtle)] transition-colors" data-value="no" aria-label="No">
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 15v3.586a1 1 0 01-.293.707l-2 2A1 1 0 016 20.586V15m4 0h5.17a2 2 0 001.98-1.742l1.08-7.56A1 1 0 0017.242 4.5H10m0 10.5V4.5m0 0H7.5A2.5 2.5 0 005 7v3" /></svg>
                 </button>
                 <span class="feedback-thanks hidden text-green-600 dark:text-green-400">Thanks for your feedback!</span>
@@ -151,8 +151,8 @@ const feedbackEndpoint = config.feedback?.endpoint;
 
       <!-- Table of Contents -->
       {headings.length > 0 && (
-        <aside class="hidden xl:block w-[180px] shrink-0">
-          <div class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto py-6 pl-6">
+        <aside class="hidden xl:block w-[220px] shrink-0">
+          <div class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto py-10 pl-8">
             <TableOfContents headings={headings} />
           </div>
         </aside>
@@ -165,6 +165,23 @@ const feedbackEndpoint = config.feedback?.endpoint;
   
   <!-- Code copy functionality -->
   <CodeCopy />
+
+  <!-- Heading anchor links -->
+  <script>
+    function initHeadingAnchors() {
+      document.querySelectorAll('.prose h2[id], .prose h3[id], .prose h4[id]').forEach((heading) => {
+        if (heading.querySelector('.heading-anchor')) return;
+        const anchor = document.createElement('a');
+        anchor.className = 'heading-anchor';
+        anchor.href = `#${heading.id}`;
+        anchor.textContent = '#';
+        anchor.setAttribute('aria-label', `Link to ${heading.textContent}`);
+        heading.appendChild(anchor);
+      });
+    }
+    initHeadingAnchors();
+    document.addEventListener('astro:page-load', initHeadingAnchors);
+  </script>
 
   {hasFeedback && (
     <script>

--- a/packages/theme-docs/src/pages/404.astro
+++ b/packages/theme-docs/src/pages/404.astro
@@ -8,10 +8,10 @@ const pathname = new URL(Astro.request.url).pathname;
 <BaseLayout title={`${config.name} · Page not found`} description="The page you are looking for does not exist.">
   <div class="min-h-screen flex flex-col items-center justify-center px-4">
     <div class="text-center max-w-md">
-      <p class="text-8xl font-bold text-[var(--color-text-muted)] select-none" aria-hidden="true">404</p>
-      <h1 class="text-2xl font-semibold text-[var(--color-text)] mt-4">Page not found</h1>
-      <p class="text-[var(--color-text-secondary)] mt-2">
-        The page at <code class="text-sm bg-[var(--color-bg-secondary)] px-2 py-1 rounded break-all">{pathname}</code> does not exist.
+      <p class="text-8xl font-bold text-[var(--bd-text-muted)] select-none" aria-hidden="true">404</p>
+      <h1 class="text-2xl font-semibold text-[var(--bd-text)] mt-4">Page not found</h1>
+      <p class="text-[var(--bd-text-secondary)] mt-2">
+        The page at <code class="text-sm bg-[var(--bd-bg-subtle)] px-2 py-1 rounded break-all">{pathname}</code> does not exist.
       </p>
       <div class="flex flex-col sm:flex-row items-center justify-center gap-3 mt-8">
         <a
@@ -22,7 +22,7 @@ const pathname = new URL(Astro.request.url).pathname;
         </a>
         <a
           href="/docs/introduction"
-          class="px-5 py-2.5 border border-[var(--color-border)] text-[var(--color-text)] rounded-xl hover:bg-[var(--color-bg-secondary)] transition-colors font-medium"
+          class="px-5 py-2.5 border border-[var(--bd-border)] text-[var(--bd-text)] rounded-xl hover:bg-[var(--bd-bg-subtle)] transition-colors font-medium"
         >
           Documentation
         </a>

--- a/packages/theme-docs/src/pages/docs/[...slug].astro
+++ b/packages/theme-docs/src/pages/docs/[...slug].astro
@@ -124,13 +124,13 @@ breadcrumbs.push({ label: doc.data.title });
   breadcrumbs={breadcrumbs}
 >
   {category && (
-    <p class="text-xs font-medium uppercase tracking-wider text-primary-600 dark:text-primary-400 mb-2">
+    <p class="text-xs font-semibold uppercase tracking-widest text-primary-600 dark:text-primary-400 mb-3">
       {category}
     </p>
   )}
   <h1>{doc.data.title}</h1>
   {doc.data.description && (
-    <p class="lead text-sm text-[var(--color-text-secondary)] mt-1 mb-4">
+    <p class="lead text-base text-[var(--bd-text-secondary)] mt-2 mb-6 leading-relaxed">
       {doc.data.description}
     </p>
   )}

--- a/packages/theme-docs/src/pages/index.astro
+++ b/packages/theme-docs/src/pages/index.astro
@@ -40,10 +40,10 @@ const features = [
 <BaseLayout title={config.name}>
   <div class="min-h-screen flex flex-col">
     <!-- Header -->
-    <header class="sticky top-0 z-50 border-b border-[var(--color-border)] bg-[var(--color-bg)]/95 backdrop-blur-md">
+    <header class="sticky top-0 z-50 border-b border-[var(--bd-border)] bg-[var(--bd-bg)]/95 backdrop-blur-md">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex h-16 items-center justify-between">
-          <a href="/" class="flex items-center gap-2.5 font-semibold text-[var(--color-text)]">
+          <a href="/" class="flex items-center gap-2.5 font-semibold text-[var(--bd-text)]">
             {config.logo && <img src={config.logo} alt={config.name} class="h-7 w-7" />}
             <span class="text-lg">{config.name}</span>
           </a>
@@ -53,7 +53,7 @@ const features = [
                 href={config.topbar.github}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="p-2.5 rounded-xl text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] transition-all"
+                class="p-2.5 rounded-xl text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] hover:bg-[var(--bd-bg-subtle)] transition-all"
                 aria-label="GitHub"
               >
                 <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
@@ -91,12 +91,12 @@ const features = [
               <span class="text-sm font-medium text-primary-700 dark:text-primary-300">Powered by Astro</span>
             </div>
             
-            <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-[var(--color-text)] mb-6 leading-tight">
+            <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-[var(--bd-text)] mb-6 leading-tight">
               Build beautiful
               <span class="text-transparent bg-clip-text bg-gradient-to-r from-primary-600 to-primary-400"> documentation</span>
             </h1>
             
-            <p class="text-lg sm:text-xl text-[var(--color-text-secondary)] mb-10 max-w-2xl mx-auto leading-relaxed">
+            <p class="text-lg sm:text-xl text-[var(--bd-text-secondary)] mb-10 max-w-2xl mx-auto leading-relaxed">
               Create stunning documentation sites with MDX, Astro, and Tailwind CSS. 
               Deploy anywhere with static site generation.
             </p>
@@ -110,19 +110,19 @@ const features = [
               </a>
               <a
                 href="/docs/quickstart"
-                class="w-full sm:w-auto px-8 py-3.5 border border-[var(--color-border)] text-[var(--color-text)] rounded-xl hover:bg-[var(--color-bg-secondary)] hover:border-[var(--color-text-muted)] transition-all font-medium"
+                class="w-full sm:w-auto px-8 py-3.5 border border-[var(--bd-border)] text-[var(--bd-text)] rounded-xl hover:bg-[var(--bd-bg-subtle)] hover:border-[var(--bd-text-muted)] transition-all font-medium"
               >
                 Quick Start
               </a>
             </div>
             
             <!-- Install command -->
-            <div class="mt-12 inline-flex items-center gap-3 px-5 py-3 bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-xl">
-              <code class="text-sm text-[var(--color-text-secondary)] font-mono">
+            <div class="mt-12 inline-flex items-center gap-3 px-5 py-3 bg-[var(--bd-bg-subtle)] border border-[var(--bd-border)] rounded-xl">
+              <code class="text-sm text-[var(--bd-text-secondary)] font-mono">
                 npx create-barodoc my-docs
               </code>
               <button 
-                class="p-1.5 rounded-lg hover:bg-[var(--color-bg-tertiary)] text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors"
+                class="p-1.5 rounded-lg hover:bg-[var(--bd-bg-muted)] text-[var(--bd-text-muted)] hover:text-[var(--bd-text)] transition-colors"
                 onclick="navigator.clipboard.writeText('npx create-barodoc my-docs')"
                 aria-label="Copy command"
               >
@@ -136,27 +136,27 @@ const features = [
       </div>
 
       <!-- Features Section -->
-      <div class="py-20 bg-[var(--color-bg-secondary)] border-y border-[var(--color-border)]">
+      <div class="py-20 bg-[var(--bd-bg-subtle)] border-y border-[var(--bd-border)]">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div class="text-center mb-16">
-            <h2 class="text-3xl font-bold text-[var(--color-text)] mb-4">
+            <h2 class="text-3xl font-bold text-[var(--bd-text)] mb-4">
               Everything you need
             </h2>
-            <p class="text-lg text-[var(--color-text-secondary)] max-w-2xl mx-auto">
+            <p class="text-lg text-[var(--bd-text-secondary)] max-w-2xl mx-auto">
               Barodoc comes with all the features you need to create beautiful documentation.
             </p>
           </div>
           
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {features.map((feature) => (
-              <div class="group p-6 bg-[var(--color-bg)] rounded-2xl border border-[var(--color-border)] hover:border-primary-300 dark:hover:border-primary-700 hover:shadow-lg transition-all duration-200">
+              <div class="group p-6 bg-[var(--bd-bg)] rounded-2xl border border-[var(--bd-border)] hover:border-primary-300 dark:hover:border-primary-700 hover:shadow-lg transition-all duration-200">
                 <div class="flex items-center justify-center w-12 h-12 rounded-xl bg-primary-50 dark:bg-primary-950/50 mb-4 group-hover:scale-110 transition-transform">
                   <span class="text-2xl">{feature.icon}</span>
                 </div>
-                <h3 class="text-lg font-semibold text-[var(--color-text)] mb-2">
+                <h3 class="text-lg font-semibold text-[var(--bd-text)] mb-2">
                   {feature.title}
                 </h3>
-                <p class="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+                <p class="text-sm text-[var(--bd-text-secondary)] leading-relaxed">
                   {feature.description}
                 </p>
               </div>
@@ -168,10 +168,10 @@ const features = [
       <!-- CTA Section -->
       <div class="py-20">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 class="text-3xl font-bold text-[var(--color-text)] mb-4">
+          <h2 class="text-3xl font-bold text-[var(--bd-text)] mb-4">
             Ready to get started?
           </h2>
-          <p class="text-lg text-[var(--color-text-secondary)] mb-8">
+          <p class="text-lg text-[var(--bd-text-secondary)] mb-8">
             Create your documentation site in minutes.
           </p>
           <a
@@ -185,10 +185,10 @@ const features = [
     </main>
 
     <!-- Footer -->
-    <footer class="border-t border-[var(--color-border)] bg-[var(--color-bg-secondary)]">
+    <footer class="border-t border-[var(--bd-border)] bg-[var(--bd-bg-subtle)]">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
-          <div class="flex items-center gap-2 text-[var(--color-text-secondary)]">
+          <div class="flex items-center gap-2 text-[var(--bd-text-secondary)]">
             {config.logo && <img src={config.logo} alt={config.name} class="h-5 w-5 opacity-60" />}
             <span class="text-sm">Built with Barodoc</span>
           </div>
@@ -198,14 +198,14 @@ const features = [
                 href={config.topbar.github}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
+                class="text-sm text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] transition-colors"
               >
                 GitHub
               </a>
             )}
             <a
               href="/docs/introduction"
-              class="text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
+              class="text-sm text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] transition-colors"
             >
               Documentation
             </a>

--- a/packages/theme-docs/src/styles/global.css
+++ b/packages/theme-docs/src/styles/global.css
@@ -1,11 +1,17 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
-/* Scan theme package files */
 @source "../**/*.{astro,tsx}";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
+/* ==========================================================================
+   Accent (primary) palette — generates Tailwind utilities:
+   bg-primary-600, text-primary-400, border-primary-500, etc.
+   Override via barodoc.config.json theme.colors.accent
+   ========================================================================== */
+
 @theme {
-  /* Primary color palette - Blue */
   --color-primary-50: oklch(0.97 0.02 250);
   --color-primary-100: oklch(0.94 0.04 250);
   --color-primary-200: oklch(0.88 0.08 250);
@@ -19,40 +25,92 @@
   --color-primary-950: oklch(0.20 0.04 250);
 }
 
+/* ==========================================================================
+   Gray scale — single source of truth, defined once.
+   Override via barodoc.config.json theme.colors.gray
+   Default: Zinc
+   ========================================================================== */
+
 @layer base {
   :root {
-    /* Mintlify-style soft colors */
-    --color-bg: #ffffff;
-    --color-bg-secondary: #f8fafc;
-    --color-bg-tertiary: #f1f5f9;
-    --color-bg-hover: #f1f5f9;
-    --color-text: #0f172a;
-    --color-text-secondary: #64748b;
-    --color-text-muted: #94a3b8;
-    --color-border: #e2e8f0;
-    --color-border-light: #f1f5f9;
-    
-    /* Shadows */
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+    --bd-gray-50:  #fafafa;
+    --bd-gray-100: #f4f4f5;
+    --bd-gray-200: #e4e4e7;
+    --bd-gray-300: #d4d4d8;
+    --bd-gray-400: #a1a1aa;
+    --bd-gray-500: #71717a;
+    --bd-gray-600: #52525b;
+    --bd-gray-700: #3f3f46;
+    --bd-gray-800: #27272a;
+    --bd-gray-900: #18181b;
+    --bd-gray-950: #09090b;
+  }
+
+/* ==========================================================================
+   Semantic tokens — map scale indices to roles.
+   Light/dark only swap which end of the scale each role points to.
+   ========================================================================== */
+
+  :root {
+    --bd-bg:          #ffffff;
+    --bd-bg-subtle:   var(--bd-gray-50);
+    --bd-bg-muted:    var(--bd-gray-100);
+    --bd-bg-hover:    var(--bd-gray-100);
+    --bd-bg-code:     var(--bd-gray-50);
+
+    --bd-text:          var(--bd-gray-900);
+    --bd-text-heading:  var(--bd-gray-950);
+    --bd-text-secondary: var(--bd-gray-600);
+    --bd-text-muted:    var(--bd-gray-400);
+
+    --bd-border:        var(--bd-gray-200);
+    --bd-border-subtle: var(--bd-gray-100);
+
+    --bd-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    --bd-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.07), 0 2px 4px -2px rgb(0 0 0 / 0.05);
+    --bd-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.04);
+
+    --bd-sidebar-active-bg:     var(--color-primary-50);
+    --bd-sidebar-active-border: var(--color-primary-500);
+    --bd-sidebar-active-text:   var(--color-primary-600);
+
+    /* Backward compat aliases */
+    --color-bg: var(--bd-bg);
+    --color-bg-secondary: var(--bd-bg-subtle);
+    --color-bg-tertiary: var(--bd-bg-muted);
+    --color-bg-hover: var(--bd-bg-hover);
+    --color-text: var(--bd-text);
+    --color-text-secondary: var(--bd-text-secondary);
+    --color-text-muted: var(--bd-text-muted);
+    --color-border: var(--bd-border);
+    --color-border-light: var(--bd-border-subtle);
+    --shadow-sm: var(--bd-shadow-sm);
+    --shadow-md: var(--bd-shadow-md);
+    --shadow-lg: var(--bd-shadow-lg);
   }
 
   .dark {
-    --color-bg: #0c0c0c;
-    --color-bg-secondary: #141414;
-    --color-bg-tertiary: #1c1c1c;
-    --color-bg-hover: #1c1c1c;
-    --color-text: #fafafa;
-    --color-text-secondary: #a1a1aa;
-    --color-text-muted: #71717a;
-    --color-border: #27272a;
-    --color-border-light: #1c1c1c;
-    
-    /* Dark shadows */
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
-    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.4), 0 2px 4px -2px rgb(0 0 0 / 0.3);
-    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.4), 0 4px 6px -4px rgb(0 0 0 / 0.3);
+    --bd-bg:          var(--bd-gray-950);
+    --bd-bg-subtle:   var(--bd-gray-900);
+    --bd-bg-muted:    var(--bd-gray-800);
+    --bd-bg-hover:    var(--bd-gray-800);
+    --bd-bg-code:     var(--bd-gray-900);
+
+    --bd-text:          var(--bd-gray-200);
+    --bd-text-heading:  var(--bd-gray-50);
+    --bd-text-secondary: var(--bd-gray-400);
+    --bd-text-muted:    var(--bd-gray-500);
+
+    --bd-border:        var(--bd-gray-800);
+    --bd-border-subtle: var(--bd-gray-900);
+
+    --bd-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.4);
+    --bd-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.5), 0 2px 4px -2px rgb(0 0 0 / 0.4);
+    --bd-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.4);
+
+    --bd-sidebar-active-bg:     var(--color-primary-950);
+    --bd-sidebar-active-border: var(--color-primary-400);
+    --bd-sidebar-active-text:   var(--color-primary-400);
   }
 
   html {
@@ -60,199 +118,249 @@
   }
 
   body {
-    background-color: var(--color-bg);
-    color: var(--color-text);
+    background-color: var(--bd-bg);
+    color: var(--bd-text);
     font-feature-settings: "rlig" 1, "calt" 1;
     overflow-x: hidden;
   }
 
-  /* Smooth transitions for all interactive elements */
   a, button, input, [role="button"] {
     transition: all 150ms ease-out;
   }
-  
-  /* Ensure cursor pointer for interactive elements */
+
   a[href], button, [role="button"] {
     cursor: pointer;
   }
 }
 
-/* Prose styling for MDX content -  */
+/* ==========================================================================
+   Prose / Typography overrides
+   Placed outside @layer so they override @tailwindcss/typography defaults
+   without needing !important.
+   ========================================================================== */
+
 .prose {
-  --tw-prose-body: var(--color-text);
-  --tw-prose-headings: var(--color-text);
+  --tw-prose-body: var(--bd-text);
+  --tw-prose-headings: var(--bd-text-heading);
+  --tw-prose-bold: var(--bd-text-heading);
   --tw-prose-links: var(--color-primary-600);
-  --tw-prose-code: var(--color-text);
-  --tw-prose-pre-bg: var(--color-bg-secondary);
-  /* font-size: 0.875rem !important; */
-  /* line-height: 1.6 !important; */
+  --tw-prose-code: var(--bd-text);
+  --tw-prose-pre-bg: var(--bd-bg-code);
+  --tw-prose-counters: var(--bd-text-muted);
+  --tw-prose-bullets: var(--bd-text-muted);
+  --tw-prose-quotes: var(--bd-text);
+  --tw-prose-quote-borders: var(--color-primary-500);
+  --tw-prose-captions: var(--bd-text-secondary);
+  --tw-prose-th-borders: var(--bd-border);
+  --tw-prose-td-borders: var(--bd-border);
 }
 
 .dark .prose {
   --tw-prose-links: var(--color-primary-400);
 }
 
-/* Headings -  */
 .prose :where(h1):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  font-size: 1.75rem !important;
-  font-weight: 700 !important;
-  letter-spacing: -0.025em !important;
-  margin-top: 0 !important;
-  margin-bottom: 0.375rem !important;
-  /* line-height: 1.25 !important; */
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.2;
+  margin-top: 0;
+  margin-bottom: 0.25rem;
 }
 
 .prose :where(h2):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  font-size: 1.1875rem !important;
-  font-weight: 600 !important;
-  letter-spacing: -0.02em !important;
-  margin-top: 1.25rem !important;
-  margin-bottom: 0.375rem !important;
-  padding-bottom: 0.25rem !important;
-  border-bottom: 1px solid var(--color-border) !important;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
 }
 
 .prose :where(h3):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  font-size: 1rem !important;
-  font-weight: 600 !important;
-  margin-top: 1rem !important;
-  margin-bottom: 0.25rem !important;
+  font-size: 1.0625rem;
+  font-weight: 600;
+  line-height: 1.4;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .prose :where(h4):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  font-size: 0.9375rem !important;
-  font-weight: 600 !important;
-  margin-top: 0.875rem !important;
-  margin-bottom: 0.25rem !important;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.4;
+  margin-top: 1.25rem;
+  margin-bottom: 0.375rem;
 }
 
-/* Paragraphs - tighter spacing */
 .prose :where(p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  margin-top: 0.5rem !important;
-  margin-bottom: 0.5rem !important;
+  margin-top: 0.625rem;
+  margin-bottom: 0.625rem;
+  line-height: 1.7;
 }
 
-/* Links with underline on hover */
 .prose :where(a):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  font-weight: 500 !important;
-  text-decoration: none !important;
+  font-weight: 500;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--tw-prose-links) 35%, transparent);
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+  transition: text-decoration-color 200ms ease;
 }
 
 .prose :where(a):not(:where([class~="not-prose"],[class~="not-prose"] *)):hover {
-  text-decoration: underline !important;
-  text-underline-offset: 2px !important;
+  text-decoration-color: var(--tw-prose-links);
 }
 
-/* Code block styling -  */
 .prose :where(pre):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  background-color: var(--color-bg) !important;
-  border: 1px solid var(--color-border) !important;
-  border-radius: 0.5rem !important;
-  padding: 0.75rem 1rem !important;
-  font-size: 0.8125rem !important;
-  line-height: 1.45 !important;
-  overflow-x: auto !important;
-  margin: 0.75rem 0 !important;
+  background-color: var(--bd-bg-code);
+  border: 1px solid var(--bd-border);
+  border-radius: 0.5rem;
+  padding: 0.875rem 1rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  overflow-x: auto;
+  margin: 1rem 0;
 }
 
 .prose :where(code):not(:where(pre code, [class~="not-prose"],[class~="not-prose"] *)) {
-  background-color: var(--color-bg-tertiary) !important;
-  padding: 0.125rem 0.375rem !important;
-  border-radius: 0.25rem !important;
-  font-size: 0.85em !important;
-  font-weight: 500 !important;
-  border: 1px solid var(--color-border) !important;
+  background-color: var(--bd-bg-muted);
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-size: 0.85em;
+  font-weight: 500;
+  border: 1px solid var(--bd-border);
 }
 
 .prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *))::before,
 .prose :where(code):not(:where([class~="not-prose"],[class~="not-prose"] *))::after {
-  content: none !important;
+  content: none;
 }
 
-/* Lists - tighter spacing */
 .prose :where(ul, ol):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  margin-top: 0.375rem !important;
-  margin-bottom: 0.375rem !important;
-  padding-left: 1.25rem !important;
+  margin-top: 0.375rem;
+  margin-bottom: 0.375rem;
+  padding-left: 1.25rem;
 }
 
 .prose :where(li):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  margin-top: 0.125rem !important;
-  margin-bottom: 0.125rem !important;
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem;
 }
 
 .prose :where(li):not(:where([class~="not-prose"],[class~="not-prose"] *))::marker {
-  color: var(--color-text-muted) !important;
+  color: var(--bd-text-muted);
 }
 
-/* Blockquotes -  */
 .prose :where(blockquote):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  border-left: 3px solid var(--color-primary-500) !important;
-  background-color: var(--color-bg-secondary) !important;
-  padding: 0.5rem 0.75rem !important;
-  margin: 0.625rem 0 !important;
-  border-radius: 0 0.5rem 0.5rem 0 !important;
-  font-style: normal !important;
+  border-left: 3px solid var(--color-primary-500);
+  background-color: var(--bd-bg-subtle);
+  padding: 0.5rem 0.75rem;
+  margin: 0.625rem 0;
+  border-radius: 0 0.5rem 0.5rem 0;
+  font-style: normal;
 }
 
 .prose :where(blockquote p):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  margin: 0 !important;
+  margin: 0;
 }
 
-/* Tables - cleaner look */
 .prose :where(table):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  width: 100% !important;
-  border-collapse: collapse !important;
-  margin: 0.625rem 0 !important;
-  font-size: 0.8125rem !important;
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+  font-size: 0.8125rem;
+  border: 1px solid var(--bd-border);
 }
 
 .prose :where(th):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  background-color: var(--color-bg-secondary) !important;
-  font-weight: 600 !important;
-  text-align: left !important;
-  padding: 0.5rem 0.75rem !important;
-  border-bottom: 2px solid var(--color-border) !important;
+  background-color: var(--bd-bg-subtle);
+  font-weight: 600;
+  text-align: left;
+  padding: 0.625rem 1rem;
+  border-bottom: 1px solid var(--bd-border);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--bd-text-secondary);
 }
 
 .prose :where(td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  padding: 0.5rem 0.75rem !important;
-  border-bottom: 1px solid var(--color-border) !important;
+  padding: 0.625rem 1rem;
+  border-bottom: 1px solid var(--bd-border-subtle);
 }
 
 .prose :where(tr:last-child td):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  border-bottom: none !important;
+  border-bottom: none;
 }
 
-/* Horizontal rule */
+.prose :where(tbody tr):not(:where([class~="not-prose"],[class~="not-prose"] *)):hover {
+  background-color: var(--bd-bg-subtle);
+}
+
 .prose :where(hr):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  border: none !important;
-  border-top: 1px solid var(--color-border) !important;
-  margin: 1.5rem 0 !important;
+  border: none;
+  border-top: 1px solid var(--bd-border);
+  margin: 1.5rem 0;
 }
 
-/* Images */
 .prose :where(img):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
-  border-radius: 0.5rem !important;
-  border: 1px solid var(--color-border) !important;
+  border-radius: 0.5rem;
+  border: 1px solid var(--bd-border);
 }
 
-/* Shiki dual theme support */
+/* ==========================================================================
+   Heading anchors
+   ========================================================================== */
+
+.prose :where(h2, h3, h4)[id] {
+  scroll-margin-top: 5rem;
+}
+
+.prose :where(h2, h3, h4)[id] > a.heading-anchor {
+  color: var(--color-primary-400);
+  opacity: 0;
+  margin-left: 0.25em;
+  font-weight: 400;
+  text-decoration: none !important;
+  transition: opacity 150ms ease;
+}
+
+.prose :where(h2, h3, h4)[id]:hover > a.heading-anchor {
+  opacity: 0.7;
+}
+
+.prose :where(h2, h3, h4)[id] > a.heading-anchor:hover {
+  opacity: 1;
+}
+
+/* ==========================================================================
+   List bullet accent
+   ========================================================================== */
+
+.prose :where(ul > li):not(:where([class~="not-prose"],[class~="not-prose"] *))::marker {
+  color: var(--color-primary-400);
+}
+
+/* ==========================================================================
+   Shiki code highlighting
+   ========================================================================== */
+
 .astro-code {
-  background-color: var(--color-bg) !important;
+  background-color: var(--bd-bg-code) !important;
   border-radius: 0.5rem;
-  line-height: 1.45;
+  line-height: 1.5;
 }
 
 .astro-code code {
   display: flex;
   flex-direction: column;
+  font-size: 0.8125rem;
 }
 
-/* Tighter line spacing: Shiki outputs each line as span.line */
 .astro-code span.line {
   display: block;
-  line-height: 1.45;
+  line-height: 1.6;
   margin: 0;
   padding: 0;
 }
@@ -263,7 +371,6 @@
   background-color: var(--shiki-dark-bg) !important;
 }
 
-/* Line numbers: applied when barodoc.config.json has "lineNumbers": true */
 .astro-code.line-numbers {
   counter-reset: line;
 }
@@ -280,22 +387,28 @@
   margin-right: 1rem;
   padding-right: 0.5rem;
   text-align: right;
-  color: var(--color-text-muted);
+  color: var(--bd-text-muted);
   user-select: none;
-  border-right: 1px solid var(--color-border);
+  border-right: 1px solid var(--bd-border);
 }
 
-/* Pagefind search styling */
+/* ==========================================================================
+   Pagefind search
+   ========================================================================== */
+
 .pagefind-ui {
   --pagefind-ui-scale: 1;
   --pagefind-ui-primary: var(--color-primary-600);
-  --pagefind-ui-text: var(--color-text);
-  --pagefind-ui-background: var(--color-bg);
-  --pagefind-ui-border: var(--color-border);
-  --pagefind-ui-tag: var(--color-bg-secondary);
+  --pagefind-ui-text: var(--bd-text);
+  --pagefind-ui-background: var(--bd-bg);
+  --pagefind-ui-border: var(--bd-border);
+  --pagefind-ui-tag: var(--bd-bg-subtle);
 }
 
-/* Scrollbar styling */
+/* ==========================================================================
+   Scrollbar
+   ========================================================================== */
+
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
@@ -306,15 +419,40 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--color-border);
+  background: var(--bd-border);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--color-text-muted);
+  background: var(--bd-text-muted);
 }
 
-/* Selection styling */
+.sidebar-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.sidebar-scroll:hover {
+  scrollbar-color: var(--bd-border) transparent;
+}
+
+.sidebar-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.sidebar-scroll::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 3px;
+}
+
+.sidebar-scroll:hover::-webkit-scrollbar-thumb {
+  background: var(--bd-border);
+}
+
+/* ==========================================================================
+   Selection
+   ========================================================================== */
+
 ::selection {
   background-color: var(--color-primary-200);
   color: var(--color-primary-900);
@@ -325,41 +463,28 @@
   color: var(--color-primary-100);
 }
 
-/* Animations for shadcn/ui components */
+/* ==========================================================================
+   Animations (Radix UI)
+   ========================================================================== */
+
 @keyframes accordion-down {
-  from {
-    height: 0;
-  }
-  to {
-    height: var(--radix-accordion-content-height);
-  }
+  from { height: 0; }
+  to { height: var(--radix-accordion-content-height); }
 }
 
 @keyframes accordion-up {
-  from {
-    height: var(--radix-accordion-content-height);
-  }
-  to {
-    height: 0;
-  }
+  from { height: var(--radix-accordion-content-height); }
+  to { height: 0; }
 }
 
 @keyframes collapsible-down {
-  from {
-    height: 0;
-  }
-  to {
-    height: var(--radix-collapsible-content-height);
-  }
+  from { height: 0; }
+  to { height: var(--radix-collapsible-content-height); }
 }
 
 @keyframes collapsible-up {
-  from {
-    height: var(--radix-collapsible-content-height);
-  }
-  to {
-    height: 0;
-  }
+  from { height: var(--radix-collapsible-content-height); }
+  to { height: 0; }
 }
 
 .animate-accordion-down {
@@ -376,4 +501,186 @@
 
 .animate-collapsible-up {
   animation: collapsible-up 0.2s ease-out;
+}
+
+/* ==========================================================================
+   Steps component
+   ========================================================================== */
+
+.bd-steps {
+  counter-reset: bd-step;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin: 1.5rem 0;
+}
+
+.bd-step {
+  display: grid;
+  grid-template-columns: 2rem 1fr;
+  gap: 0 0.875rem;
+  counter-increment: bd-step;
+  min-height: 0;
+}
+
+.bd-step-indicator {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  grid-row: 1 / -1;
+}
+
+.bd-step-number {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  background-color: var(--color-primary-500);
+  color: #fff;
+}
+
+.bd-step-number::before {
+  content: counter(bd-step);
+}
+
+.dark .bd-step-number {
+  background-color: var(--color-primary-400);
+  color: var(--color-primary-950);
+}
+
+.bd-step-connector {
+  flex: 1;
+  width: 2px;
+  background-color: var(--bd-border);
+  margin: 0.375rem 0 0;
+  min-height: 0.75rem;
+}
+
+.bd-step:last-child .bd-step-connector {
+  display: none;
+}
+
+.bd-step-content {
+  padding-bottom: 1.75rem;
+}
+
+.bd-step:last-child .bd-step-content {
+  padding-bottom: 0;
+}
+
+.bd-step-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--bd-text);
+  line-height: 2rem;
+  margin: 0;
+}
+
+.bd-step-body {
+  margin-top: 0.375rem;
+  font-size: 0.875rem;
+  color: var(--bd-text-secondary);
+}
+
+.bd-step-body > p {
+  margin: 0;
+}
+
+.bd-step-body > p + p {
+  margin-top: 0.5rem;
+}
+
+.bd-step-body .code-block-wrapper {
+  margin-top: 0.5rem;
+}
+
+/* ==========================================================================
+   Tooltip component
+   ========================================================================== */
+
+.bd-tooltip-trigger {
+  cursor: help;
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: var(--color-primary-400);
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1.5px;
+  color: var(--bd-text);
+  border-radius: 2px;
+  transition: background-color 150ms ease, text-decoration-color 150ms ease;
+}
+
+.bd-tooltip-trigger:hover {
+  background-color: color-mix(in srgb, var(--color-primary-400) 12%, transparent);
+  text-decoration-color: var(--color-primary-500);
+}
+
+.dark .bd-tooltip-trigger:hover {
+  background-color: color-mix(in srgb, var(--color-primary-400) 15%, transparent);
+}
+
+.bd-tooltip-content {
+  z-index: 9999;
+  max-width: 20rem;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  font-weight: 450;
+  letter-spacing: -0.01em;
+  background-color: var(--bd-gray-900);
+  color: var(--bd-gray-100);
+  box-shadow:
+    0 4px 16px -2px rgba(0, 0, 0, 0.2),
+    0 0 0 1px rgba(0, 0, 0, 0.06);
+  animation: tooltip-in 150ms cubic-bezier(0.16, 1, 0.3, 1);
+  transform-origin: var(--radix-tooltip-content-transform-origin);
+}
+
+.dark .bd-tooltip-content {
+  background-color: var(--bd-gray-100);
+  color: var(--bd-gray-900);
+  box-shadow:
+    0 4px 20px -2px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.bd-tooltip-content[data-state="closed"] {
+  animation: tooltip-out 100ms ease-in;
+}
+
+.bd-tooltip-arrow {
+  fill: var(--bd-gray-900);
+}
+
+.dark .bd-tooltip-arrow {
+  fill: var(--bd-gray-100);
+}
+
+@keyframes tooltip-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes tooltip-out {
+  from {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.96) translateY(2px);
+  }
 }


### PR DESCRIPTION
## Summary

- Replace hardcoded Tailwind classes with CSS custom properties (`--bd-*`) across all theme-docs components
- Introduce OKLCH-based `accent`/`gray` color palette generation in `@barodoc/core`, replacing single `primary` color
- Fix CodeGroup duplicate tabs, Mermaid dayjs CJS/ESM interop, Steps numbering (CSS counters), and Tooltip transparent background (`--gray-*` → `--bd-gray-*`)

Closes #53

## Test plan

- [ ] Verify accent color palette generates correctly from a custom hex value
- [ ] Verify gray presets (`zinc`, `slate`, `neutral`, `stone`, `gray`) apply correctly
- [ ] Verify CodeGroup tabs render without duplication on page navigation
- [ ] Verify Mermaid diagrams render without `dayjs` export error
- [ ] Verify Steps component shows sequential numbering (1, 2, 3…) with aligned connector lines
- [ ] Verify Tooltip displays with opaque background above other content
- [ ] Test light/dark mode toggle across all components

Made with [Cursor](https://cursor.com)