### PR TITLE
feat: feature expansion — blog, changelog, versioning, OpenAPI, API playground, and 7 more

### DIFF
--- a/.changeset/feature-expansion.md
+++ b/.changeset/feature-expansion.md
@@ -1,0 +1,28 @@
+---
+"@barodoc/core": minor
+"@barodoc/theme-docs": minor
+---
+
+Add 12 new features across 4 phases
+
+**Phase 1: Quick Wins**
+- Image zoom/lightbox with medium-zoom (auto-applied to all prose images)
+- Video embed component (YouTube, Vimeo, Loom auto-detect)
+- Math/KaTeX support via remark-math + rehype-katex ($inline$ and $$block$$)
+- Reading time display on docs pages
+- Keyboard shortcuts (Cmd/Ctrl+K search, arrow keys navigation, ? help modal)
+
+**Phase 2: Content Types**
+- Blog system with content collection, card grid index, and dedicated BlogLayout
+- Changelog page with timeline UI and version badge grouping
+
+**Phase 3: Plugins**
+- @barodoc/plugin-docsearch: Algolia DocSearch integration
+- @barodoc/plugin-rss: RSS feed generation from blog/changelog collections
+- @barodoc/plugin-pwa: PWA manifest and service worker for offline support
+- Page contributors component using git log with Gravatar avatars
+
+**Phase 4: Major Features**
+- Doc versioning with folder-based version management and VersionSwitcher dropdown
+- @barodoc/plugin-openapi: OpenAPI spec auto-generation into MDX pages
+- API Playground component for interactive API testing with form builder

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -14,6 +14,30 @@ const docsCollection = defineCollection({
   }),
 });
 
+const blogCollection = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    excerpt: z.string().optional(),
+    date: z.coerce.date().optional(),
+    author: z.string().optional(),
+    image: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+  }),
+});
+
+const changelogCollection = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string().optional(),
+    version: z.string(),
+    date: z.coerce.date(),
+  }),
+});
+
 export const collections = {
   docs: docsCollection,
+  blog: blogCollection,
+  changelog: changelogCollection,
 };

--- a/packages/barodoc/src/runtime/project.ts
+++ b/packages/barodoc/src/runtime/project.ts
@@ -272,8 +272,32 @@ const docsCollection = defineCollection({
   }),
 });
 
