### PR TITLE
docs: add missing documentation for Video, ImageZoom, and 9 plugins

### DIFF
--- a/docs/barodoc.config.json
+++ b/docs/barodoc.config.json
@@ -41,12 +41,29 @@
         "components/file-tree",
         "components/frame",
         "components/icon",
+        "components/image-zoom",
         "components/mermaid",
         "components/param-field",
         "components/response-field",
         "components/steps",
         "components/tabs",
-        "components/tooltip"
+        "components/tooltip",
+        "components/video"
+      ]
+    },
+    {
+      "group": "Plugins",
+      "group:ko": "플러그인",
+      "pages": [
+        "guides/plugins/openapi",
+        "guides/plugins/search",
+        "guides/plugins/analytics",
+        "guides/plugins/sitemap",
+        "guides/plugins/rss",
+        "guides/plugins/pwa",
+        "guides/plugins/og-image",
+        "guides/plugins/llms-txt",
+        "guides/plugins/docsearch"
       ]
     },
     {

--- a/docs/src/content/docs/en/components/image-zoom.mdx
+++ b/docs/src/content/docs/en/components/image-zoom.mdx
@@ -1,0 +1,60 @@
+---
+title: Image Zoom
+description: Click-to-zoom images with medium-zoom
+---
+import { ImageZoom } from "@barodoc/theme-docs/components/mdx/ImageZoom.tsx";
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+Add click-to-zoom functionality to images. Powered by [medium-zoom](https://github.com/francoischalifour/medium-zoom).
+
+## Basic Usage
+
+<ImageZoom client:load src="/logo.svg" alt="Barodoc Logo" width={200} />
+
+Click the image above to zoom in. Click again or press `Esc` to close.
+
+```mdx
+<ImageZoom client:load src="/images/screenshot.png" alt="Screenshot" />
+```
+
+## With High-Resolution Zoom Source
+
+Use `zoomSrc` to load a higher-resolution image when zoomed:
+
+```mdx
+<ImageZoom
+  client:load
+  src="/images/thumbnail.png"
+  zoomSrc="/images/full-resolution.png"
+  alt="Architecture diagram"
+/>
+```
+
+## With Custom Dimensions
+
+```mdx
+<ImageZoom client:load src="/images/diagram.png" alt="Diagram" width={600} height={400} />
+```
+
+## Props
+
+<ParamFieldGroup>
+  <ParamField name="src" type="string" required>
+    Image source URL
+  </ParamField>
+  <ParamField name="alt" type="string">
+    Alt text for accessibility
+  </ParamField>
+  <ParamField name="zoomSrc" type="string">
+    Higher-resolution image URL loaded when zoomed
+  </ParamField>
+  <ParamField name="width" type="number">
+    Image width in pixels
+  </ParamField>
+  <ParamField name="height" type="number">
+    Image height in pixels
+  </ParamField>
+  <ParamField name="client:load" type="directive" required>
+    Required Astro directive for client-side interactivity
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/en/components/video.mdx
+++ b/docs/src/content/docs/en/components/video.mdx
@@ -1,0 +1,53 @@
+---
+title: Video
+description: Embed videos from YouTube, Vimeo, and Loom
+---
+import { Video } from "@barodoc/theme-docs/components/mdx/Video.tsx";
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+Embed videos from YouTube, Vimeo, and Loom with a responsive player and optional caption.
+
+## YouTube
+
+<Video client:load url="https://www.youtube.com/watch?v=dQw4w9WgXcQ" title="Demo video" caption="A YouTube video embedded with the Video component" />
+
+```mdx
+<Video client:load url="https://www.youtube.com/watch?v=dQw4w9WgXcQ" title="Demo video" caption="A YouTube video" />
+```
+
+## Vimeo
+
+```mdx
+<Video client:load url="https://vimeo.com/123456789" title="Vimeo video" />
+```
+
+## Loom
+
+```mdx
+<Video client:load url="https://www.loom.com/share/abc123def456" title="Loom recording" caption="Screen recording" />
+```
+
+## Supported URL Formats
+
+| Provider | Formats |
+|----------|---------|
+| YouTube | `youtube.com/watch?v=ID`, `youtu.be/ID`, `youtube.com/embed/ID` |
+| Vimeo | `vimeo.com/ID`, `player.vimeo.com/video/ID` |
+| Loom | `loom.com/share/ID`, `loom.com/embed/ID` |
+
+## Props
+
+<ParamFieldGroup>
+  <ParamField name="url" type="string" required>
+    Video URL from YouTube, Vimeo, or Loom
+  </ParamField>
+  <ParamField name="title" type="string">
+    Accessible title for the iframe (defaults to provider name)
+  </ParamField>
+  <ParamField name="caption" type="string">
+    Caption text displayed below the video
+  </ParamField>
+  <ParamField name="client:load" type="directive" required>
+    Required Astro directive for client-side interactivity
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/en/guides/plugins/analytics.mdx
+++ b/docs/src/content/docs/en/guides/plugins/analytics.mdx
@@ -1,0 +1,94 @@
+---
+title: Analytics Plugin
+description: Add analytics tracking to your docs
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+The analytics plugin injects tracking scripts into your documentation site. It supports Google Analytics, Plausible, and Umami.
+
+## Installation
+
+```bash
+pnpm add @barodoc/plugin-analytics@latest
+```
+
+## Google Analytics
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-analytics", {
+      "provider": "google",
+      "id": "G-XXXXXXXXXX"
+    }]
+  ]
+}
+```
+
+## Plausible
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-analytics", {
+      "provider": "plausible",
+      "domain": "docs.example.com"
+    }]
+  ]
+}
+```
+
+## Umami
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-analytics", {
+      "provider": "umami",
+      "websiteId": "your-website-id",
+      "src": "https://analytics.example.com/umami.js"
+    }]
+  ]
+}
+```
+
+## Options
+
+### Google Analytics
+
+<ParamFieldGroup>
+  <ParamField name="provider" type="'google'" required>
+    Set to `"google"`
+  </ParamField>
+  <ParamField name="id" type="string" required>
+    Google Analytics measurement ID (e.g. `"G-XXXXXXXXXX"`)
+  </ParamField>
+</ParamFieldGroup>
+
+### Plausible
+
+<ParamFieldGroup>
+  <ParamField name="provider" type="'plausible'" required>
+    Set to `"plausible"`
+  </ParamField>
+  <ParamField name="domain" type="string" required>
+    Your site domain
+  </ParamField>
+  <ParamField name="src" type="string">
+    Custom Plausible script URL. Default: `"https://plausible.io/js/script.js"`
+  </ParamField>
+</ParamFieldGroup>
+
+### Umami
+
+<ParamFieldGroup>
+  <ParamField name="provider" type="'umami'" required>
+    Set to `"umami"`
+  </ParamField>
+  <ParamField name="websiteId" type="string" required>
+    Your Umami website ID
+  </ParamField>
+  <ParamField name="src" type="string" required>
+    Umami script URL
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/en/guides/plugins/docsearch.mdx
+++ b/docs/src/content/docs/en/guides/plugins/docsearch.mdx
@@ -1,0 +1,53 @@
+---
+title: DocSearch Plugin
+description: Integrate Algolia DocSearch for advanced search
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+The DocSearch plugin integrates [Algolia DocSearch](https://docsearch.algolia.com) into your documentation site, replacing the default Pagefind search with Algolia's AI-powered search.
+
+## Installation
+
+```bash
+pnpm add @barodoc/plugin-docsearch@latest
+```
+
+## Prerequisites
+
+Apply for DocSearch at [docsearch.algolia.com](https://docsearch.algolia.com/apply). You will receive an `appId`, `apiKey`, and `indexName` after approval.
+
+## Configuration
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-docsearch", {
+      "appId": "YOUR_APP_ID",
+      "apiKey": "YOUR_SEARCH_API_KEY",
+      "indexName": "your_index_name"
+    }]
+  ]
+}
+```
+
+When enabled, the DocSearch plugin automatically disables the default Pagefind search and replaces it with the Algolia search modal.
+
+## Options
+
+<ParamFieldGroup>
+  <ParamField name="appId" type="string" required>
+    Algolia application ID
+  </ParamField>
+  <ParamField name="apiKey" type="string" required>
+    Algolia search-only API key (not the admin key)
+  </ParamField>
+  <ParamField name="indexName" type="string" required>
+    Algolia index name
+  </ParamField>
+  <ParamField name="container" type="string">
+    CSS selector for the search container element. Default: `"#docsearch"`
+  </ParamField>
+  <ParamField name="placeholder" type="string">
+    Placeholder text for the search input. Default: `"Search docs..."`
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/en/guides/plugins/llms-txt.mdx
+++ b/docs/src/content/docs/en/guides/plugins/llms-txt.mdx
@@ -1,0 +1,49 @@
+---
+title: LLMs.txt Plugin
+description: Generate llms.txt for AI-friendly documentation
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+The LLMs.txt plugin generates `llms.txt` and `llms-full.txt` files following the [llms.txt specification](https://llmstxt.org). These files make your documentation easily consumable by AI assistants and large language models.
+
+## Installation
+
+```bash
+pnpm add @barodoc/plugin-llms-txt@latest
+```
+
+## Configuration
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-llms-txt", {
+      "description": "Documentation for My Project",
+      "full": true,
+      "links": [
+        { "title": "GitHub", "url": "https://github.com/user/repo" },
+        { "title": "API Reference", "url": "https://docs.example.com/api" }
+      ]
+    }]
+  ]
+}
+```
+
+## Generated Files
+
+- **`llms.txt`** — Summary with page titles, descriptions, and links
+- **`llms-full.txt`** — Full content of all documentation pages (when `full: true`)
+
+## Options
+
+<ParamFieldGroup>
+  <ParamField name="description" type="string">
+    Site description for the llms.txt header. Defaults to the site name
+  </ParamField>
+  <ParamField name="full" type="boolean">
+    Generate `llms-full.txt` with complete page content. Default: `true`
+  </ParamField>
+  <ParamField name="links" type="Array<{ title, url, description? }>">
+    Additional links to include (e.g. GitHub repo, API docs)
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/en/guides/plugins/og-image.mdx
+++ b/docs/src/content/docs/en/guides/plugins/og-image.mdx
@@ -1,0 +1,57 @@
+---
+title: OG Image Plugin
+description: Auto-generate Open Graph images for social sharing
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+The OG Image plugin generates Open Graph images for each documentation page at build time. These images appear when your docs are shared on social media platforms like Twitter, Facebook, and Slack.
+
+## Installation
+
+```bash
+pnpm add @barodoc/plugin-og-image@latest
+```
+
+## Configuration
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-og-image", {
+      "background": "#ffffff",
+      "textColor": "#0f172a",
+      "accentColor": "#0070f3"
+    }]
+  ]
+}
+```
+
+Generated images are placed in `dist/og/` and automatically linked via `<meta property="og:image">` tags.
+
+Each image includes:
+- Site name (in accent color)
+- Page title
+- Page description
+
+## Options
+
+<ParamFieldGroup>
+  <ParamField name="fontPath" type="string">
+    Path to a TTF/OTF font file for text rendering. Falls back to a system default
+  </ParamField>
+  <ParamField name="background" type="string">
+    Background color. Default: `"#ffffff"`
+  </ParamField>
+  <ParamField name="textColor" type="string">
+    Text color for title and description. Default: `"#0f172a"`
+  </ParamField>
+  <ParamField name="accentColor" type="string">
+    Accent color for the site name. Default: `"#0070f3"`
+  </ParamField>
+  <ParamField name="width" type="number">
+    Image width in pixels. Default: `1200`
+  </ParamField>
+  <ParamField name="height" type="number">
+    Image height in pixels. Default: `630`
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/en/guides/plugins/openapi.mdx
+++ b/docs/src/content/docs/en/guides/plugins/openapi.mdx
@@ -1,0 +1,104 @@
+---
+title: OpenAPI Plugin
+description: Generate API documentation from OpenAPI/Swagger specs
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+The OpenAPI plugin automatically generates API documentation pages from an OpenAPI (Swagger) specification file. It includes an interactive API Playground for testing endpoints directly from the docs.
+
+## Installation
+
+```bash
+pnpm add @barodoc/plugin-openapi@latest
+```
+
+## Configuration
+
+Add the plugin to `barodoc.config.json`:
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-openapi", {
+      "specFile": "openapi.yaml",
+      "basePath": "api",
+      "groupBy": "tags",
+      "baseUrl": "https://api.example.com",
+      "playground": true
+    }]
+  ]
+}
+```
+
+## Spec File
+
+Place your OpenAPI spec file (YAML or JSON) in the docs root directory:
+
+```
+docs/
+├── openapi.yaml    ← spec file
+├── barodoc.config.json
+└── src/
+```
+
+The plugin supports OpenAPI 3.0+ specs. It reads paths, operations, parameters, request bodies, response schemas, and examples.
+
+## Generated Output
+
+The plugin generates MDX pages grouped by tags (or paths). Each page includes:
+
+- **Endpoint header** with method badge, path, and description
+- **Endpoint TOC** at the top for quick navigation
+- **Parameters table** with name, type, required status, and enum values
+- **Request body schema** with field descriptions
+- **Response examples** auto-generated from schemas
+- **cURL request examples**
+- **Interactive API Playground** (when `playground: true`)
+
+## API Playground Features
+
+The generated playground supports:
+
+- **Multiple auth types**: Bearer Token, API Key, and Basic Auth
+- **Enum dropdowns**: Parameters with enum values render as `<select>` dropdowns
+- **JSON body validation**: Request body is validated before sending
+- **Code snippets**: cURL, JavaScript, Python, and Node.js
+- **Response inspector**: Body with JSON syntax highlighting, headers, status, time, and size
+- **Request history**: Last 5 requests stored in IndexedDB
+
+## Navigation
+
+Add the generated pages to your navigation:
+
+```json
+{
+  "navigation": [
+    {
+      "group": "API Reference",
+      "pages": ["api/pet", "api/store", "api/user"]
+    }
+  ]
+}
+```
+
+Page slugs match the tag names from your spec, lowercased and hyphenated.
+
+## Options
+
+<ParamFieldGroup>
+  <ParamField name="specFile" type="string" required>
+    Path to the OpenAPI spec file (YAML or JSON), relative to the docs root
+  </ParamField>
+  <ParamField name="basePath" type="string">
+    Base path for generated API doc pages. Default: `"api"`
+  </ParamField>
+  <ParamField name="groupBy" type="'tags' | 'paths'">
+    Group endpoints by tags or paths. Default: `"tags"`
+  </ParamField>
+  <ParamField name="baseUrl" type="string">
+    Base URL for API requests in the playground. Default: `""`
+  </ParamField>
+  <ParamField name="playground" type="boolean">
+    Enable the interactive API Playground. Default: `true`
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/en/guides/plugins/pwa.mdx
+++ b/docs/src/content/docs/en/guides/plugins/pwa.mdx
@@ -1,0 +1,56 @@
+---
+title: PWA Plugin
+description: Add Progressive Web App support with offline access
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+The PWA plugin adds Progressive Web App capabilities to your documentation site, including offline access, installability, and a web app manifest.
+
+## Installation
+
+```bash
+pnpm add @barodoc/plugin-pwa@latest
+```
+
+## Configuration
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-pwa", {
+      "name": "My Docs",
+      "shortName": "Docs",
+      "themeColor": "#0070f3",
+      "backgroundColor": "#ffffff",
+      "display": "standalone"
+    }]
+  ]
+}
+```
+
+The plugin generates:
+- `manifest.json` — web app manifest with name, icons, and display mode
+- `sw.js` — service worker for offline caching
+
+## Options
+
+<ParamFieldGroup>
+  <ParamField name="name" type="string">
+    Full app name. Defaults to the site name from config
+  </ParamField>
+  <ParamField name="shortName" type="string">
+    Short app name for the home screen. Defaults to `name`
+  </ParamField>
+  <ParamField name="themeColor" type="string">
+    Theme color for the browser chrome. Default: `"#2563eb"`
+  </ParamField>
+  <ParamField name="backgroundColor" type="string">
+    Background color for the splash screen. Default: `"#ffffff"`
+  </ParamField>
+  <ParamField name="display" type="'standalone' | 'fullscreen' | 'minimal-ui' | 'browser'">
+    Display mode. Default: `"standalone"`
+  </ParamField>
+  <ParamField name="offlineFallback" type="string">
+    Page to show when offline and the requested page is not cached. Default: `"/404"`
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/en/guides/plugins/rss.mdx
+++ b/docs/src/content/docs/en/guides/plugins/rss.mdx
@@ -1,0 +1,41 @@
+---
+title: RSS Plugin
+description: Generate RSS feeds for blog and changelog
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+The RSS plugin generates an RSS feed at `/rss.xml`, allowing users to subscribe to updates from your blog or changelog.
+
+## Installation
+
+```bash
+pnpm add @barodoc/plugin-rss@latest
+```
+
+## Configuration
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-rss", {
+      "title": "My Docs Updates",
+      "description": "Latest updates from our documentation",
+      "collections": ["blog", "changelog"]
+    }]
+  ]
+}
+```
+
+## Options
+
+<ParamFieldGroup>
+  <ParamField name="title" type="string">
+    Feed title. Defaults to the site name from config
+  </ParamField>
+  <ParamField name="description" type="string">
+    Feed description. Default: `"Latest updates"`
+  </ParamField>
+  <ParamField name="collections" type="('blog' | 'changelog')[]">
+    Content collections to include in the feed. Default: `["blog"]`
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/en/guides/plugins/search.mdx
+++ b/docs/src/content/docs/en/guides/plugins/search.mdx
@@ -1,0 +1,44 @@
+---
+title: Search Plugin
+description: Full-text search with Pagefind
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+The search plugin enables full-text search powered by [Pagefind](https://pagefind.app). It indexes your documentation at build time and provides a fast, client-side search experience.
+
+## Installation
+
+```bash
+pnpm add @barodoc/plugin-search@latest
+```
+
+## Configuration
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-search", {
+      "enabled": true,
+      "pagefind": {
+        "exclude": ["api/*"]
+      }
+    }]
+  ]
+}
+```
+
+Search is enabled by default. The search UI is built into the theme and accessible via the search bar in the header or the `Ctrl+K` / `Cmd+K` keyboard shortcut.
+
+## Options
+
+<ParamFieldGroup>
+  <ParamField name="enabled" type="boolean">
+    Enable or disable search. Default: `true`
+  </ParamField>
+  <ParamField name="pagefind.baseUrl" type="string">
+    Base URL for Pagefind index
+  </ParamField>
+  <ParamField name="pagefind.exclude" type="string[]">
+    Glob patterns for pages to exclude from the search index
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/en/guides/plugins/sitemap.mdx
+++ b/docs/src/content/docs/en/guides/plugins/sitemap.mdx
@@ -1,0 +1,46 @@
+---
+title: Sitemap Plugin
+description: Auto-generate sitemap.xml for search engines
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+The sitemap plugin generates a `sitemap.xml` file at build time, helping search engines discover and index your documentation pages.
+
+## Installation
+
+```bash
+pnpm add @barodoc/plugin-sitemap@latest
+```
+
+## Configuration
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-sitemap", {
+      "exclude": ["/404", "/api/*"],
+      "customPages": ["https://docs.example.com/changelog"]
+    }]
+  ]
+}
+```
+
+The sitemap is generated at `sitemap-index.xml` and `sitemap-0.xml` in the build output. Make sure to set the `site` option in your config for absolute URLs:
+
+```json
+{
+  "site": "https://docs.example.com",
+  "plugins": ["@barodoc/plugin-sitemap"]
+}
+```
+
+## Options
+
+<ParamFieldGroup>
+  <ParamField name="exclude" type="string[]">
+    Glob patterns for pages to exclude from the sitemap
+  </ParamField>
+  <ParamField name="customPages" type="string[]">
+    Additional full URLs to include in the sitemap
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/ko/components/image-zoom.mdx
+++ b/docs/src/content/docs/ko/components/image-zoom.mdx
@@ -1,0 +1,60 @@
+---
+title: Image Zoom
+description: 클릭하면 확대되는 이미지
+---
+import { ImageZoom } from "@barodoc/theme-docs/components/mdx/ImageZoom.tsx";
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+이미지를 클릭하면 확대되는 기능을 추가합니다. [medium-zoom](https://github.com/francoischalifour/medium-zoom) 기반입니다.
+
+## 기본 사용법
+
+<ImageZoom client:load src="/logo.svg" alt="Barodoc Logo" width={200} />
+
+위 이미지를 클릭하면 확대됩니다. 다시 클릭하거나 `Esc`를 누르면 닫힙니다.
+
+```mdx
+<ImageZoom client:load src="/images/screenshot.png" alt="스크린샷" />
+```
+
+## 고해상도 줌 소스
+
+`zoomSrc`를 사용하면 확대 시 더 높은 해상도의 이미지를 로드합니다:
+
+```mdx
+<ImageZoom
+  client:load
+  src="/images/thumbnail.png"
+  zoomSrc="/images/full-resolution.png"
+  alt="아키텍처 다이어그램"
+/>
+```
+
+## 크기 지정
+
+```mdx
+<ImageZoom client:load src="/images/diagram.png" alt="다이어그램" width={600} height={400} />
+```
+
+## Props
+
+<ParamFieldGroup>
+  <ParamField name="src" type="string" required>
+    이미지 소스 URL
+  </ParamField>
+  <ParamField name="alt" type="string">
+    접근성을 위한 대체 텍스트
+  </ParamField>
+  <ParamField name="zoomSrc" type="string">
+    확대 시 로드되는 고해상도 이미지 URL
+  </ParamField>
+  <ParamField name="width" type="number">
+    이미지 너비 (픽셀)
+  </ParamField>
+  <ParamField name="height" type="number">
+    이미지 높이 (픽셀)
+  </ParamField>
+  <ParamField name="client:load" type="directive" required>
+    클라이언트 사이드 인터랙티비티를 위한 Astro 디렉티브
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/ko/components/video.mdx
+++ b/docs/src/content/docs/ko/components/video.mdx
@@ -1,0 +1,53 @@
+---
+title: Video
+description: YouTube, Vimeo, Loom 비디오 임베딩
+---
+import { Video } from "@barodoc/theme-docs/components/mdx/Video.tsx";
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+YouTube, Vimeo, Loom 비디오를 반응형 플레이어와 캡션으로 임베딩합니다.
+
+## YouTube
+
+<Video client:load url="https://www.youtube.com/watch?v=dQw4w9WgXcQ" title="데모 비디오" caption="Video 컴포넌트로 임베딩한 YouTube 비디오" />
+
+```mdx
+<Video client:load url="https://www.youtube.com/watch?v=dQw4w9WgXcQ" title="데모 비디오" caption="YouTube 비디오" />
+```
+
+## Vimeo
+
+```mdx
+<Video client:load url="https://vimeo.com/123456789" title="Vimeo 비디오" />
+```
+
+## Loom
+
+```mdx
+<Video client:load url="https://www.loom.com/share/abc123def456" title="Loom 녹화" caption="화면 녹화" />
+```
+
+## 지원되는 URL 형식
+
+| 제공자 | 형식 |
+|--------|------|
+| YouTube | `youtube.com/watch?v=ID`, `youtu.be/ID`, `youtube.com/embed/ID` |
+| Vimeo | `vimeo.com/ID`, `player.vimeo.com/video/ID` |
+| Loom | `loom.com/share/ID`, `loom.com/embed/ID` |
+
+## Props
+
+<ParamFieldGroup>
+  <ParamField name="url" type="string" required>
+    YouTube, Vimeo 또는 Loom 비디오 URL
+  </ParamField>
+  <ParamField name="title" type="string">
+    iframe의 접근성 제목 (기본값: 제공자 이름)
+  </ParamField>
+  <ParamField name="caption" type="string">
+    비디오 아래에 표시되는 캡션 텍스트
+  </ParamField>
+  <ParamField name="client:load" type="directive" required>
+    클라이언트 사이드 인터랙티비티를 위한 Astro 디렉티브
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/ko/guides/plugins/analytics.mdx
+++ b/docs/src/content/docs/ko/guides/plugins/analytics.mdx
@@ -1,0 +1,94 @@
+---
+title: 분석 플러그인
+description: 문서 사이트에 분석 추적 추가
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+분석 플러그인은 문서 사이트에 추적 스크립트를 삽입합니다. Google Analytics, Plausible, Umami를 지원합니다.
+
+## 설치
+
+```bash
+pnpm add @barodoc/plugin-analytics@latest
+```
+
+## Google Analytics
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-analytics", {
+      "provider": "google",
+      "id": "G-XXXXXXXXXX"
+    }]
+  ]
+}
+```
+
+## Plausible
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-analytics", {
+      "provider": "plausible",
+      "domain": "docs.example.com"
+    }]
+  ]
+}
+```
+
+## Umami
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-analytics", {
+      "provider": "umami",
+      "websiteId": "your-website-id",
+      "src": "https://analytics.example.com/umami.js"
+    }]
+  ]
+}
+```
+
+## 옵션
+
+### Google Analytics
+
+<ParamFieldGroup>
+  <ParamField name="provider" type="'google'" required>
+    `"google"`로 설정
+  </ParamField>
+  <ParamField name="id" type="string" required>
+    Google Analytics 측정 ID (예: `"G-XXXXXXXXXX"`)
+  </ParamField>
+</ParamFieldGroup>
+
+### Plausible
+
+<ParamFieldGroup>
+  <ParamField name="provider" type="'plausible'" required>
+    `"plausible"`로 설정
+  </ParamField>
+  <ParamField name="domain" type="string" required>
+    사이트 도메인
+  </ParamField>
+  <ParamField name="src" type="string">
+    Plausible 스크립트 URL. 기본값: `"https://plausible.io/js/script.js"`
+  </ParamField>
+</ParamFieldGroup>
+
+### Umami
+
+<ParamFieldGroup>
+  <ParamField name="provider" type="'umami'" required>
+    `"umami"`로 설정
+  </ParamField>
+  <ParamField name="websiteId" type="string" required>
+    Umami 웹사이트 ID
+  </ParamField>
+  <ParamField name="src" type="string" required>
+    Umami 스크립트 URL
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/ko/guides/plugins/docsearch.mdx
+++ b/docs/src/content/docs/ko/guides/plugins/docsearch.mdx
@@ -1,0 +1,53 @@
+---
+title: DocSearch 플러그인
+description: Algolia DocSearch 고급 검색 연동
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+DocSearch 플러그인은 [Algolia DocSearch](https://docsearch.algolia.com)를 문서 사이트에 연동하여 기본 Pagefind 검색을 Algolia의 AI 기반 검색으로 교체합니다.
+
+## 설치
+
+```bash
+pnpm add @barodoc/plugin-docsearch@latest
+```
+
+## 사전 요구사항
+
+[docsearch.algolia.com](https://docsearch.algolia.com/apply)에서 DocSearch를 신청하세요. 승인 후 `appId`, `apiKey`, `indexName`을 받게 됩니다.
+
+## 설정
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-docsearch", {
+      "appId": "YOUR_APP_ID",
+      "apiKey": "YOUR_SEARCH_API_KEY",
+      "indexName": "your_index_name"
+    }]
+  ]
+}
+```
+
+활성화되면 DocSearch 플러그인이 기본 Pagefind 검색을 자동으로 비활성화하고 Algolia 검색 모달로 교체합니다.
+
+## 옵션
+
+<ParamFieldGroup>
+  <ParamField name="appId" type="string" required>
+    Algolia 애플리케이션 ID
+  </ParamField>
+  <ParamField name="apiKey" type="string" required>
+    Algolia 검색 전용 API 키 (관리자 키가 아님)
+  </ParamField>
+  <ParamField name="indexName" type="string" required>
+    Algolia 인덱스 이름
+  </ParamField>
+  <ParamField name="container" type="string">
+    검색 컨테이너 요소의 CSS 셀렉터. 기본값: `"#docsearch"`
+  </ParamField>
+  <ParamField name="placeholder" type="string">
+    검색 입력 플레이스홀더 텍스트. 기본값: `"Search docs..."`
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/ko/guides/plugins/llms-txt.mdx
+++ b/docs/src/content/docs/ko/guides/plugins/llms-txt.mdx
@@ -1,0 +1,49 @@
+---
+title: LLMs.txt 플러그인
+description: AI 친화적 문서를 위한 llms.txt 생성
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+LLMs.txt 플러그인은 [llms.txt 사양](https://llmstxt.org)에 따라 `llms.txt`와 `llms-full.txt` 파일을 생성합니다. 이 파일들은 AI 어시스턴트와 대규모 언어 모델이 문서를 쉽게 소비할 수 있게 합니다.
+
+## 설치
+
+```bash
+pnpm add @barodoc/plugin-llms-txt@latest
+```
+
+## 설정
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-llms-txt", {
+      "description": "My Project 문서",
+      "full": true,
+      "links": [
+        { "title": "GitHub", "url": "https://github.com/user/repo" },
+        { "title": "API Reference", "url": "https://docs.example.com/api" }
+      ]
+    }]
+  ]
+}
+```
+
+## 생성되는 파일
+
+- **`llms.txt`** — 페이지 제목, 설명, 링크가 포함된 요약
+- **`llms-full.txt`** — 모든 문서 페이지의 전체 내용 (`full: true` 설정 시)
+
+## 옵션
+
+<ParamFieldGroup>
+  <ParamField name="description" type="string">
+    llms.txt 헤더의 사이트 설명. 기본값: 사이트 이름
+  </ParamField>
+  <ParamField name="full" type="boolean">
+    전체 페이지 내용이 포함된 `llms-full.txt` 생성 여부. 기본값: `true`
+  </ParamField>
+  <ParamField name="links" type="Array<{ title, url, description? }>">
+    포함할 추가 링크 (예: GitHub 저장소, API 문서)
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/ko/guides/plugins/og-image.mdx
+++ b/docs/src/content/docs/ko/guides/plugins/og-image.mdx
@@ -1,0 +1,57 @@
+---
+title: OG 이미지 플러그인
+description: 소셜 공유용 Open Graph 이미지 자동 생성
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+OG 이미지 플러그인은 빌드 시 각 문서 페이지의 Open Graph 이미지를 생성합니다. 이 이미지는 Twitter, Facebook, Slack 등 소셜 미디어에서 문서를 공유할 때 표시됩니다.
+
+## 설치
+
+```bash
+pnpm add @barodoc/plugin-og-image@latest
+```
+
+## 설정
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-og-image", {
+      "background": "#ffffff",
+      "textColor": "#0f172a",
+      "accentColor": "#0070f3"
+    }]
+  ]
+}
+```
+
+생성된 이미지는 `dist/og/`에 배치되며 `<meta property="og:image">` 태그로 자동 연결됩니다.
+
+각 이미지에 포함되는 내용:
+- 사이트 이름 (액센트 색상)
+- 페이지 제목
+- 페이지 설명
+
+## 옵션
+
+<ParamFieldGroup>
+  <ParamField name="fontPath" type="string">
+    텍스트 렌더링용 TTF/OTF 폰트 파일 경로. 시스템 기본 폰트로 대체
+  </ParamField>
+  <ParamField name="background" type="string">
+    배경색. 기본값: `"#ffffff"`
+  </ParamField>
+  <ParamField name="textColor" type="string">
+    제목과 설명의 텍스트 색상. 기본값: `"#0f172a"`
+  </ParamField>
+  <ParamField name="accentColor" type="string">
+    사이트 이름의 액센트 색상. 기본값: `"#0070f3"`
+  </ParamField>
+  <ParamField name="width" type="number">
+    이미지 너비 (픽셀). 기본값: `1200`
+  </ParamField>
+  <ParamField name="height" type="number">
+    이미지 높이 (픽셀). 기본값: `630`
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/ko/guides/plugins/openapi.mdx
+++ b/docs/src/content/docs/ko/guides/plugins/openapi.mdx
@@ -1,0 +1,104 @@
+---
+title: OpenAPI 플러그인
+description: OpenAPI/Swagger 스펙에서 API 문서를 자동 생성
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+OpenAPI 플러그인은 OpenAPI (Swagger) 스펙 파일에서 API 문서 페이지를 자동으로 생성합니다. 문서에서 직접 엔드포인트를 테스트할 수 있는 인터랙티브 API Playground가 포함됩니다.
+
+## 설치
+
+```bash
+pnpm add @barodoc/plugin-openapi@latest
+```
+
+## 설정
+
+`barodoc.config.json`에 플러그인을 추가합니다:
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-openapi", {
+      "specFile": "openapi.yaml",
+      "basePath": "api",
+      "groupBy": "tags",
+      "baseUrl": "https://api.example.com",
+      "playground": true
+    }]
+  ]
+}
+```
+
+## 스펙 파일
+
+OpenAPI 스펙 파일 (YAML 또는 JSON)을 docs 루트 디렉토리에 배치합니다:
+
+```
+docs/
+├── openapi.yaml    ← 스펙 파일
+├── barodoc.config.json
+└── src/
+```
+
+OpenAPI 3.0+ 스펙을 지원합니다. 경로, 오퍼레이션, 파라미터, 요청 본문, 응답 스키마, 예제를 읽습니다.
+
+## 생성되는 결과물
+
+플러그인은 태그(또는 경로)별로 그룹화된 MDX 페이지를 생성합니다. 각 페이지에는 다음이 포함됩니다:
+
+- **엔드포인트 헤더**: 메서드 배지, 경로, 설명
+- **엔드포인트 목차**: 상단에서 빠른 네비게이션
+- **파라미터 테이블**: 이름, 타입, 필수 여부, enum 값
+- **요청 본문 스키마**: 필드 설명 포함
+- **응답 예제**: 스키마에서 자동 생성
+- **cURL 요청 예제**
+- **인터랙티브 API Playground** (`playground: true` 설정 시)
+
+## API Playground 기능
+
+생성된 Playground는 다음을 지원합니다:
+
+- **다중 인증 방식**: Bearer Token, API Key, Basic Auth
+- **Enum 드롭다운**: enum 값이 있는 파라미터는 `<select>` 드롭다운으로 렌더링
+- **JSON 본문 유효성 검증**: 전송 전 요청 본문 검증
+- **코드 스니펫**: cURL, JavaScript, Python, Node.js
+- **응답 인스펙터**: JSON 구문 강조, 헤더, 상태, 시간, 크기 표시
+- **요청 히스토리**: 최근 5건의 요청을 IndexedDB에 저장
+
+## 네비게이션
+
+생성된 페이지를 네비게이션에 추가합니다:
+
+```json
+{
+  "navigation": [
+    {
+      "group": "API Reference",
+      "pages": ["api/pet", "api/store", "api/user"]
+    }
+  ]
+}
+```
+
+페이지 슬러그는 스펙의 태그 이름을 소문자로 변환하고 하이픈으로 연결한 값입니다.
+
+## 옵션
+
+<ParamFieldGroup>
+  <ParamField name="specFile" type="string" required>
+    docs 루트 기준 OpenAPI 스펙 파일 경로 (YAML 또는 JSON)
+  </ParamField>
+  <ParamField name="basePath" type="string">
+    생성될 API 문서 페이지의 기본 경로. 기본값: `"api"`
+  </ParamField>
+  <ParamField name="groupBy" type="'tags' | 'paths'">
+    엔드포인트 그룹화 방식. 기본값: `"tags"`
+  </ParamField>
+  <ParamField name="baseUrl" type="string">
+    Playground에서 API 요청에 사용할 기본 URL. 기본값: `""`
+  </ParamField>
+  <ParamField name="playground" type="boolean">
+    인터랙티브 API Playground 활성화 여부. 기본값: `true`
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/ko/guides/plugins/pwa.mdx
+++ b/docs/src/content/docs/ko/guides/plugins/pwa.mdx
@@ -1,0 +1,56 @@
+---
+title: PWA 플러그인
+description: 오프라인 접근이 가능한 Progressive Web App 지원 추가
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+PWA 플러그인은 문서 사이트에 오프라인 접근, 설치 가능성, 웹 앱 매니페스트 등 Progressive Web App 기능을 추가합니다.
+
+## 설치
+
+```bash
+pnpm add @barodoc/plugin-pwa@latest
+```
+
+## 설정
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-pwa", {
+      "name": "My Docs",
+      "shortName": "Docs",
+      "themeColor": "#0070f3",
+      "backgroundColor": "#ffffff",
+      "display": "standalone"
+    }]
+  ]
+}
+```
+
+플러그인이 생성하는 파일:
+- `manifest.json` — 이름, 아이콘, 디스플레이 모드가 포함된 웹 앱 매니페스트
+- `sw.js` — 오프라인 캐싱을 위한 서비스 워커
+
+## 옵션
+
+<ParamFieldGroup>
+  <ParamField name="name" type="string">
+    전체 앱 이름. 기본값: config의 사이트 이름
+  </ParamField>
+  <ParamField name="shortName" type="string">
+    홈 화면용 짧은 앱 이름. 기본값: `name`
+  </ParamField>
+  <ParamField name="themeColor" type="string">
+    브라우저 크롬 테마 색상. 기본값: `"#2563eb"`
+  </ParamField>
+  <ParamField name="backgroundColor" type="string">
+    스플래시 화면 배경색. 기본값: `"#ffffff"`
+  </ParamField>
+  <ParamField name="display" type="'standalone' | 'fullscreen' | 'minimal-ui' | 'browser'">
+    디스플레이 모드. 기본값: `"standalone"`
+  </ParamField>
+  <ParamField name="offlineFallback" type="string">
+    오프라인 상태에서 캐시되지 않은 페이지 요청 시 표시할 페이지. 기본값: `"/404"`
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/ko/guides/plugins/rss.mdx
+++ b/docs/src/content/docs/ko/guides/plugins/rss.mdx
@@ -1,0 +1,41 @@
+---
+title: RSS 플러그인
+description: 블로그 및 변경 로그용 RSS 피드 생성
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+RSS 플러그인은 `/rss.xml`에 RSS 피드를 생성하여 사용자가 블로그나 변경 로그의 업데이트를 구독할 수 있게 합니다.
+
+## 설치
+
+```bash
+pnpm add @barodoc/plugin-rss@latest
+```
+
+## 설정
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-rss", {
+      "title": "문서 업데이트",
+      "description": "문서의 최신 업데이트",
+      "collections": ["blog", "changelog"]
+    }]
+  ]
+}
+```
+
+## 옵션
+
+<ParamFieldGroup>
+  <ParamField name="title" type="string">
+    피드 제목. 기본값: config의 사이트 이름
+  </ParamField>
+  <ParamField name="description" type="string">
+    피드 설명. 기본값: `"Latest updates"`
+  </ParamField>
+  <ParamField name="collections" type="('blog' | 'changelog')[]">
+    피드에 포함할 콘텐츠 컬렉션. 기본값: `["blog"]`
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/ko/guides/plugins/search.mdx
+++ b/docs/src/content/docs/ko/guides/plugins/search.mdx
@@ -1,0 +1,44 @@
+---
+title: 검색 플러그인
+description: Pagefind 기반 전문 검색
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+검색 플러그인은 [Pagefind](https://pagefind.app) 기반의 전문 검색을 제공합니다. 빌드 시 문서를 인덱싱하고 빠른 클라이언트 사이드 검색 경험을 제공합니다.
+
+## 설치
+
+```bash
+pnpm add @barodoc/plugin-search@latest
+```
+
+## 설정
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-search", {
+      "enabled": true,
+      "pagefind": {
+        "exclude": ["api/*"]
+      }
+    }]
+  ]
+}
+```
+
+검색은 기본적으로 활성화됩니다. 검색 UI는 테마에 내장되어 있으며 헤더의 검색 바 또는 `Ctrl+K` / `Cmd+K` 단축키로 접근할 수 있습니다.
+
+## 옵션
+
+<ParamFieldGroup>
+  <ParamField name="enabled" type="boolean">
+    검색 활성화 여부. 기본값: `true`
+  </ParamField>
+  <ParamField name="pagefind.baseUrl" type="string">
+    Pagefind 인덱스 기본 URL
+  </ParamField>
+  <ParamField name="pagefind.exclude" type="string[]">
+    검색 인덱스에서 제외할 페이지의 glob 패턴
+  </ParamField>
+</ParamFieldGroup>

--- a/docs/src/content/docs/ko/guides/plugins/sitemap.mdx
+++ b/docs/src/content/docs/ko/guides/plugins/sitemap.mdx
@@ -1,0 +1,46 @@
+---
+title: 사이트맵 플러그인
+description: 검색 엔진용 sitemap.xml 자동 생성
+---
+import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+
+사이트맵 플러그인은 빌드 시 `sitemap.xml` 파일을 생성하여 검색 엔진이 문서 페이지를 찾고 인덱싱할 수 있도록 합니다.
+
+## 설치
+
+```bash
+pnpm add @barodoc/plugin-sitemap@latest
+```
+
+## 설정
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-sitemap", {
+      "exclude": ["/404", "/api/*"],
+      "customPages": ["https://docs.example.com/changelog"]
+    }]
+  ]
+}
+```
+
+사이트맵은 빌드 출력에 `sitemap-index.xml`과 `sitemap-0.xml`로 생성됩니다. 절대 URL을 위해 config에 `site` 옵션을 설정하세요:
+
+```json
+{
+  "site": "https://docs.example.com",
+  "plugins": ["@barodoc/plugin-sitemap"]
+}
+```
+
+## 옵션
+
+<ParamFieldGroup>
+  <ParamField name="exclude" type="string[]">
+    사이트맵에서 제외할 페이지의 glob 패턴
+  </ParamField>
+  <ParamField name="customPages" type="string[]">
+    사이트맵에 포함할 추가 전체 URL
+  </ParamField>
+</ParamFieldGroup>


### PR DESCRIPTION
## Summary

- Add EN/KO documentation pages for **Video** component (YouTube, Vimeo, Loom embedding)
- Add EN/KO documentation pages for **ImageZoom** component (medium-zoom click-to-zoom)
- Add EN/KO plugin guide pages for all 9 plugins: openapi, search, analytics, sitemap, rss, pwa, og-image, llms-txt, docsearch
- Update `barodoc.config.json` navigation with new Components entries and a Plugins group

Total: 22 new MDX files + 1 config update

Closes #62

## Test plan

- [ ] Verify all 22 new docs pages render correctly in dev server
- [ ] Verify EN/KO locale switching works for each page
- [ ] Verify sidebar navigation shows Components and Plugins groups correctly


Made with [Cursor](https://cursor.com)