+const blogCollection = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    excerpt: z.string().optional(),
+    date: z.coerce.date().optional(),
+    author: z.string().optional(),
+    image: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+  }),
+});
+
+const changelogCollection = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string().optional(),
+    version: z.string(),
+    date: z.coerce.date(),
+  }),
+});
+
 export const collections = {
   docs: docsCollection,
+  blog: blogCollection,
+  changelog: changelogCollection,
 };
 `;
 }

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -87,6 +87,17 @@ export const pluginConfigSchema = z.union([
   z.tuple([z.string(), z.record(z.unknown())]),
 ]);
 
+export const blogConfigSchema = z.object({
+  enabled: z.boolean().optional(),
+}).optional();
+
+export const versionConfigSchema = z.object({
+  label: z.string(),
+  path: z.string(),
+}).strict();
+
+export const versionsSchema = z.array(versionConfigSchema).optional();
+
 export const barodocConfigSchema = z.object({
   name: z.string(),
   logo: z.string().optional(),
@@ -103,6 +114,8 @@ export const barodocConfigSchema = z.object({
   lastUpdated: z.boolean().optional(),
   announcement: announcementSchema,
   feedback: feedbackSchema,
+  blog: blogConfigSchema,
+  versions: versionsSchema,
   plugins: z.array(pluginConfigSchema).optional(),
   customCss: z.array(z.string()).optional(),
 });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -83,6 +83,15 @@ export interface BarodocConfig {
     endpoint?: string;
   };
   
+  blog?: {
+    enabled?: boolean;
+  };
+
+  versions?: {
+    label: string;
+    path: string;
+  }[];
+  
   plugins?: PluginConfig[];
   
   customCss?: string[];

--- a/packages/plugin-docsearch/package.json
+++ b/packages/plugin-docsearch/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@barodoc/plugin-docsearch",
+  "version": "5.0.0",
+  "description": "Algolia DocSearch plugin for Barodoc",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean",
+    "dev": "tsup src/index.ts --format esm --dts --watch"
+  },
+  "peerDependencies": {
+    "@barodoc/core": "workspace:*",
+    "astro": "^5.0.0"
+  },
+  "devDependencies": {
+    "@barodoc/core": "workspace:*",
+    "@types/node": "^22.0.0",
+    "astro": "^5.0.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT"
+}

--- a/packages/plugin-docsearch/src/index.ts
+++ b/packages/plugin-docsearch/src/index.ts
@@ -1,0 +1,64 @@
+import type { AstroIntegration } from "astro";
+import { definePlugin } from "@barodoc/core";
+
+export interface DocSearchPluginOptions {
+  appId: string;
+  apiKey: string;
+  indexName: string;
+  container?: string;
+  placeholder?: string;
+}
+
+export default definePlugin<DocSearchPluginOptions>((options) => {
+  return {
+    name: "@barodoc/plugin-docsearch",
+    hooks: {
+      "config:loaded": (config) => {
+        return {
+          ...config,
+          search: { ...config.search, enabled: false },
+        };
+      },
+    },
+    astroIntegration: () => {
+      const integration: AstroIntegration = {
+        name: "@barodoc/plugin-docsearch",
+        hooks: {
+          "astro:config:setup": ({ injectScript }) => {
+            const cssUrl = "https://cdn.jsdelivr.net/npm/@docsearch/css@3/dist/style.min.css";
+            const jsUrl = "https://cdn.jsdelivr.net/npm/@docsearch/js@3";
+
+            injectScript(
+              "head-inline",
+              `document.head.insertAdjacentHTML('beforeend', '<link rel="stylesheet" href="${cssUrl}" />');`
+            );
+
+            injectScript(
+              "page",
+              `
+import docsearch from "${jsUrl}";
+
+function initDocSearch() {
+  const container = document.querySelector('${options.container || "#docsearch"}');
+  if (!container || container.hasChildNodes()) return;
+  docsearch({
+    appId: "${options.appId}",
+    apiKey: "${options.apiKey}",
+    indexName: "${options.indexName}",
+    container: "${options.container || "#docsearch"}",
+    placeholder: "${options.placeholder || "Search docs..."}",
+  });
+}
+
+if (document.readyState === "complete") initDocSearch();
+else document.addEventListener("DOMContentLoaded", initDocSearch);
+document.addEventListener("astro:page-load", initDocSearch);
+`
+            );
+          },
+        },
+      };
+      return integration;
+    },
+  };
+});

--- a/packages/plugin-docsearch/tsconfig.json
+++ b/packages/plugin-docsearch/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-openapi/package.json
+++ b/packages/plugin-openapi/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@barodoc/plugin-openapi",
+  "version": "5.0.0",
+  "description": "OpenAPI/Swagger auto-generation plugin for Barodoc",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean",
+    "dev": "tsup src/index.ts --format esm --dts --watch"
+  },
+  "dependencies": {
+    "yaml": "^2.7.0"
+  },
+  "peerDependencies": {
+    "@barodoc/core": "workspace:*",
+    "astro": "^5.0.0"
+  },
+  "devDependencies": {
+    "@barodoc/core": "workspace:*",
+    "@types/node": "^22.0.0",
+    "astro": "^5.0.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT"
+}

--- a/packages/plugin-openapi/src/index.ts
+++ b/packages/plugin-openapi/src/index.ts
@@ -1,0 +1,217 @@
+import type { AstroIntegration } from "astro";
+import { definePlugin } from "@barodoc/core";
+import fs from "node:fs";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+
+export interface OpenApiPluginOptions {
+  specFile: string;
+  basePath?: string;
+  groupBy?: "tags" | "paths";
+}
+
+interface OpenApiSpec {
+  openapi?: string;
+  info?: { title?: string; version?: string; description?: string };
+  paths?: Record<string, Record<string, OpenApiOperation>>;
+  components?: { schemas?: Record<string, unknown> };
+}
+
+interface OpenApiOperation {
+  summary?: string;
+  description?: string;
+  operationId?: string;
+  tags?: string[];
+  parameters?: OpenApiParameter[];
+  requestBody?: {
+    required?: boolean;
+    content?: Record<string, { schema?: OpenApiSchema }>;
+  };
+  responses?: Record<string, {
+    description?: string;
+    content?: Record<string, { schema?: OpenApiSchema }>;
+  }>;
+}
+
+interface OpenApiParameter {
+  name: string;
+  in: "query" | "path" | "header" | "cookie";
+  description?: string;
+  required?: boolean;
+  schema?: OpenApiSchema;
+}
+
+interface OpenApiSchema {
+  type?: string;
+  format?: string;
+  items?: OpenApiSchema;
+  properties?: Record<string, OpenApiSchema>;
+  required?: string[];
+  description?: string;
+  enum?: string[];
+  $ref?: string;
+}
+
+function resolveRef(ref: string, spec: OpenApiSpec): OpenApiSchema {
+  const parts = ref.replace("#/", "").split("/");
+  let current: unknown = spec;
+  for (const part of parts) {
+    current = (current as Record<string, unknown>)?.[part];
+  }
+  return (current as OpenApiSchema) || {};
+}
+
+function schemaToType(schema: OpenApiSchema | undefined, spec: OpenApiSpec): string {
+  if (!schema) return "any";
+  if (schema.$ref) return schemaToType(resolveRef(schema.$ref, spec), spec);
+  if (schema.enum) return schema.enum.map((e) => `"${e}"`).join(" | ");
+  if (schema.type === "array") return `${schemaToType(schema.items, spec)}[]`;
+  if (schema.type === "object" && schema.properties) return "object";
+  return schema.type || "any";
+}
+
+function generateMdxForOperation(
+  httpMethod: string,
+  urlPath: string,
+  op: OpenApiOperation,
+  spec: OpenApiSpec
+): string {
+  const lines: string[] = [];
+  const method = httpMethod.toUpperCase();
+
+  lines.push(`### ${method} ${urlPath}\n`);
+  if (op.summary) lines.push(`${op.summary}\n`);
+  if (op.description) lines.push(`${op.description}\n`);
+
+  // Parameters
+  const params = op.parameters || [];
+  if (params.length > 0) {
+    lines.push(`#### Parameters\n`);
+    lines.push(`| Name | In | Type | Required | Description |`);
+    lines.push(`| --- | --- | --- | --- | --- |`);
+    for (const p of params) {
+      const type = schemaToType(p.schema, spec);
+      lines.push(`| \`${p.name}\` | ${p.in} | \`${type}\` | ${p.required ? "Yes" : "No"} | ${p.description || ""} |`);
+    }
+    lines.push("");
+  }
+
+  // Request body
+  if (op.requestBody) {
+    lines.push(`#### Request Body\n`);
+    const content = op.requestBody.content;
+    if (content) {
+      for (const [mediaType, mediaObj] of Object.entries(content)) {
+        lines.push(`**Content-Type**: \`${mediaType}\`\n`);
+        if (mediaObj.schema) {
+          const resolved = mediaObj.schema.$ref
+            ? resolveRef(mediaObj.schema.$ref, spec)
+            : mediaObj.schema;
+          if (resolved.properties) {
+            lines.push(`| Property | Type | Required | Description |`);
+            lines.push(`| --- | --- | --- | --- |`);
+            for (const [name, prop] of Object.entries(resolved.properties)) {
+              const req = resolved.required?.includes(name) ? "Yes" : "No";
+              lines.push(`| \`${name}\` | \`${schemaToType(prop, spec)}\` | ${req} | ${prop.description || ""} |`);
+            }
+            lines.push("");
+          }
+        }
+      }
+    }
+  }
+
+  // Responses
+  if (op.responses) {
+    lines.push(`#### Responses\n`);
+    for (const [status, resp] of Object.entries(op.responses)) {
+      lines.push(`**${status}**: ${resp.description || ""}\n`);
+    }
+  }
+
+  lines.push("---\n");
+  return lines.join("\n");
+}
+
+export default definePlugin<OpenApiPluginOptions>((options) => {
+  const { specFile, basePath = "/api", groupBy = "tags" } = options;
+
+  return {
+    name: "@barodoc/plugin-openapi",
+    astroIntegration: (context) => {
+      const integration: AstroIntegration = {
+        name: "@barodoc/plugin-openapi",
+        hooks: {
+          "astro:config:setup": ({ injectRoute, config: astroConfig }) => {
+            const root = astroConfig.root.pathname;
+            const specPath = path.resolve(root, specFile);
+
+            if (!fs.existsSync(specPath)) {
+              console.warn(`[plugin-openapi] Spec file not found: ${specPath}`);
+              return;
+            }
+
+            const raw = fs.readFileSync(specPath, "utf-8");
+            const spec: OpenApiSpec = specPath.endsWith(".yaml") || specPath.endsWith(".yml")
+              ? parseYaml(raw)
+              : JSON.parse(raw);
+
+            if (!spec.paths) return;
+
+            // Generate a single MDX page with all endpoints
+            const pagesDir = path.join(root, "src/content/docs");
+            const apiDir = path.join(pagesDir, basePath.replace(/^\//, ""));
+            fs.mkdirSync(apiDir, { recursive: true });
+
+            if (groupBy === "tags") {
+              const tagMap = new Map<string, string[]>();
+
+              for (const [urlPath, methods] of Object.entries(spec.paths)) {
+                for (const [method, op] of Object.entries(methods)) {
+                  const tags = op.tags?.length ? op.tags : ["default"];
+                  const mdx = generateMdxForOperation(method, urlPath, op, spec);
+                  for (const tag of tags) {
+                    if (!tagMap.has(tag)) tagMap.set(tag, []);
+                    tagMap.get(tag)!.push(mdx);
+                  }
+                }
+              }
+
+              for (const [tag, operations] of tagMap) {
+                const slug = tag.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+                const content = [
+                  "---",
+                  `title: "${tag}"`,
+                  `description: "API endpoints for ${tag}"`,
+                  "api_reference: true",
+                  "---",
+                  "",
+                  ...operations,
+                ].join("\n");
+                fs.writeFileSync(path.join(apiDir, `${slug}.mdx`), content);
+              }
+            } else {
+              const allOps: string[] = [];
+              for (const [urlPath, methods] of Object.entries(spec.paths)) {
+                for (const [method, op] of Object.entries(methods)) {
+                  allOps.push(generateMdxForOperation(method, urlPath, op, spec));
+                }
+              }
+              const content = [
+                "---",
+                `title: "API Reference"`,
+                `description: "Auto-generated from OpenAPI spec"`,
+                "api_reference: true",
+                "---",
+                "",
+                ...allOps,
+              ].join("\n");
+              fs.writeFileSync(path.join(apiDir, "index.mdx"), content);
+            }
+          },
+        },
+      };
+      return integration;
+    },
+  };
+});

--- a/packages/plugin-openapi/tsconfig.json
+++ b/packages/plugin-openapi/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-pwa/package.json
+++ b/packages/plugin-pwa/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@barodoc/plugin-pwa",
+  "version": "5.0.0",
+  "description": "PWA and offline support plugin for Barodoc",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean",
+    "dev": "tsup src/index.ts --format esm --dts --watch"
+  },
+  "peerDependencies": {
+    "@barodoc/core": "workspace:*",
+    "astro": "^5.0.0"
+  },
+  "devDependencies": {
+    "@barodoc/core": "workspace:*",
+    "@types/node": "^22.0.0",
+    "astro": "^5.0.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT"
+}

--- a/packages/plugin-pwa/src/index.ts
+++ b/packages/plugin-pwa/src/index.ts
@@ -1,0 +1,105 @@
+import type { AstroIntegration } from "astro";
+import { definePlugin } from "@barodoc/core";
+import fs from "node:fs";
+import path from "node:path";
+
+export interface PwaPluginOptions {
+  name?: string;
+  shortName?: string;
+  themeColor?: string;
+  backgroundColor?: string;
+  display?: "standalone" | "fullscreen" | "minimal-ui" | "browser";
+  offlineFallback?: string;
+}
+
+export default definePlugin<PwaPluginOptions>((options = {}) => {
+  const {
+    display = "standalone",
+    themeColor = "#2563eb",
+    backgroundColor = "#ffffff",
+    offlineFallback = "/404",
+  } = options;
+
+  return {
+    name: "@barodoc/plugin-pwa",
+    astroIntegration: (context) => {
+      const siteName = options.name || context.config.name;
+      const shortName = options.shortName || siteName;
+
+      const integration: AstroIntegration = {
+        name: "@barodoc/plugin-pwa",
+        hooks: {
+          "astro:config:setup": ({ injectScript }) => {
+            injectScript(
+              "head-inline",
+              `document.head.insertAdjacentHTML('beforeend', '<link rel="manifest" href="/manifest.json" />');`
+            );
+
+            injectScript(
+              "page",
+              `
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register("/sw.js").catch(() => {});
+}
+`
+            );
+          },
+
+          "astro:build:done": async ({ dir }) => {
+            const outDir = dir.pathname;
+
+            const manifest = {
+              name: siteName,
+              short_name: shortName,
+              start_url: "/",
+              display,
+              theme_color: themeColor,
+              background_color: backgroundColor,
+              icons: [
+                { src: "/favicon.ico", sizes: "64x64", type: "image/x-icon" },
+              ],
+            };
+
+            fs.writeFileSync(
+              path.join(outDir, "manifest.json"),
+              JSON.stringify(manifest, null, 2)
+            );
+
+            const sw = `
+const CACHE_NAME = "barodoc-v1";
+const OFFLINE_URL = "${offlineFallback}";
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.add(OFFLINE_URL))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  if (event.request.mode !== "navigate") return;
+  event.respondWith(
+    fetch(event.request).catch(() =>
+      caches.match(OFFLINE_URL).then((r) => r || new Response("Offline", { status: 503 }))
+    )
+  );
+});
+`;
+
+            fs.writeFileSync(path.join(outDir, "sw.js"), sw.trim());
+          },
+        },
+      };
+      return integration;
+    },
+  };
+});

--- a/packages/plugin-pwa/tsconfig.json
+++ b/packages/plugin-pwa/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@barodoc/plugin-rss",
+  "version": "5.0.0",
+  "description": "RSS feed plugin for Barodoc",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean",
+    "dev": "tsup src/index.ts --format esm --dts --watch"
+  },
+  "dependencies": {
+    "@astrojs/rss": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@barodoc/core": "workspace:*",
+    "astro": "^5.0.0"
+  },
+  "devDependencies": {
+    "@barodoc/core": "workspace:*",
+    "@types/node": "^22.0.0",
+    "astro": "^5.0.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT"
+}

--- a/packages/plugin-rss/src/feed.ts
+++ b/packages/plugin-rss/src/feed.ts
@@ -1,0 +1,50 @@
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+
+export async function GET(context: APIContext) {
+  const site = context.site ?? new URL("https://localhost");
+
+  let items: { title: string; pubDate: Date; link: string; description?: string }[] = [];
+
+  try {
+    const { getCollection } = await import("astro:content");
+    
+    try {
+      const blogs = await getCollection("blog");
+      for (const post of blogs) {
+        items.push({
+          title: post.data.title,
+          pubDate: post.data.date ? new Date(post.data.date) : new Date(),
+          link: `/blog/${post.slug}`,
+          description: post.data.description || post.data.excerpt || "",
+        });
+      }
+    } catch {
+      // blog collection doesn't exist
+    }
+
+    try {
+      const changelogs = await getCollection("changelog");
+      for (const entry of changelogs) {
+        items.push({
+          title: `${entry.data.version}${entry.data.title ? ` - ${entry.data.title}` : ""}`,
+          pubDate: new Date(entry.data.date),
+          link: `/changelog#${entry.data.version}`,
+        });
+      }
+    } catch {
+      // changelog collection doesn't exist
+    }
+  } catch {
+    // no collections available
+  }
+
+  items.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
+
+  return rss({
+    title: "Barodoc",
+    description: "Latest updates",
+    site: site.toString(),
+    items,
+  });
+}

--- a/packages/plugin-rss/src/index.ts
+++ b/packages/plugin-rss/src/index.ts
@@ -1,0 +1,44 @@
+import type { AstroIntegration } from "astro";
+import { definePlugin } from "@barodoc/core";
+
+export interface RssPluginOptions {
+  title?: string;
+  description?: string;
+  collections?: ("blog" | "changelog")[];
+}
+
+export default definePlugin<RssPluginOptions>((options = {}) => {
+  const {
+    title,
+    description = "Latest updates",
+    collections = ["blog"],
+  } = options;
+
+  return {
+    name: "@barodoc/plugin-rss",
+    astroIntegration: (context) => {
+      const feedTitle = title || context.config.name;
+
+      const integration: AstroIntegration = {
+        name: "@barodoc/plugin-rss",
+        hooks: {
+          "astro:config:setup": ({ injectRoute }) => {
+            injectRoute({
+              pattern: "/rss.xml",
+              entrypoint: "@barodoc/plugin-rss/feed-endpoint",
+            });
+          },
+        },
+      };
+      return integration;
+    },
+    hooks: {
+      "config:loaded": (config) => {
+        return {
+          ...config,
+          _rss: { title: title || config.name, description, collections },
+        } as typeof config;
+      },
+    },
+  };
+});

--- a/packages/plugin-rss/tsconfig.json
+++ b/packages/plugin-rss/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/theme-docs/package.json
+++ b/packages/theme-docs/package.json
@@ -32,7 +32,11 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.563.0",
+    "medium-zoom": "^1.1.0",
     "mermaid": "^11.12.2",
+    "reading-time": "^1.5.0",
+    "rehype-katex": "^7.0.1",
+    "remark-math": "^6.0.0",
     "tailwind-merge": "^3.4.0"
   },
   "peerDependencies": {

--- a/packages/theme-docs/src/components/Contributors.astro
+++ b/packages/theme-docs/src/components/Contributors.astro
@@ -1,0 +1,71 @@
+---
+import { execSync } from "node:child_process";
+
+interface Props {
+  filePath?: string;
+}
+
+interface Contributor {
+  name: string;
+  email: string;
+  avatarUrl: string;
+}
+
+const { filePath } = Astro.props;
+
+let contributors: Contributor[] = [];
+
+if (filePath) {
+  try {
+    const raw = execSync(
+      `git log --format='%aN|%aE' -- "${filePath}"`,
+      { encoding: "utf-8", timeout: 5000 }
+    ).trim();
+
+    if (raw) {
+      const seen = new Map<string, Contributor>();
+      for (const line of raw.split("\n")) {
+        const [name, email] = line.split("|");
+        if (!name || seen.has(email)) continue;
+        const hash = email.trim().toLowerCase();
+        seen.set(email, {
+          name: name.trim(),
+          email: email.trim(),
+          avatarUrl: `https://gravatar.com/avatar/${await computeHash(hash)}?s=64&d=mp`,
+        });
+      }
+      contributors = Array.from(seen.values());
+    }
+  } catch {
+    // git not available or file not tracked
+  }
+}
+
+async function computeHash(input: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(input);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+---
+
+{contributors.length > 0 && (
+  <div class="bd-contributors">
+    <span class="bd-contributors-label">Contributors</span>
+    <div class="bd-contributors-avatars">
+      {contributors.map((c) => (
+        <img
+          src={c.avatarUrl}
+          alt={c.name}
+          title={c.name}
+          class="bd-contributor-avatar"
+          loading="lazy"
+          width="28"
+          height="28"
+        />
+      ))}
+    </div>
+  </div>
+)}

--- a/packages/theme-docs/src/components/KeyboardShortcuts.astro
+++ b/packages/theme-docs/src/components/KeyboardShortcuts.astro
@@ -1,0 +1,108 @@
+---
+// Keyboard shortcuts: Cmd/Ctrl+K → search, ←/→ → prev/next, ? → help modal
+---
+
+<script>
+  function initKeyboardShortcuts() {
+    if (window.__bdShortcutsInit) return;
+    window.__bdShortcutsInit = true;
+
+    const isMac = navigator.platform.toUpperCase().includes('MAC');
+    const modLabel = isMac ? '⌘' : 'Ctrl';
+
+    function isInputFocused(): boolean {
+      const el = document.activeElement;
+      if (!el) return false;
+      const tag = el.tagName;
+      return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (el as HTMLElement).isContentEditable;
+    }
+
+    function showShortcutsModal() {
+      if (document.querySelector('.bd-shortcuts-overlay')) return;
+
+      const overlay = document.createElement('div');
+      overlay.className = 'bd-shortcuts-overlay';
+      overlay.addEventListener('click', (e) => {
+        if (e.target === overlay) overlay.remove();
+      });
+
+      overlay.innerHTML = `
+        <div class="bd-shortcuts-modal">
+          <h3>Keyboard Shortcuts</h3>
+          <div class="bd-shortcut-row">
+            <span class="bd-shortcut-desc">Search</span>
+            <span class="bd-shortcut-keys"><kbd class="bd-kbd">${modLabel}</kbd><kbd class="bd-kbd">K</kbd></span>
+          </div>
+          <div class="bd-shortcut-row">
+            <span class="bd-shortcut-desc">Previous page</span>
+            <span class="bd-shortcut-keys"><kbd class="bd-kbd">←</kbd></span>
+          </div>
+          <div class="bd-shortcut-row">
+            <span class="bd-shortcut-desc">Next page</span>
+            <span class="bd-shortcut-keys"><kbd class="bd-kbd">→</kbd></span>
+          </div>
+          <div class="bd-shortcut-row">
+            <span class="bd-shortcut-desc">Show shortcuts</span>
+            <span class="bd-shortcut-keys"><kbd class="bd-kbd">?</kbd></span>
+          </div>
+        </div>
+      `;
+
+      document.body.appendChild(overlay);
+    }
+
+    document.addEventListener('keydown', (e: KeyboardEvent) => {
+      // Close modal on Escape
+      if (e.key === 'Escape') {
+        const modal = document.querySelector('.bd-shortcuts-overlay');
+        if (modal) { modal.remove(); return; }
+      }
+
+      // Cmd/Ctrl+K → open search
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        const searchBtn = document.querySelector('[data-search-trigger]') as HTMLButtonElement;
+        if (searchBtn) searchBtn.click();
+        return;
+      }
+
+      if (isInputFocused()) return;
+
+      // ? → show shortcuts
+      if (e.key === '?' || (e.shiftKey && e.key === '/')) {
+        e.preventDefault();
+        showShortcutsModal();
+        return;
+      }
+
+      // ← → prev page
+      if (e.key === 'ArrowLeft' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const prev = document.querySelector('nav[aria-label="Page navigation"] a:first-of-type') as HTMLAnchorElement;
+        if (prev) { prev.click(); return; }
+      }
+
+      // → → next page
+      if (e.key === 'ArrowRight' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const links = document.querySelectorAll('nav[aria-label="Page navigation"] a');
+        const next = links[links.length - 1] as HTMLAnchorElement;
+        if (next && links.length > 1) { next.click(); return; }
+        if (next && links.length === 1) {
+          const parent = next.closest('.col-span-1');
+          if (parent && parent === parent.parentElement?.lastElementChild) { next.click(); }
+        }
+      }
+    });
+  }
+
+  initKeyboardShortcuts();
+  document.addEventListener('astro:page-load', () => {
+    window.__bdShortcutsInit = false;
+    initKeyboardShortcuts();
+  });
+
+  declare global {
+    interface Window {
+      __bdShortcutsInit?: boolean;
+    }
+  }
+</script>

--- a/packages/theme-docs/src/components/VersionSwitcher.tsx
+++ b/packages/theme-docs/src/components/VersionSwitcher.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+
+interface VersionConfig {
+  label: string;
+  path: string;
+}
+
+interface VersionSwitcherProps {
+  versions: VersionConfig[];
+  currentPath: string;
+}
+
+export function VersionSwitcher({ versions, currentPath }: VersionSwitcherProps) {
+  if (!versions || versions.length <= 1) return null;
+
+  const current = versions.find((v) => currentPath.includes(`/docs/${v.path}/`)) || versions[0];
+
+  function switchVersion(target: VersionConfig) {
+    const regex = /\/docs\/([^/]+)\//;
+    const match = currentPath.match(regex);
+    if (match) {
+      const newPath = currentPath.replace(`/docs/${match[1]}/`, `/docs/${target.path}/`);
+      window.location.href = newPath;
+    } else {
+      window.location.href = `/docs/${target.path}/`;
+    }
+  }
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button className="bd-version-trigger">
+          {current.label}
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="m6 9 6 6 6-6" />
+          </svg>
+        </button>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content className="bd-version-menu" sideOffset={4} align="start">
+          {versions.map((v) => (
+            <DropdownMenu.Item
+              key={v.path}
+              className={`bd-version-item ${v.path === current.path ? "bd-version-active" : ""}`}
+              onSelect={() => switchVersion(v)}
+            >
+              {v.label}
+              {v.path === current.path && (
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              )}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/packages/theme-docs/src/components/index.ts
+++ b/packages/theme-docs/src/components/index.ts
@@ -24,6 +24,11 @@ export { Expandable, ExpandableList, ExpandableItem } from "./mdx/Expandable.tsx
 export { Icon, CheckIcon, XIcon, InfoIcon, WarningIcon } from "./mdx/Icon.tsx";
 export { Steps, Step } from "./mdx/Steps.tsx";
 export { Mermaid } from "./mdx/Mermaid.tsx";
+export { ImageZoom } from "./mdx/ImageZoom.tsx";
+export { Video } from "./mdx/Video.tsx";
+export { ApiPlayground } from "./mdx/ApiPlayground.tsx";
+
+export { VersionSwitcher } from "./VersionSwitcher.tsx";
 
 // Legacy exports for backwards compatibility
 export { Tabs, Tab } from "./mdx/Tabs.tsx";

--- a/packages/theme-docs/src/components/mdx/ApiPlayground.tsx
+++ b/packages/theme-docs/src/components/mdx/ApiPlayground.tsx
@@ -1,0 +1,200 @@
+import * as React from "react";
+import { cn } from "../../lib/utils.js";
+
+interface ParamDef {
+  name: string;
+  in: "query" | "path" | "header" | "body";
+  type?: string;
+  required?: boolean;
+  defaultValue?: string;
+  description?: string;
+}
+
+interface ApiPlaygroundProps {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  url: string;
+  params?: ParamDef[];
+  body?: string;
+  headers?: Record<string, string>;
+  className?: string;
+}
+
+const methodColors: Record<string, string> = {
+  GET: "bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300",
+  POST: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+  PUT: "bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-300",
+  PATCH: "bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-300",
+  DELETE: "bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-300",
+};
+
+export function ApiPlayground({
+  method = "GET",
+  url,
+  params = [],
+  body: initialBody,
+  headers: initialHeaders = {},
+  className,
+}: ApiPlaygroundProps) {
+  const [paramValues, setParamValues] = React.useState<Record<string, string>>(() => {
+    const vals: Record<string, string> = {};
+    for (const p of params) {
+      vals[p.name] = p.defaultValue || "";
+    }
+    return vals;
+  });
+  const [bodyValue, setBodyValue] = React.useState(initialBody || "");
+  const [response, setResponse] = React.useState<{
+    status: number;
+    statusText: string;
+    body: string;
+    time: number;
+  } | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  function buildUrl(): string {
+    let finalUrl = url;
+    const queryParams = new URLSearchParams();
+
+    for (const p of params) {
+      const val = paramValues[p.name] || "";
+      if (p.in === "path") {
+        finalUrl = finalUrl.replace(`{${p.name}}`, encodeURIComponent(val));
+      } else if (p.in === "query" && val) {
+        queryParams.set(p.name, val);
+      }
+    }
+
+    const qs = queryParams.toString();
+    return qs ? `${finalUrl}?${qs}` : finalUrl;
+  }
+
+  async function sendRequest() {
+    setLoading(true);
+    setError(null);
+    setResponse(null);
+
+    const start = performance.now();
+    const reqUrl = buildUrl();
+
+    const headers: Record<string, string> = { ...initialHeaders };
+    for (const p of params) {
+      if (p.in === "header" && paramValues[p.name]) {
+        headers[p.name] = paramValues[p.name];
+      }
+    }
+
+    const hasBody = ["POST", "PUT", "PATCH"].includes(method) && bodyValue;
+    if (hasBody && !headers["Content-Type"]) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    try {
+      const res = await fetch(reqUrl, {
+        method,
+        headers,
+        body: hasBody ? bodyValue : undefined,
+      });
+
+      const elapsed = Math.round(performance.now() - start);
+      let text: string;
+      try {
+        const json = await res.json();
+        text = JSON.stringify(json, null, 2);
+      } catch {
+        text = await res.text();
+      }
+
+      setResponse({ status: res.status, statusText: res.statusText, body: text, time: elapsed });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className={cn("bd-playground", className)}>
+      {/* Header */}
+      <div className="bd-playground-header">
+        <span className={cn("bd-playground-method", methodColors[method])}>
+          {method}
+        </span>
+        <code className="bd-playground-url">{url}</code>
+        <button
+          className="bd-playground-send"
+          onClick={sendRequest}
+          disabled={loading}
+        >
+          {loading ? "Sending..." : "Send"}
+        </button>
+      </div>
+
+      {/* Parameters */}
+      {params.length > 0 && (
+        <div className="bd-playground-params">
+          {params.map((p) => (
+            <div key={p.name} className="bd-playground-param">
+              <label className="bd-playground-label">
+                <span>{p.name}</span>
+                <span className="bd-playground-param-meta">
+                  {p.in}
+                  {p.required && <span className="bd-playground-required">*</span>}
+                </span>
+              </label>
+              <input
+                type="text"
+                className="bd-playground-input"
+                value={paramValues[p.name] || ""}
+                placeholder={p.description || p.type || ""}
+                onChange={(e) =>
+                  setParamValues((prev) => ({ ...prev, [p.name]: e.target.value }))
+                }
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Body */}
+      {["POST", "PUT", "PATCH"].includes(method) && (
+        <div className="bd-playground-body-section">
+          <label className="bd-playground-label">Request Body</label>
+          <textarea
+            className="bd-playground-textarea"
+            value={bodyValue}
+            onChange={(e) => setBodyValue(e.target.value)}
+            rows={6}
+            placeholder='{ "key": "value" }'
+          />
+        </div>
+      )}
+
+      {/* Response */}
+      {(response || error) && (
+        <div className="bd-playground-response">
+          {error ? (
+            <div className="bd-playground-error">{error}</div>
+          ) : response ? (
+            <>
+              <div className="bd-playground-response-header">
+                <span
+                  className={cn(
+                    "bd-playground-status",
+                    response.status < 300 ? "bd-status-ok" : "bd-status-err"
+                  )}
+                >
+                  {response.status} {response.statusText}
+                </span>
+                <span className="bd-playground-time">{response.time}ms</span>
+              </div>
+              <pre className="bd-playground-pre">
+                <code>{response.body}</code>
+              </pre>
+            </>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/theme-docs/src/components/mdx/ImageZoom.tsx
+++ b/packages/theme-docs/src/components/mdx/ImageZoom.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import mediumZoom from "medium-zoom";
+import type { Zoom } from "medium-zoom";
+
+interface ImageZoomProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+  zoomSrc?: string;
+}
+
+export function ImageZoom({ zoomSrc, ...props }: ImageZoomProps) {
+  const imgRef = React.useRef<HTMLImageElement>(null);
+  const zoomRef = React.useRef<Zoom | null>(null);
+
+  React.useEffect(() => {
+    if (!imgRef.current) return;
+
+    zoomRef.current = mediumZoom(imgRef.current, {
+      margin: 24,
+      background: "var(--bd-bg)",
+      scrollOffset: 0,
+    });
+
+    return () => {
+      zoomRef.current?.detach();
+    };
+  }, []);
+
+  return (
+    <img
+      ref={imgRef}
+      data-zoom-src={zoomSrc}
+      className="bd-image-zoom"
+      {...props}
+    />
+  );
+}

--- a/packages/theme-docs/src/components/mdx/Video.tsx
+++ b/packages/theme-docs/src/components/mdx/Video.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+import { cn } from "../../lib/utils.js";
+
+interface VideoProps {
+  url: string;
+  title?: string;
+  caption?: string;
+  className?: string;
+}
+
+function parseVideoUrl(url: string): { provider: string; embedUrl: string } | null {
+  // YouTube: youtube.com/watch?v=ID, youtu.be/ID, youtube.com/embed/ID
+  const ytMatch = url.match(
+    /(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})/
+  );
+  if (ytMatch) {
+    return {
+      provider: "youtube",
+      embedUrl: `https://www.youtube-nocookie.com/embed/${ytMatch[1]}?rel=0`,
+    };
+  }
+
+  // Vimeo: vimeo.com/ID, player.vimeo.com/video/ID
+  const vimeoMatch = url.match(/(?:vimeo\.com\/|player\.vimeo\.com\/video\/)(\d+)/);
+  if (vimeoMatch) {
+    return {
+      provider: "vimeo",
+      embedUrl: `https://player.vimeo.com/video/${vimeoMatch[1]}?dnt=1`,
+    };
+  }
+
+  // Loom: loom.com/share/ID, loom.com/embed/ID
+  const loomMatch = url.match(/loom\.com\/(?:share|embed)\/([a-f0-9]+)/);
+  if (loomMatch) {
+    return {
+      provider: "loom",
+      embedUrl: `https://www.loom.com/embed/${loomMatch[1]}`,
+    };
+  }
+
+  return null;
+}
+
+export function Video({ url, title, caption, className }: VideoProps) {
+  const parsed = parseVideoUrl(url);
+
+  if (!parsed) {
+    return (
+      <div className={cn("bd-video", className)} style={{ paddingTop: 0, padding: "2rem" }}>
+        <p style={{ color: "var(--bd-text-muted)", margin: 0, textAlign: "center" }}>
+          Unsupported video URL: {url}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <figure className={className}>
+      <div className="bd-video">
+        <iframe
+          src={parsed.embedUrl}
+          title={title || `${parsed.provider} video`}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          loading="lazy"
+        />
+      </div>
+      {caption && <figcaption className="bd-video-caption">{caption}</figcaption>}
+    </figure>
+  );
+}

--- a/packages/theme-docs/src/index.ts
+++ b/packages/theme-docs/src/index.ts
@@ -3,6 +3,8 @@ import type { ThemeExport, ResolvedBarodocConfig } from "@barodoc/core";
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import tailwindcss from "@tailwindcss/vite";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
 
 export interface DocsThemeOptions {
   customCss?: string[];
@@ -79,9 +81,33 @@ function createThemeIntegration(
           entrypoint: "@barodoc/theme-docs/pages/docs/[...slug].astro",
         });
 
+        // Blog routes
+        if (config?.blog?.enabled !== false) {
+          injectRoute({
+            pattern: "/blog",
+            entrypoint: "@barodoc/theme-docs/pages/blog/index.astro",
+          });
+          injectRoute({
+            pattern: "/blog/[...slug]",
+            entrypoint: "@barodoc/theme-docs/pages/blog/[...slug].astro",
+          });
+        }
+
+        // Changelog route
+        injectRoute({
+          pattern: "/changelog",
+          entrypoint: "@barodoc/theme-docs/pages/changelog/index.astro",
+        });
+
         // Update Astro config with integrations and Vite plugins
         updateConfig({
-          integrations: [mdx(), react()],
+          integrations: [
+            mdx({
+              remarkPlugins: [remarkMath],
+              rehypePlugins: [rehypeKatex],
+            }),
+            react(),
+          ],
           vite: {
             plugins: [tailwindcss()],
             optimizeDeps: {

--- a/packages/theme-docs/src/layouts/BaseLayout.astro
+++ b/packages/theme-docs/src/layouts/BaseLayout.astro
@@ -45,6 +45,9 @@ const themeCSS = config.theme?.colors ? generateThemeCSS(config.theme.colors) : 
     <meta name="twitter:description" content={description} />
     {ogImageUrl && <meta name="twitter:image" content={ogImageUrl} />}
 
+    <!-- KaTeX math rendering -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css" crossorigin="anonymous" />
+
     <title>{title}</title>
     <ThemeScript />
     <ClientRouter />

--- a/packages/theme-docs/src/layouts/BlogLayout.astro
+++ b/packages/theme-docs/src/layouts/BlogLayout.astro
@@ -1,0 +1,93 @@
+---
+import BaseLayout from "./BaseLayout.astro";
+import Header from "../components/Header.astro";
+import Banner from "../components/Banner.astro";
+import { defaultLocale } from "virtual:barodoc/i18n";
+import { getLocaleFromPath } from "@barodoc/core";
+
+interface Props {
+  title: string;
+  description?: string;
+  date?: Date;
+  author?: string;
+  image?: string;
+  tags?: string[];
+  readingTime?: string;
+}
+
+const { title, description, date, author, image, tags = [], readingTime } = Astro.props;
+const currentPath = Astro.url.pathname;
+const i18nConfig = { defaultLocale, locales: [defaultLocale] };
+const currentLocale = getLocaleFromPath(currentPath, i18nConfig);
+---
+
+<BaseLayout title={title} description={description} ogImage={image}>
+  <Banner />
+  <Header currentLocale={currentLocale} currentPath={currentPath} />
+  
+  <div class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex justify-center">
+    <article class="w-full max-w-[720px] px-4 py-10 sm:px-6 lg:px-8">
+      <!-- Blog post header -->
+      <header class="mb-10">
+        {tags.length > 0 && (
+          <div class="flex flex-wrap gap-2 mb-4">
+            {tags.map((tag) => (
+              <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary-50 text-primary-700 dark:bg-primary-950 dark:text-primary-300">
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+        <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-[var(--bd-text-heading)] leading-tight">
+          {title}
+        </h1>
+        {description && (
+          <p class="mt-3 text-lg text-[var(--bd-text-secondary)] leading-relaxed">
+            {description}
+          </p>
+        )}
+        <div class="mt-4 flex items-center gap-3 text-sm text-[var(--bd-text-muted)]">
+          {author && <span>{author}</span>}
+          {author && date && <span class="text-[var(--bd-border)]">&middot;</span>}
+          {date && (
+            <time datetime={date.toISOString()}>
+              {date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}
+            </time>
+          )}
+          {readingTime && (
+            <>
+              <span class="text-[var(--bd-border)]">&middot;</span>
+              <span>{readingTime}</span>
+            </>
+          )}
+        </div>
+      </header>
+
+      {image && (
+        <img
+          src={image}
+          alt={title}
+          class="w-full rounded-lg mb-10 bd-no-zoom"
+          loading="eager"
+        />
+      )}
+
+      <div class="prose prose-gray dark:prose-invert max-w-none">
+        <slot />
+      </div>
+
+      <!-- Back to blog -->
+      <div class="mt-12 pt-8 border-t border-[var(--bd-border)]">
+        <a
+          href="/blog"
+          class="inline-flex items-center gap-1.5 text-sm text-[var(--bd-text-secondary)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to Blog
+        </a>
+      </div>
+    </article>
+  </div>
+</BaseLayout>

--- a/packages/theme-docs/src/layouts/DocsLayout.astro
+++ b/packages/theme-docs/src/layouts/DocsLayout.astro
@@ -7,6 +7,8 @@ import MobileNav from "../components/MobileNav.astro";
 import CodeCopy from "../components/CodeCopy.astro";
 import Breadcrumb from "../components/Breadcrumb.astro";
 import Banner from "../components/Banner.astro";
+import KeyboardShortcuts from "../components/KeyboardShortcuts.astro";
+import Contributors from "../components/Contributors.astro";
 import { defaultLocale } from "virtual:barodoc/i18n";
 import { getLocaleFromPath } from "@barodoc/core";
 import config from "virtual:barodoc/config";
@@ -30,9 +32,11 @@ interface Props {
   editUrl?: string | null;
   lastUpdated?: Date | null;
   breadcrumbs?: BreadcrumbItem[];
+  readingTime?: string;
+  filePath?: string;
 }
 
-const { title, description, headings = [], prevPage, nextPage, editUrl, lastUpdated, breadcrumbs = [] } = Astro.props;
+const { title, description, headings = [], prevPage, nextPage, editUrl, lastUpdated, breadcrumbs = [], readingTime, filePath } = Astro.props;
 const currentPath = Astro.url.pathname;
 
 // Get locale from path
@@ -61,6 +65,14 @@ const feedbackEndpoint = config.feedback?.endpoint;
       <main class="flex-1 min-w-0 max-w-[768px]">
         <div class="px-4 py-8 sm:px-6 sm:py-10 lg:px-10 lg:py-10">
           {breadcrumbs.length > 0 && <Breadcrumb items={breadcrumbs} />}
+          {readingTime && (
+            <div class="bd-reading-time mb-4">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
+              </svg>
+              <span>{readingTime}</span>
+            </div>
+          )}
           <article class="prose prose-gray dark:prose-invert max-w-none min-w-0 overflow-x-auto">
             <slot />
           </article>
@@ -111,6 +123,7 @@ const feedbackEndpoint = config.feedback?.endpoint;
 
           <!-- Page footer -->
           <footer class="mt-8 pt-6 border-t border-[var(--bd-border-subtle)] flex flex-col gap-3">
+            {filePath && <Contributors filePath={filePath} />}
             <div class="flex flex-wrap items-center justify-between gap-2 text-[13px] text-[var(--bd-text-muted)]">
               {lastUpdated && (
                 <span>
@@ -165,6 +178,25 @@ const feedbackEndpoint = config.feedback?.endpoint;
   
   <!-- Code copy functionality -->
   <CodeCopy />
+
+  <!-- Keyboard shortcuts -->
+  <KeyboardShortcuts />
+
+  <!-- Image zoom for all prose images -->
+  <script>
+    async function initImageZoom() {
+      const images = document.querySelectorAll('.prose img:not(.bd-no-zoom):not(.medium-zoom-image)');
+      if (images.length === 0) return;
+      const { default: mediumZoom } = await import('medium-zoom');
+      mediumZoom(images as any, {
+        margin: 24,
+        background: 'var(--bd-bg)',
+        scrollOffset: 0,
+      });
+    }
+    initImageZoom();
+    document.addEventListener('astro:page-load', initImageZoom);
+  </script>
 
   <!-- Heading anchor links -->
   <script>

--- a/packages/theme-docs/src/pages/blog/[...slug].astro
+++ b/packages/theme-docs/src/pages/blog/[...slug].astro
@@ -1,0 +1,39 @@
+---
+import { getCollection } from "astro:content";
+import BlogLayout from "../../layouts/BlogLayout.astro";
+import readingTime from "reading-time";
+
+export async function getStaticPaths() {
+  let posts: Awaited<ReturnType<typeof getCollection<"blog">>> = [];
+  try {
+    posts = await getCollection("blog");
+  } catch {
+    return [];
+  }
+
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { post },
+  }));
+}
+
+interface Props {
+  post: Awaited<ReturnType<typeof getCollection<"blog">>>[number];
+}
+
+const { post } = Astro.props;
+const { Content } = await post.render();
+const readTime = readingTime(post.body ?? "");
+---
+
+<BlogLayout
+  title={post.data.title}
+  description={post.data.description || post.data.excerpt}
+  date={post.data.date ? new Date(post.data.date) : undefined}
+  author={post.data.author}
+  image={post.data.image}
+  tags={post.data.tags}
+  readingTime={readTime.text}
+>
+  <Content />
+</BlogLayout>

--- a/packages/theme-docs/src/pages/blog/index.astro
+++ b/packages/theme-docs/src/pages/blog/index.astro
@@ -1,0 +1,92 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Header from "../../components/Header.astro";
+import Banner from "../../components/Banner.astro";
+import { defaultLocale } from "virtual:barodoc/i18n";
+import { getLocaleFromPath } from "@barodoc/core";
+import config from "virtual:barodoc/config";
+
+const currentPath = Astro.url.pathname;
+const i18nConfig = { defaultLocale, locales: [defaultLocale] };
+const currentLocale = getLocaleFromPath(currentPath, i18nConfig);
+
+let posts: Awaited<ReturnType<typeof getCollection<"blog">>> = [];
+try {
+  posts = await getCollection("blog");
+} catch {
+  // blog collection may not exist
+}
+
+const sortedPosts = posts.sort((a, b) => {
+  const dateA = a.data.date ? new Date(a.data.date).getTime() : 0;
+  const dateB = b.data.date ? new Date(b.data.date).getTime() : 0;
+  return dateB - dateA;
+});
+---
+
+<BaseLayout title={`Blog - ${config.name}`} description="Latest blog posts and updates">
+  <Banner />
+  <Header currentLocale={currentLocale} currentPath={currentPath} />
+  
+  <div class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex justify-center">
+    <div class="w-full max-w-[960px] px-4 py-10 sm:px-6 lg:px-8">
+      <header class="mb-10">
+        <h1 class="text-3xl font-bold tracking-tight text-[var(--bd-text-heading)]">Blog</h1>
+        <p class="mt-2 text-[var(--bd-text-secondary)]">Latest posts and updates</p>
+      </header>
+
+      {sortedPosts.length === 0 ? (
+        <p class="text-[var(--bd-text-muted)]">No posts yet.</p>
+      ) : (
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {sortedPosts.map((post) => (
+            <a
+              href={`/blog/${post.slug}`}
+              class="group flex flex-col rounded-lg border border-[var(--bd-border)] hover:border-primary-400/50 dark:hover:border-primary-500/40 hover:shadow-[var(--bd-shadow-sm)] transition-all overflow-hidden"
+            >
+              {post.data.image && (
+                <div class="aspect-[16/9] overflow-hidden bg-[var(--bd-bg-subtle)]">
+                  <img
+                    src={post.data.image}
+                    alt={post.data.title}
+                    class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                    loading="lazy"
+                  />
+                </div>
+              )}
+              <div class="flex flex-col gap-2 p-5">
+                {post.data.tags && post.data.tags.length > 0 && (
+                  <div class="flex flex-wrap gap-1.5">
+                    {post.data.tags.slice(0, 3).map((tag: string) => (
+                      <span class="text-[11px] font-medium px-2 py-0.5 rounded-full bg-primary-50 text-primary-700 dark:bg-primary-950 dark:text-primary-300">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <h2 class="text-base font-semibold text-[var(--bd-text)] group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors leading-snug">
+                  {post.data.title}
+                </h2>
+                {post.data.excerpt && (
+                  <p class="text-sm text-[var(--bd-text-muted)] line-clamp-2">
+                    {post.data.excerpt}
+                  </p>
+                )}
+                <div class="mt-auto pt-2 flex items-center gap-2 text-xs text-[var(--bd-text-muted)]">
+                  {post.data.author && <span>{post.data.author}</span>}
+                  {post.data.author && post.data.date && <span>&middot;</span>}
+                  {post.data.date && (
+                    <time datetime={new Date(post.data.date).toISOString()}>
+                      {new Date(post.data.date).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}
+                    </time>
+                  )}
+                </div>
+              </div>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  </div>
+</BaseLayout>

--- a/packages/theme-docs/src/pages/changelog/index.astro
+++ b/packages/theme-docs/src/pages/changelog/index.astro
@@ -1,0 +1,72 @@
+---
+import { getCollection } from "astro:content";
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import Header from "../../components/Header.astro";
+import Banner from "../../components/Banner.astro";
+import { defaultLocale } from "virtual:barodoc/i18n";
+import { getLocaleFromPath } from "@barodoc/core";
+import config from "virtual:barodoc/config";
+
+const currentPath = Astro.url.pathname;
+const i18nConfig = { defaultLocale, locales: [defaultLocale] };
+const currentLocale = getLocaleFromPath(currentPath, i18nConfig);
+
+let entries: Awaited<ReturnType<typeof getCollection<"changelog">>> = [];
+try {
+  entries = await getCollection("changelog");
+} catch {
+  // changelog collection may not exist
+}
+
+const sorted = entries.sort((a, b) => {
+  return new Date(b.data.date).getTime() - new Date(a.data.date).getTime();
+});
+---
+
+<BaseLayout title={`Changelog - ${config.name}`} description="Release history and changelog">
+  <Banner />
+  <Header currentLocale={currentLocale} currentPath={currentPath} />
+
+  <div class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex justify-center">
+    <div class="w-full max-w-[720px] px-4 py-10 sm:px-6 lg:px-8">
+      <header class="mb-10">
+        <h1 class="text-3xl font-bold tracking-tight text-[var(--bd-text-heading)]">Changelog</h1>
+        <p class="mt-2 text-[var(--bd-text-secondary)]">Release history and notable changes</p>
+      </header>
+
+      {sorted.length === 0 ? (
+        <p class="text-[var(--bd-text-muted)]">No changelog entries yet.</p>
+      ) : (
+        <div class="bd-changelog-timeline">
+          {sorted.map(async (entry) => {
+            const { Content } = await entry.render();
+            return (
+              <article class="bd-changelog-entry">
+                <div class="bd-changelog-marker">
+                  <div class="bd-changelog-dot" />
+                  <div class="bd-changelog-line" />
+                </div>
+                <div class="bd-changelog-content">
+                  <div class="bd-changelog-header">
+                    <span class="bd-changelog-version">{entry.data.version}</span>
+                    <time class="bd-changelog-date" datetime={new Date(entry.data.date).toISOString()}>
+                      {new Date(entry.data.date).toLocaleDateString("en-US", {
+                        year: "numeric", month: "long", day: "numeric",
+                      })}
+                    </time>
+                  </div>
+                  {entry.data.title && (
+                    <h2 class="bd-changelog-title">{entry.data.title}</h2>
+                  )}
+                  <div class="prose prose-sm prose-gray dark:prose-invert max-w-none bd-changelog-body">
+                    <Content />
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  </div>
+</BaseLayout>

--- a/packages/theme-docs/src/pages/docs/[...slug].astro
+++ b/packages/theme-docs/src/pages/docs/[...slug].astro
@@ -4,6 +4,7 @@ import DocsLayout from "../../layouts/DocsLayout.astro";
 import config from "virtual:barodoc/config";
 import { defaultLocale, locales } from "virtual:barodoc/i18n";
 import { getLocalizedNavGroup } from "@barodoc/core";
+import readingTime from "reading-time";
 
 export async function getStaticPaths() {
   const docs = await getCollection("docs");
@@ -41,6 +42,7 @@ interface Props {
 
 const { doc, locale, cleanSlug } = Astro.props;
 const { Content, headings } = await doc.render();
+const readTime = readingTime(doc.body ?? "");
 
 // Find the category (navigation group) for this page
 function findCategory(slug: string): string | null {
@@ -122,6 +124,8 @@ breadcrumbs.push({ label: doc.data.title });
   editUrl={editUrl}
   lastUpdated={lastUpdated}
   breadcrumbs={breadcrumbs}
+  readingTime={readTime.text}
+  filePath={doc.id}
 >
   {category && (
     <p class="text-xs font-semibold uppercase tracking-widest text-primary-600 dark:text-primary-400 mb-3">

--- a/packages/theme-docs/src/styles/global.css
+++ b/packages/theme-docs/src/styles/global.css
@@ -684,3 +684,571 @@
     transform: scale(0.96) translateY(2px);
   }
 }
+
+/* ==========================================================================
+   Image Zoom
+   ========================================================================== */
+
+.bd-image-zoom {
+  cursor: zoom-in;
+}
+
+.medium-zoom-overlay {
+  z-index: 10000;
+}
+
+.medium-zoom-image--opened {
+  z-index: 10001;
+}
+
+/* ==========================================================================
+   Video Embed
+   ========================================================================== */
+
+.bd-video {
+  position: relative;
+  width: 100%;
+  padding-top: 56.25%;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  margin: 1.5rem 0;
+  background-color: var(--bd-gray-900);
+}
+
+.bd-video iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.bd-video-caption {
+  margin-top: 0.5rem;
+  text-align: center;
+  font-size: 0.8125rem;
+  color: var(--bd-text-muted);
+}
+
+/* ==========================================================================
+   KaTeX math overrides
+   ========================================================================== */
+
+.katex-display {
+  margin: 1.25rem 0 !important;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding: 0.25rem 0;
+}
+
+.katex {
+  font-size: 1.05em;
+}
+
+/* ==========================================================================
+   Reading time
+   ========================================================================== */
+
+.bd-reading-time {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--bd-text-muted);
+}
+
+.bd-reading-time svg {
+  width: 0.875rem;
+  height: 0.875rem;
+  opacity: 0.7;
+}
+
+/* ==========================================================================
+   Keyboard shortcuts modal
+   ========================================================================== */
+
+.bd-shortcuts-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: fade-in 150ms ease;
+}
+
+.dark .bd-shortcuts-overlay {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+.bd-shortcuts-modal {
+  background-color: var(--bd-bg);
+  border: 1px solid var(--bd-border);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 28rem;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+}
+
+.bd-shortcuts-modal h3 {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--bd-text-heading);
+  margin: 0 0 1rem;
+}
+
+.bd-shortcut-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--bd-border-subtle);
+}
+
+.bd-shortcut-row:last-child {
+  border-bottom: 0;
+}
+
+.bd-shortcut-desc {
+  font-size: 0.8125rem;
+  color: var(--bd-text-secondary);
+}
+
+.bd-shortcut-keys {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.bd-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.375rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--bd-border);
+  background-color: var(--bd-bg-subtle);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  font-family: inherit;
+  color: var(--bd-text-secondary);
+  line-height: 1;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ==========================================================================
+   Changelog timeline
+   ========================================================================== */
+
+.bd-changelog-timeline {
+  display: flex;
+  flex-direction: column;
+}
+
+.bd-changelog-entry {
+  display: grid;
+  grid-template-columns: 1.25rem 1fr;
+  gap: 0 1rem;
+}
+
+.bd-changelog-marker {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.bd-changelog-dot {
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: 9999px;
+  background-color: var(--color-primary-500);
+  margin-top: 0.375rem;
+  flex-shrink: 0;
+}
+
+.dark .bd-changelog-dot {
+  background-color: var(--color-primary-400);
+}
+
+.bd-changelog-line {
+  flex: 1;
+  width: 2px;
+  background-color: var(--bd-border);
+  margin: 0.375rem 0 0;
+}
+
+.bd-changelog-entry:last-child .bd-changelog-line {
+  display: none;
+}
+
+.bd-changelog-content {
+  padding-bottom: 2.5rem;
+}
+
+.bd-changelog-entry:last-child .bd-changelog-content {
+  padding-bottom: 0;
+}
+
+.bd-changelog-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.bd-changelog-version {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  background-color: var(--color-primary-50);
+  color: var(--color-primary-700);
+}
+
+.dark .bd-changelog-version {
+  background-color: var(--color-primary-950);
+  color: var(--color-primary-300);
+}
+
+.bd-changelog-date {
+  font-size: 0.8125rem;
+  color: var(--bd-text-muted);
+}
+
+.bd-changelog-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--bd-text-heading);
+  margin: 0 0 0.5rem;
+}
+
+.bd-changelog-body h3 {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0.75rem 0 0.25rem;
+}
+
+.bd-changelog-body ul {
+  margin: 0.25rem 0;
+  padding-left: 1.25rem;
+}
+
+.bd-changelog-body li {
+  font-size: 0.875rem;
+}
+
+/* ==========================================================================
+   Contributors
+   ========================================================================== */
+
+.bd-contributors {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bd-contributors-label {
+  font-size: 0.8125rem;
+  color: var(--bd-text-muted);
+  white-space: nowrap;
+}
+
+.bd-contributors-avatars {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0;
+}
+
+.bd-contributor-avatar {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 9999px;
+  border: 2px solid var(--bd-bg);
+  margin-left: -0.375rem;
+  object-fit: cover;
+}
+
+.bd-contributor-avatar:first-child {
+  margin-left: 0;
+}
+
+/* ==========================================================================
+   Version Switcher
+   ========================================================================== */
+
+.bd-version-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--bd-border);
+  background-color: var(--bd-bg);
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--bd-text-secondary);
+  cursor: pointer;
+  transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.bd-version-trigger:hover {
+  border-color: var(--color-primary-400);
+  background-color: var(--bd-bg-subtle);
+}
+
+.bd-version-menu {
+  z-index: 100;
+  min-width: 8rem;
+  overflow: hidden;
+  border-radius: 0.5rem;
+  border: 1px solid var(--bd-border);
+  background-color: var(--bd-bg);
+  padding: 0.25rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  animation: fade-in 100ms ease;
+}
+
+.bd-version-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.8125rem;
+  color: var(--bd-text-secondary);
+  cursor: pointer;
+  outline: none;
+}
+
+.bd-version-item:hover,
+.bd-version-item[data-highlighted] {
+  background-color: var(--bd-bg-hover);
+  color: var(--bd-text);
+}
+
+.bd-version-active {
+  color: var(--color-primary-600);
+  font-weight: 500;
+}
+
+.dark .bd-version-active {
+  color: var(--color-primary-400);
+}
+
+/* ==========================================================================
+   API Playground
+   ========================================================================== */
+
+.bd-playground {
+  border: 1px solid var(--bd-border);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  margin: 1.5rem 0;
+  font-size: 0.875rem;
+}
+
+.bd-playground-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background-color: var(--bd-bg-subtle);
+  border-bottom: 1px solid var(--bd-border);
+}
+
+.bd-playground-method {
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.025em;
+  flex-shrink: 0;
+}
+
+.bd-playground-url {
+  flex: 1;
+  font-size: 0.8125rem;
+  color: var(--bd-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bd-playground-send {
+  padding: 0.375rem 0.875rem;
+  border-radius: 0.375rem;
+  background-color: var(--color-primary-600);
+  color: #fff;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background-color 150ms ease;
+}
+
+.bd-playground-send:hover {
+  background-color: var(--color-primary-700);
+}
+
+.bd-playground-send:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.dark .bd-playground-send {
+  background-color: var(--color-primary-500);
+}
+
+.dark .bd-playground-send:hover {
+  background-color: var(--color-primary-400);
+}
+
+.bd-playground-params {
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--bd-border);
+}
+
+.bd-playground-param {
+  display: grid;
+  grid-template-columns: 8rem 1fr;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.bd-playground-label {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--bd-text);
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.bd-playground-param-meta {
+  font-size: 0.6875rem;
+  color: var(--bd-text-muted);
+  font-weight: 400;
+}
+
+.bd-playground-required {
+  color: var(--bd-error, #ef4444);
+  font-weight: 600;
+}
+
+.bd-playground-input {
+  width: 100%;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--bd-border);
+  background-color: var(--bd-bg);
+  color: var(--bd-text);
+  font-size: 0.8125rem;
+  font-family: ui-monospace, monospace;
+  outline: none;
+}
+
+.bd-playground-input:focus {
+  border-color: var(--color-primary-400);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary-400) 20%, transparent);
+}
+
+.bd-playground-body-section {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--bd-border);
+}
+
+.bd-playground-textarea {
+  width: 100%;
+  margin-top: 0.375rem;
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--bd-border);
+  background-color: var(--bd-bg);
+  color: var(--bd-text);
+  font-size: 0.8125rem;
+  font-family: ui-monospace, monospace;
+  resize: vertical;
+  outline: none;
+}
+
+.bd-playground-textarea:focus {
+  border-color: var(--color-primary-400);
+}
+
+.bd-playground-response {
+  background-color: var(--bd-bg-subtle);
+}
+
+.bd-playground-response-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--bd-border);
+}
+
+.bd-playground-status {
+  font-weight: 600;
+  font-size: 0.8125rem;
+}
+
+.bd-status-ok {
+  color: #16a34a;
+}
+
+.dark .bd-status-ok {
+  color: #4ade80;
+}
+
+.bd-status-err {
+  color: #dc2626;
+}
+
+.dark .bd-status-err {
+  color: #f87171;
+}
+
+.bd-playground-time {
+  font-size: 0.75rem;
+  color: var(--bd-text-muted);
+}
+
+.bd-playground-pre {
+  margin: 0;
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  max-height: 20rem;
+}
+
+.bd-playground-pre code {
+  font-family: ui-monospace, monospace;
+  color: var(--bd-text);
+}
+
+.bd-playground-error {
+  padding: 0.75rem 1rem;
+  color: #dc2626;
+  font-size: 0.8125rem;
+}
+
+.dark .bd-playground-error {
+  color: #f87171;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,10 +26,10 @@ importers:
     dependencies:
       '@astrojs/mdx':
         specifier: ^4.0.0
-        version: 4.3.13(astro@5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3))
+        version: 4.3.13(astro@5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       '@astrojs/react':
         specifier: ^4.0.0
-        version: 4.4.2(@types/node@22.19.8)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)
+        version: 4.4.2(@types/node@22.19.8)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.8.2)
       '@barodoc/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -38,7 +38,7 @@ importers:
         version: link:../packages/theme-docs
       astro:
         specifier: ^5.0.0
-        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)
+        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -97,7 +97,7 @@ importers:
         version: 22.19.8
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -113,10 +113,10 @@ importers:
         version: 22.19.8
       astro:
         specifier: ^5.0.0
-        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)
+        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -128,7 +128,7 @@ importers:
         version: 22.19.8
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -143,10 +143,28 @@ importers:
         version: 22.19.8
       astro:
         specifier: ^5.0.0
-        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)
+        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/plugin-docsearch:
+    devDependencies:
+      '@barodoc/core':
+        specifier: workspace:*
+        version: link:../core
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.8
+      astro:
+        specifier: ^5.0.0
+        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -161,7 +179,7 @@ importers:
         version: 22.19.8
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -183,10 +201,72 @@ importers:
         version: 22.19.8
       astro:
         specifier: ^5.0.0
-        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)
+        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/plugin-openapi:
+    dependencies:
+      yaml:
+        specifier: ^2.7.0
+        version: 2.8.2
+    devDependencies:
+      '@barodoc/core':
+        specifier: workspace:*
+        version: link:../core
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.8
+      astro:
+        specifier: ^5.0.0
+        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/plugin-pwa:
+    devDependencies:
+      '@barodoc/core':
+        specifier: workspace:*
+        version: link:../core
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.8
+      astro:
+        specifier: ^5.0.0
+        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/plugin-rss:
+    dependencies:
+      '@astrojs/rss':
+        specifier: ^4.0.0
+        version: 4.0.15
+    devDependencies:
+      '@barodoc/core':
+        specifier: workspace:*
+        version: link:../core
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.8
+      astro:
+        specifier: ^5.0.0
+        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -201,10 +281,10 @@ importers:
         version: 22.19.8
       astro:
         specifier: ^5.0.0
-        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)
+        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -223,10 +303,10 @@ importers:
         version: 22.19.8
       astro:
         specifier: ^5.0.0
-        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)
+        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -272,6 +352,9 @@ importers:
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.4)
+      medium-zoom:
+        specifier: ^1.1.0
+        version: 1.1.0
       mermaid:
         specifier: ^11.12.2
         version: 11.12.2
@@ -281,22 +364,31 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      reading-time:
+        specifier: ^1.5.0
+        version: 1.5.0
+      rehype-katex:
+        specifier: ^7.0.1
+        version: 7.0.1
+      remark-math:
+        specifier: ^6.0.0
+        version: 6.0.0
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
     devDependencies:
       '@astrojs/mdx':
         specifier: ^4.0.0
-        version: 4.3.13(astro@5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3))
+        version: 4.3.13(astro@5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))
       '@astrojs/react':
         specifier: ^4.0.0
-        version: 4.4.2(@types/node@22.19.8)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)
+        version: 4.4.2(@types/node@22.19.8)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.8.2)
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.1.18)
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.1.18(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 4.1.18(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.8
@@ -308,7 +400,7 @@ importers:
         version: 19.2.3(@types/react@19.2.10)
       astro:
         specifier: ^5.0.0
-        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)
+        version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.18
@@ -348,6 +440,9 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/rss@4.0.15':
+    resolution: {integrity: sha512-uXO/k6AhRkIDXmRoc6xQpoPZrimQNUmS43X4+60yunfuMNHtSRN5e/FiSi7NApcZqmugSMc5+cJi8ovqgO+qIg==}
 
   '@astrojs/sitemap@3.7.0':
     resolution: {integrity: sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA==}
@@ -1966,6 +2061,9 @@ packages:
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
 
+  '@types/katex@0.16.8':
+    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -2663,6 +2761,10 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-xml-parser@5.3.7:
+    resolution: {integrity: sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -2771,6 +2873,12 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  hast-util-from-dom@5.0.1:
+    resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
+
+  hast-util-from-html-isomorphic@2.0.0:
+    resolution: {integrity: sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==}
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -3143,6 +3251,9 @@ packages:
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
+  mdast-util-math@3.0.0:
+    resolution: {integrity: sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==}
+
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
 
@@ -3172,6 +3283,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  medium-zoom@1.1.0:
+    resolution: {integrity: sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -3203,6 +3317,9 @@ packages:
 
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-math@3.1.0:
+    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
   micromark-extension-mdx-expression@3.0.1:
     resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
@@ -3584,6 +3701,9 @@ packages:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
 
+  reading-time@1.5.0:
+    resolution: {integrity: sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==}
+
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
 
@@ -3607,6 +3727,9 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
+  rehype-katex@7.0.1:
+    resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
+
   rehype-parse@9.0.1:
     resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
 
@@ -3624,6 +3747,9 @@ packages:
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-math@6.0.0:
+    resolution: {integrity: sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==}
 
   remark-mdx@3.1.1:
     resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
@@ -3814,6 +3940,9 @@ packages:
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
+
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -4213,6 +4342,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -4290,12 +4424,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.13(astro@5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3))':
+  '@astrojs/mdx@4.3.13(astro@5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.10
       '@mdx-js/mdx': 3.1.1
       acorn: 8.15.0
-      astro: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)
+      astro: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -4313,15 +4447,15 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@4.4.2(@types/node@22.19.8)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)':
+  '@astrojs/react@4.4.2(@types/node@22.19.8)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.8.2)':
     dependencies:
       '@types/react': 19.2.10
       '@types/react-dom': 19.2.3(@types/react@19.2.10)
-      '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       ultrahtml: 1.6.0
-      vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4335,6 +4469,11 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  '@astrojs/rss@4.0.15':
+    dependencies:
+      fast-xml-parser: 5.3.7
+      piccolore: 0.1.3
 
   '@astrojs/sitemap@3.7.0':
     dependencies:
@@ -5678,12 +5817,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -5848,6 +5987,8 @@ snapshots:
     dependencies:
       '@types/node': 22.19.8
 
+  '@types/katex@0.16.8': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -5889,7 +6030,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5897,7 +6038,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -5950,7 +6091,7 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro@5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3):
+  astro@5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 2.13.0
       '@astrojs/internal-helpers': 0.7.5
@@ -6007,8 +6148,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.4
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -6684,6 +6825,10 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-xml-parser@5.3.7:
+    dependencies:
+      strnum: 2.1.2
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -6800,6 +6945,19 @@ snapshots:
   hachure-fill@0.5.2: {}
 
   has-flag@4.0.0: {}
+
+  hast-util-from-dom@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hastscript: 9.0.1
+      web-namespaces: 2.0.1
+
+  hast-util-from-html-isomorphic@2.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-dom: 5.0.1
+      hast-util-from-html: 2.0.3
+      unist-util-remove-position: 5.0.0
 
   hast-util-from-html@2.0.3:
     dependencies:
@@ -7244,6 +7402,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-math@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      longest-streak: 3.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      unist-util-remove-position: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -7329,6 +7499,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.12.2: {}
+
+  medium-zoom@1.1.0: {}
 
   merge2@1.4.1: {}
 
@@ -7430,6 +7602,16 @@ snapshots:
       micromark-extension-gfm-tagfilter: 2.0.0
       micromark-extension-gfm-task-list-item: 2.1.0
       micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-math@3.1.0:
+    dependencies:
+      '@types/katex': 0.16.8
+      devlop: 1.1.0
+      katex: 0.16.28
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-extension-mdx-expression@3.0.1:
@@ -7799,13 +7981,14 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
       postcss: 8.5.6
       tsx: 4.21.0
+      yaml: 2.8.2
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -7888,6 +8071,8 @@ snapshots:
 
   readdirp@5.0.0: {}
 
+  reading-time@1.5.0: {}
+
   recma-build-jsx@1.0.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -7926,6 +8111,16 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  rehype-katex@7.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/katex': 0.16.8
+      hast-util-from-html-isomorphic: 2.0.0
+      hast-util-to-text: 4.0.2
+      katex: 0.16.28
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
 
   rehype-parse@9.0.1:
     dependencies:
@@ -7967,6 +8162,15 @@ snapshots:
       micromark-extension-gfm: 3.0.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-math@6.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-math: 3.0.0
+      micromark-extension-math: 3.1.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
@@ -8264,6 +8468,8 @@ snapshots:
 
   strip-final-newline@4.0.0: {}
 
+  strnum@2.1.2: {}
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -8349,7 +8555,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -8360,7 +8566,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
       resolve-from: 5.0.0
       rollup: 4.57.1
       source-map: 0.7.6
@@ -8520,7 +8726,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+  vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -8534,10 +8740,11 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
+      yaml: 2.8.2
 
-  vitefu@1.1.1(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)):
+  vitefu@1.1.1(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   vscode-jsonrpc@8.2.0: {}
 
@@ -8585,6 +8792,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.2: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary

- Add 12 new features across 4 implementation phases to reach feature parity with Docusaurus/Mintlify/Starlight
- New MDX components: `ImageZoom`, `Video`, `ApiPlayground`
- New content types: Blog (collection + pages + layout), Changelog (timeline UI)
- New plugins: `@barodoc/plugin-docsearch`, `@barodoc/plugin-rss`, `@barodoc/plugin-pwa`, `@barodoc/plugin-openapi`
- New theme features: reading time, keyboard shortcuts, page contributors, doc versioning with VersionSwitcher
- Math/KaTeX support via remark-math + rehype-katex in MDX pipeline

Closes #56

## Test plan

- [ ] Verify image zoom works on prose images (hover → click → zoom overlay)
- [ ] Verify `<Video url="https://youtube.com/watch?v=..." />` renders responsive iframe
- [ ] Verify `$E=mc^2$` renders inline math and `$$` renders block math
- [ ] Verify reading time appears on docs pages
- [ ] Verify keyboard shortcuts: Cmd+K opens search, ? shows modal, ← → navigate pages
- [ ] Verify /blog page renders empty state or blog posts if present
- [ ] Verify /changelog page renders timeline from changelog collection
- [ ] Verify VersionSwitcher renders when `versions` config is provided
- [ ] Verify ApiPlayground sends requests and displays responses
- [ ] Build succeeds with new plugins registered in config

Made with [Cursor](https://cursor.com)