### PR TITLE
feat: add unit tests, fix CI pipeline, add docs and blog content

### DIFF
--- a/.changeset/testing-ci-docs-blog.md
+++ b/.changeset/testing-ci-docs-blog.md
@@ -1,0 +1,6 @@
+---
+"barodoc": patch
+"@barodoc/core": patch
+---
+
+Add unit test infrastructure with Vitest (38 tests), fix CI pipeline, add migration guide and troubleshooting docs, add sample blog posts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,7 @@ jobs:
         run: pnpm build:packages
 
       - name: Type check
-        run: pnpm -r exec tsc --noEmit || true
+        run: pnpm -r exec tsc --noEmit
+
+      - name: Run tests
+        run: pnpm test

--- a/docs/barodoc.config.json
+++ b/docs/barodoc.config.json
@@ -24,7 +24,7 @@
     {
       "group": "Guides",
       "group:ko": "가이드",
-      "pages": ["guides/installation", "guides/configuration", "guides/content-structure", "guides/cli", "guides/overrides", "guides/deployment", "guides/i18n"]
+      "pages": ["guides/installation", "guides/configuration", "guides/content-structure", "guides/cli", "guides/overrides", "guides/deployment", "guides/i18n", "guides/migration", "guides/troubleshooting"]
     },
     {
       "group": "Components",

--- a/docs/src/content/blog/introducing-barodoc.mdx
+++ b/docs/src/content/blog/introducing-barodoc.mdx
@@ -1,0 +1,51 @@
+---
+title: "Introducing Barodoc: Documentation Made Right"
+description: "Zero-config documentation framework built on Astro — beautiful docs in seconds."
+excerpt: "Meet Barodoc, the Mintlify-style documentation framework that lets you focus on content, not configuration."
+date: 2025-12-01
+author: "Barodoc Team"
+image: "/logo.svg"
+tags: ["announcement", "release"]
+---
+
+We're excited to introduce **Barodoc** — a documentation framework built for developers who want beautiful docs without the setup overhead.
+
+## Why Barodoc?
+
+Building documentation should be about writing great content, not fighting with build tools. That's why we created Barodoc with a simple philosophy: **just write Markdown**.
+
+### Zero Config, Full Power
+
+Drop your Markdown files in a folder and run:
+
+```bash
+barodoc serve docs
+```
+
+That's it. No `package.json`, no config files, no dependency installation. Barodoc handles everything behind the scenes.
+
+### When You Need More
+
+For advanced use cases, eject to a full Astro project with complete control over components, layouts, and pages:
+
+```bash
+barodoc eject
+```
+
+## Key Features
+
+- **MDX Support** — Use React components in your documentation
+- **Dark Mode** — Built-in with system preference detection
+- **i18n** — Multi-language support out of the box
+- **Search** — Full-text search powered by Pagefind
+- **Plugin System** — Extend with analytics, sitemaps, OpenAPI, and more
+
+## Get Started
+
+```bash
+barodoc create my-docs
+cd my-docs
+barodoc serve
+```
+
+Visit [the docs](/introduction) to learn more.

--- a/docs/src/content/blog/v6-release.mdx
+++ b/docs/src/content/blog/v6-release.mdx
@@ -1,0 +1,60 @@
+---
+title: "Barodoc v6: A Major Leap Forward"
+description: "Version 6 brings 12 new features including blog, changelog, API playground, and more."
+excerpt: "A deep dive into all the new features and improvements in Barodoc v6."
+date: 2026-01-15
+author: "Barodoc Team"
+tags: ["release", "v6"]
+---
+
+Barodoc v6 is our biggest release yet, introducing 12 new features that make your documentation even more powerful.
+
+## What's New
+
+### Blog & Changelog
+
+You're reading this on the new built-in blog! Barodoc now supports blog posts and changelogs as first-class content types. Create posts in `src/content/blog/` and they're automatically available at `/blog`.
+
+### API Playground
+
+Interactive API testing directly in your documentation. Users can try API endpoints without leaving the page.
+
+### KaTeX Math Support
+
+Render mathematical expressions beautifully:
+
+```
+$$E = mc^2$$
+```
+
+### Image Zoom
+
+Click any image to view it full-screen with smooth zoom transitions.
+
+### Video Embeds
+
+Embed videos from YouTube, Vimeo, or self-hosted sources with a simple component.
+
+### Reading Time
+
+Blog posts automatically show estimated reading time.
+
+### Keyboard Shortcuts
+
+Navigate docs faster with keyboard shortcuts — press `⌘K` to search.
+
+### Contributors
+
+Show contributors at the bottom of each page, pulled from Git history.
+
+### PWA Support
+
+Install your documentation as a Progressive Web App for offline access.
+
+## Upgrading
+
+```bash
+npm install barodoc@latest
+```
+
+See the [migration guide](/guides/migration) for detailed upgrade instructions.

--- a/docs/src/content/blog/writing-great-docs.mdx
+++ b/docs/src/content/blog/writing-great-docs.mdx
@@ -1,0 +1,71 @@
+---
+title: "Tips for Writing Great Documentation"
+description: "Practical advice for creating documentation that developers actually want to read."
+excerpt: "Learn the principles behind effective technical documentation and how to apply them."
+date: 2026-02-10
+author: "Barodoc Team"
+tags: ["guide", "writing"]
+---
+
+Great documentation isn't just about having the right information — it's about presenting it in a way that respects your readers' time.
+
+## Start With Why
+
+Before diving into how, explain **why**. Developers need to understand the purpose of a feature before learning its API.
+
+```mdx
+## Authentication
+
+Barodoc uses token-based auth to keep your API 
+stateless and horizontally scalable.
+```
+
+Compare with a less effective approach:
+
+```mdx
+## Authentication
+
+Call `POST /auth/login` with username and password.
+```
+
+The first version helps readers decide if this is even the right approach for them.
+
+## Use Progressive Disclosure
+
+Don't dump everything on the reader at once. Start with the simplest case and layer complexity:
+
+1. **Quick Start** — The happy path, 5 minutes
+2. **Guides** — Common use cases with context
+3. **API Reference** — Complete details for every option
+
+## Show, Don't Just Tell
+
+A code example is worth a thousand words of explanation.
+
+```typescript
+// Good: Shows real usage
+const config = {
+  name: "My Docs",
+  theme: { colors: { primary: "#0070f3" } },
+  navigation: [
+    { group: "Guides", pages: ["quickstart", "setup"] }
+  ]
+};
+```
+
+## Keep Pages Focused
+
+Each page should answer **one question**. If you find yourself writing "See also..." frequently, consider splitting the page.
+
+## Write for Scanners
+
+Most readers scan before reading. Help them:
+
+- Use descriptive headings
+- Bold key terms on first use
+- Use tables for reference data
+- Keep paragraphs short (3-4 lines max)
+
+## Test Your Docs
+
+The best way to find gaps in documentation: follow your own instructions on a fresh machine. If you get stuck, your users will too.

--- a/docs/src/content/docs/en/guides/migration.mdx
+++ b/docs/src/content/docs/en/guides/migration.mdx
@@ -1,0 +1,165 @@
+---
+title: Migration Guide
+description: Migrate to Barodoc from other documentation frameworks.
+---
+
+import { Callout, Tabs, Tab, Steps, Step } from "@barodoc/theme-docs";
+
+# Migration Guide
+
+Moving to Barodoc from another documentation framework? This guide walks you through the key differences and steps for a smooth migration.
+
+## From Docusaurus
+
+<Steps>
+  <Step title="Create a Barodoc project">
+    ```bash
+    barodoc create my-docs
+    ```
+  </Step>
+  <Step title="Move your content">
+    Copy your Markdown/MDX files from `docs/` into `docs/en/` (or your locale folder).
+    
+    ```bash
+    cp -r old-project/docs/* my-docs/docs/en/
+    ```
+  </Step>
+  <Step title="Update frontmatter">
+    Docusaurus uses `sidebar_position` and `sidebar_label`. In Barodoc, navigation order is controlled by `barodoc.config.json`:
+
+    ```diff
+    ---
+    - sidebar_position: 1
+    - sidebar_label: "Getting Started"
+    + title: Getting Started
+    ---
+    ```
+
+    You can remove Docusaurus-specific frontmatter fields. Barodoc only requires `title` (or a `# Heading`).
+  </Step>
+  <Step title="Configure navigation">
+    Replace Docusaurus `sidebars.js` with `barodoc.config.json` navigation:
+
+    ```json
+    {
+      "navigation": [
+        {
+          "group": "Getting Started",
+          "pages": ["introduction", "quickstart"]
+        }
+      ]
+    }
+    ```
+  </Step>
+  <Step title="Update MDX components">
+    Replace Docusaurus components with Barodoc equivalents:
+
+    | Docusaurus | Barodoc |
+    |------------|---------|
+    | `:::note` / `:::tip` / `:::warning` | `<Callout type="note">` / `<Callout type="tip">` / `<Callout type="warning">` |
+    | `<Tabs>` / `<TabItem>` | `<Tabs>` / `<Tab>` |
+    | `<details>` | `<Accordion>` |
+    | `@theme/CodeBlock` | Fenced code blocks (built-in) |
+  </Step>
+</Steps>
+
+## From GitBook
+
+<Steps>
+  <Step title="Export your content">
+    Export your GitBook space as Markdown files. GitBook provides this in **Space Settings → Export**.
+  </Step>
+  <Step title="Create a Barodoc project">
+    ```bash
+    barodoc create my-docs
+    ```
+  </Step>
+  <Step title="Reorganize files">
+    GitBook uses `SUMMARY.md` for navigation. In Barodoc, move your content into `docs/en/` and define navigation in `barodoc.config.json`:
+
+    ```json
+    {
+      "navigation": [
+        {
+          "group": "Overview",
+          "pages": ["introduction", "quickstart"]
+        },
+        {
+          "group": "Guides",
+          "pages": ["guides/setup", "guides/deployment"]
+        }
+      ]
+    }
+    ```
+    
+    Delete `SUMMARY.md` — it's no longer needed.
+  </Step>
+  <Step title="Update image paths">
+    GitBook often stores images in `.gitbook/assets/`. Move them to `public/` and update references:
+
+    ```diff
+    - ![Screenshot](.gitbook/assets/screenshot.png)
+    + ![Screenshot](/images/screenshot.png)
+    ```
+  </Step>
+</Steps>
+
+## From Mintlify
+
+Barodoc's configuration is designed to be familiar if you've used Mintlify.
+
+<Steps>
+  <Step title="Copy your content">
+    Your MDX files can be used largely as-is. Copy them into `docs/en/`.
+  </Step>
+  <Step title="Convert mint.json to barodoc.config.json">
+    The structure is very similar:
+
+    ```diff
+    // mint.json → barodoc.config.json
+    {
+    -  "name": "My Docs",
+    -  "navigation": [
+    -    { "group": "Guides", "pages": ["quickstart"] }
+    -  ],
+    -  "colors": { "primary": "#0070f3" }
+    +  "name": "My Docs",
+    +  "navigation": [
+    +    { "group": "Guides", "pages": ["quickstart"] }
+    +  ],
+    +  "theme": { "colors": { "primary": "#0070f3" } }
+    }
+    ```
+
+    Key differences:
+    - Colors are nested under `theme.colors` instead of top-level `colors`
+    - `anchors` → use `topbar` for external links
+    - `tabs` → use navigation groups
+  </Step>
+  <Step title="Update components">
+    Most Mintlify components have direct equivalents:
+
+    | Mintlify | Barodoc |
+    |----------|---------|
+    | `<Note>` / `<Warning>` / `<Tip>` | `<Callout type="note">` / `<Callout type="warning">` / `<Callout type="tip">` |
+    | `<Card>` / `<CardGroup>` | `<Card>` / `<CardGroup>` (same) |
+    | `<Tabs>` / `<Tab>` | `<Tabs>` / `<Tab>` (same) |
+    | `<Steps>` / `<Step>` | `<Steps>` / `<Step>` (same) |
+    | `<Accordion>` | `<Accordion>` (same) |
+    | `<CodeGroup>` | `<CodeGroup>` (same) |
+    | `<ParamField>` | `<ParamField>` (same) |
+    | `<ResponseField>` | `<ResponseField>` (same) |
+    | `<Expandable>` | `<Expandable>` (same) |
+  </Step>
+</Steps>
+
+<Callout type="tip">
+  Many Mintlify components work in Barodoc without any changes since Barodoc was designed with Mintlify API compatibility in mind.
+</Callout>
+
+## Common Migration Tips
+
+- **Frontmatter is optional**: If your file starts with `# Title`, Barodoc extracts the title automatically — no frontmatter needed.
+- **Static assets**: Place images, fonts, and other assets in the `public/` directory.
+- **Plugins**: Add search, analytics, sitemap, etc. via the `plugins` array in config.
+- **Testing**: Run `barodoc check` to validate your docs structure after migration.

--- a/docs/src/content/docs/en/guides/troubleshooting.mdx
+++ b/docs/src/content/docs/en/guides/troubleshooting.mdx
@@ -1,0 +1,246 @@
+---
+title: Troubleshooting
+description: Solutions for common issues when working with Barodoc.
+---
+
+import { Callout, Accordion, AccordionGroup } from "@barodoc/theme-docs";
+
+# Troubleshooting
+
+Common issues and their solutions.
+
+## Setup & Installation
+
+<AccordionGroup>
+  <Accordion title="'Config file not found' error">
+    Make sure `barodoc.config.json` exists in your project root (or the directory you're running from).
+
+    ```bash
+    # Verify the file exists
+    ls barodoc.config.json
+
+    # Or specify the config path explicitly
+    barodoc serve --config ./path/to/barodoc.config.json
+    ```
+  </Accordion>
+
+  <Accordion title="'Unsupported Node.js version' error">
+    Barodoc requires **Node.js 20 or later**. Check your version:
+
+    ```bash
+    node --version
+    ```
+
+    If you're using a version manager, switch to Node 20+:
+
+    ```bash
+    # nvm
+    nvm install 20
+    nvm use 20
+
+    # fnm
+    fnm use 20
+    ```
+  </Accordion>
+
+  <Accordion title="Port already in use">
+    Use a different port:
+
+    ```bash
+    barodoc serve --port 4322
+    ```
+
+    Or kill the process using the default port:
+
+    ```bash
+    lsof -ti:4321 | xargs kill -9
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Content & Build
+
+<AccordionGroup>
+  <Accordion title="Pages not appearing in sidebar">
+    Pages must be listed in `barodoc.config.json` under `navigation`:
+
+    ```json
+    {
+      "navigation": [
+        {
+          "group": "Guides",
+          "pages": ["guides/my-new-page"]
+        }
+      ]
+    }
+    ```
+
+    The page path should match the file path relative to your docs locale folder, without the extension. For example, `docs/en/guides/my-new-page.mdx` becomes `"guides/my-new-page"`.
+  </Accordion>
+
+  <Accordion title="MDX component not rendering">
+    Make sure you're importing the component at the top of your MDX file:
+
+    ```mdx
+    import { Callout, Card } from "@barodoc/theme-docs";
+
+    <Callout type="tip">
+      This will render correctly.
+    </Callout>
+    ```
+
+    <Callout type="warning">
+      MDX files must use `.mdx` extension (not `.md`) to use components.
+    </Callout>
+  </Accordion>
+
+  <Accordion title="Build fails with 'collection not found'">
+    If you're in **Full Custom Mode** (with `astro.config.mjs`), make sure your content collections are defined in `src/content/config.ts`:
+
+    ```typescript
+    import { defineCollection, z } from "astro:content";
+
+    const docsCollection = defineCollection({
+      type: "content",
+      schema: z.object({
+        title: z.string(),
+        description: z.string().optional(),
+      }),
+    });
+
+    export const collections = { docs: docsCollection };
+    ```
+
+    In **Quick Mode**, this is handled automatically.
+  </Accordion>
+
+  <Accordion title="Images not loading">
+    Static assets should be placed in the `public/` directory:
+
+    ```
+    my-docs/
+    ├── public/
+    │   └── images/
+    │       └── screenshot.png   ← here
+    └── docs/
+        └── en/
+            └── guide.mdx        ← references /images/screenshot.png
+    ```
+
+    Reference them with absolute paths:
+
+    ```mdx
+    ![Screenshot](/images/screenshot.png)
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## i18n
+
+<AccordionGroup>
+  <Accordion title="Translations not showing up">
+    Ensure your folder structure matches the configured locales:
+
+    ```json
+    {
+      "i18n": {
+        "defaultLocale": "en",
+        "locales": ["en", "ko"]
+      }
+    }
+    ```
+
+    Each locale needs its own directory with matching file paths:
+
+    ```
+    docs/
+    ├── en/
+    │   └── guides/setup.mdx
+    └── ko/
+        └── guides/setup.mdx   ← same path structure
+    ```
+  </Accordion>
+
+  <Accordion title="Language switcher not appearing">
+    The language switcher only appears when **more than one locale** is configured in `barodoc.config.json`. Make sure `locales` has at least two entries.
+  </Accordion>
+</AccordionGroup>
+
+## Plugins
+
+<AccordionGroup>
+  <Accordion title="Search not working after build">
+    Search is powered by Pagefind, which indexes your site **during the build step**. Make sure you:
+
+    1. Run a full build: `barodoc build`
+    2. Preview the build: `barodoc preview`
+
+    Search won't work in dev mode — it only works on built output.
+  </Accordion>
+
+  <Accordion title="OpenAPI spec not generating pages">
+    Check your plugin configuration:
+
+    ```json
+    {
+      "plugins": [
+        ["@barodoc/plugin-openapi", {
+          "specFile": "openapi.yaml",
+          "basePath": "api"
+        }]
+      ]
+    }
+    ```
+
+    The `specFile` path is relative to your project root. Verify the file exists and is valid YAML/JSON.
+  </Accordion>
+
+  <Accordion title="Analytics not tracking">
+    Ensure you've provided the correct tracking ID for your provider:
+
+    ```json
+    {
+      "plugins": [
+        ["@barodoc/plugin-analytics", {
+          "google": { "measurementId": "G-XXXXXXXXXX" },
+          "plausible": { "domain": "docs.example.com" }
+        }]
+      ]
+    }
+    ```
+
+    Analytics scripts are only injected in production builds, not during development.
+  </Accordion>
+</AccordionGroup>
+
+## Deployment
+
+<AccordionGroup>
+  <Accordion title="Blank page after deploying to GitHub Pages">
+    If your docs are hosted at a subpath (e.g., `username.github.io/my-docs/`), set the `base` option:
+
+    ```json
+    {
+      "base": "/my-docs"
+    }
+    ```
+
+    Without this, asset paths will resolve incorrectly.
+  </Accordion>
+
+  <Accordion title="404 on page refresh (SPA-like behavior)">
+    Barodoc generates static HTML files. Configure your hosting provider to serve `index.html` for directory routes:
+
+    - **Netlify**: Add `_redirects` file with `/* /index.html 200`
+    - **Vercel**: Works automatically
+    - **GitHub Pages**: Works automatically for static files
+  </Accordion>
+</AccordionGroup>
+
+## Still stuck?
+
+If your issue isn't covered here:
+
+1. Run `barodoc check` to validate your project
+2. Check the [GitHub Issues](https://github.com/barocss/barodoc/issues) for similar reports
+3. Open a new issue with your error message and config

--- a/docs/src/content/docs/ko/guides/migration.mdx
+++ b/docs/src/content/docs/ko/guides/migration.mdx
@@ -1,0 +1,91 @@
+---
+title: 마이그레이션 가이드
+description: 다른 문서 프레임워크에서 Barodoc으로 마이그레이션하는 방법을 안내합니다.
+---
+
+import { Callout, Tabs, Tab, Steps, Step } from "@barodoc/theme-docs";
+
+# 마이그레이션 가이드
+
+다른 문서 프레임워크에서 Barodoc으로 이전하시나요? 주요 차이점과 단계를 안내합니다.
+
+## Docusaurus에서 이전
+
+<Steps>
+  <Step title="Barodoc 프로젝트 생성">
+    ```bash
+    barodoc create my-docs
+    ```
+  </Step>
+  <Step title="콘텐츠 이동">
+    Markdown/MDX 파일을 `docs/en/` (또는 해당 로캘 폴더)으로 복사합니다.
+    
+    ```bash
+    cp -r old-project/docs/* my-docs/docs/en/
+    ```
+  </Step>
+  <Step title="프론트매터 업데이트">
+    Docusaurus의 `sidebar_position`, `sidebar_label`은 Barodoc에서 `barodoc.config.json`으로 대체됩니다:
+
+    ```diff
+    ---
+    - sidebar_position: 1
+    - sidebar_label: "시작하기"
+    + title: 시작하기
+    ---
+    ```
+  </Step>
+  <Step title="네비게이션 설정">
+    Docusaurus의 `sidebars.js`를 `barodoc.config.json`의 navigation으로 대체합니다:
+
+    ```json
+    {
+      "navigation": [
+        {
+          "group": "시작하기",
+          "pages": ["introduction", "quickstart"]
+        }
+      ]
+    }
+    ```
+  </Step>
+  <Step title="MDX 컴포넌트 변환">
+    | Docusaurus | Barodoc |
+    |------------|---------|
+    | `:::note` / `:::tip` / `:::warning` | `<Callout type="note">` / `<Callout type="tip">` / `<Callout type="warning">` |
+    | `<Tabs>` / `<TabItem>` | `<Tabs>` / `<Tab>` |
+    | `<details>` | `<Accordion>` |
+  </Step>
+</Steps>
+
+## Mintlify에서 이전
+
+Barodoc은 Mintlify와 호환되도록 설계되어 대부분의 컴포넌트가 그대로 동작합니다.
+
+<Steps>
+  <Step title="콘텐츠 복사">
+    MDX 파일을 `docs/en/`으로 복사합니다.
+  </Step>
+  <Step title="설정 파일 변환">
+    ```diff
+    // mint.json → barodoc.config.json
+    {
+    -  "colors": { "primary": "#0070f3" }
+    +  "theme": { "colors": { "primary": "#0070f3" } }
+    }
+    ```
+  </Step>
+  <Step title="컴포넌트 확인">
+    `Card`, `Tabs`, `Steps`, `Accordion`, `CodeGroup`, `ParamField`, `ResponseField` 등은 변경 없이 사용 가능합니다.
+  </Step>
+</Steps>
+
+<Callout type="tip">
+  Mintlify 컴포넌트 대부분이 Barodoc에서 변경 없이 동작합니다.
+</Callout>
+
+## 공통 팁
+
+- **프론트매터는 선택사항**: `# 제목`으로 시작하면 자동으로 제목이 추출됩니다.
+- **정적 에셋**: 이미지 등은 `public/` 디렉토리에 넣으세요.
+- **마이그레이션 후 검증**: `barodoc check`으로 문서 구조를 검증할 수 있습니다.

--- a/docs/src/content/docs/ko/guides/troubleshooting.mdx
+++ b/docs/src/content/docs/ko/guides/troubleshooting.mdx
@@ -1,0 +1,103 @@
+---
+title: 문제 해결
+description: Barodoc 사용 시 자주 발생하는 문제와 해결 방법을 안내합니다.
+---
+
+import { Callout, Accordion, AccordionGroup } from "@barodoc/theme-docs";
+
+# 문제 해결
+
+자주 발생하는 문제와 해결 방법입니다.
+
+## 설정 & 설치
+
+<AccordionGroup>
+  <Accordion title="'Config file not found' 에러">
+    프로젝트 루트에 `barodoc.config.json`이 있는지 확인하세요.
+
+    ```bash
+    ls barodoc.config.json
+
+    # 또는 경로를 명시적으로 지정
+    barodoc serve --config ./path/to/barodoc.config.json
+    ```
+  </Accordion>
+
+  <Accordion title="Node.js 버전 에러">
+    Barodoc은 **Node.js 20 이상**이 필요합니다.
+
+    ```bash
+    node --version
+
+    # nvm 사용 시
+    nvm install 20 && nvm use 20
+    ```
+  </Accordion>
+
+  <Accordion title="포트 충돌">
+    ```bash
+    barodoc serve --port 4322
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## 콘텐츠 & 빌드
+
+<AccordionGroup>
+  <Accordion title="사이드바에 페이지가 안 보임">
+    `barodoc.config.json`의 `navigation`에 페이지를 추가해야 합니다:
+
+    ```json
+    {
+      "navigation": [
+        {
+          "group": "가이드",
+          "pages": ["guides/my-new-page"]
+        }
+      ]
+    }
+    ```
+
+    경로는 로캘 폴더 기준 상대 경로이며 확장자는 제외합니다.
+  </Accordion>
+
+  <Accordion title="MDX 컴포넌트가 렌더링되지 않음">
+    파일 상단에 import를 확인하세요:
+
+    ```mdx
+    import { Callout } from "@barodoc/theme-docs";
+    ```
+
+    <Callout type="warning">
+      컴포넌트를 사용하려면 `.md`가 아닌 `.mdx` 확장자를 사용해야 합니다.
+    </Callout>
+  </Accordion>
+
+  <Accordion title="이미지가 로드되지 않음">
+    정적 에셋은 `public/` 디렉토리에 넣고 절대 경로로 참조하세요:
+
+    ```mdx
+    ![스크린샷](/images/screenshot.png)
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## 배포
+
+<AccordionGroup>
+  <Accordion title="GitHub Pages 배포 후 빈 페이지">
+    서브 경로에 배포하는 경우 `base` 옵션을 설정하세요:
+
+    ```json
+    {
+      "base": "/my-docs"
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## 해결되지 않는 문제
+
+1. `barodoc check`으로 프로젝트 검증
+2. [GitHub Issues](https://github.com/barocss/barodoc/issues)에서 유사한 이슈 검색
+3. 에러 메시지와 설정을 포함해 새 이슈 등록

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev:docs": "pnpm --filter docs dev",
     "build": "pnpm --filter docs build",
     "build:packages": "pnpm --filter @barodoc/core --filter barodoc --filter create-barodoc --filter @barodoc/plugin-sitemap --filter @barodoc/plugin-search --filter @barodoc/plugin-analytics build",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "pnpm -r typecheck",
     "barodoc": "tsx packages/barodoc/src/cli.ts",
     "test:cli": "pnpm --filter barodoc build && node packages/barodoc/dist/cli.js",
@@ -30,7 +32,8 @@
   "devDependencies": {
     "@changesets/cli": "^2.27.0",
     "concurrently": "^9.2.1",
-    "tsx": "^4.21.0"
+    "tsx": "^4.21.0",
+    "vitest": "^4.0.18"
   },
   "pnpm": {
     "overrides": {

--- a/packages/barodoc/src/runtime/content.test.ts
+++ b/packages/barodoc/src/runtime/content.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { extractFrontmatter, processMarkdown, pathToSlug, getLocaleFromFilePath } from "./content.js";
+
+describe("extractFrontmatter", () => {
+  it("extracts YAML frontmatter", () => {
+    const md = `---
+title: Hello World
+description: A test doc
+---
+
+## Content here`;
+    const result = extractFrontmatter(md);
+    expect(result.data.title).toBe("Hello World");
+    expect(result.data.description).toBe("A test doc");
+  });
+
+  it("extracts title from first heading when no frontmatter title", () => {
+    const md = `# My Page Title
+
+This is the first paragraph.
+
+## Section`;
+    const result = extractFrontmatter(md);
+    expect(result.data.title).toBe("My Page Title");
+    expect(result.data.description).toBe("This is the first paragraph.");
+  });
+
+  it("returns 'Untitled' when no title or heading found", () => {
+    const md = `Just some content without a heading.`;
+    const result = extractFrontmatter(md);
+    expect(result.data.title).toBe("Untitled");
+  });
+
+  it("preserves extra frontmatter fields", () => {
+    const md = `---
+title: Test
+tags:
+  - guide
+  - setup
+---
+Content`;
+    const result = extractFrontmatter(md);
+    expect(result.data.tags).toEqual(["guide", "setup"]);
+  });
+});
+
+describe("processMarkdown", () => {
+  it("returns frontmatter and body", () => {
+    const md = `---
+title: Test Doc
+---
+
+Body content here`;
+    const result = processMarkdown("test.md", md);
+    expect(result.frontmatter.title).toBe("Test Doc");
+    expect(result.body).toContain("Body content here");
+  });
+});
+
+describe("pathToSlug", () => {
+  it("converts file path to slug", () => {
+    expect(pathToSlug("/docs/en/guides/setup.md", "/docs")).toBe("en/guides/setup");
+  });
+
+  it("handles .mdx extension", () => {
+    expect(pathToSlug("/docs/en/intro.mdx", "/docs")).toBe("en/intro");
+  });
+
+  it("strips leading slash after removing docsDir", () => {
+    expect(pathToSlug("/docs/introduction.md", "/docs")).toBe("introduction");
+  });
+});
+
+describe("getLocaleFromFilePath", () => {
+  it("returns locale when file is in a locale directory", () => {
+    expect(getLocaleFromFilePath("/docs/en/intro.md", "/docs", ["en", "ko"])).toBe("en");
+    expect(getLocaleFromFilePath("/docs/ko/guides/setup.md", "/docs", ["en", "ko"])).toBe("ko");
+  });
+
+  it("returns null when file is not in a locale directory", () => {
+    expect(getLocaleFromFilePath("/docs/intro.md", "/docs", ["en", "ko"])).toBeNull();
+  });
+
+  it("returns null for unknown locale", () => {
+    expect(getLocaleFromFilePath("/docs/fr/intro.md", "/docs", ["en", "ko"])).toBeNull();
+  });
+});

--- a/packages/core/src/i18n/utils.test.ts
+++ b/packages/core/src/i18n/utils.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import {
+  getLocaleFromPath,
+  removeLocaleFromPath,
+  getLocalizedPath,
+  getLocalizedNavGroup,
+  getLocaleLabel,
+  getAllLocalePaths,
+} from "./utils.js";
+
+const i18n = { defaultLocale: "en", locales: ["en", "ko", "ja"] };
+
+describe("getLocaleFromPath", () => {
+  it("returns locale when path starts with a known locale", () => {
+    expect(getLocaleFromPath("/ko/guides/setup", i18n)).toBe("ko");
+    expect(getLocaleFromPath("/ja/introduction", i18n)).toBe("ja");
+  });
+
+  it("returns default locale when path has no locale prefix", () => {
+    expect(getLocaleFromPath("/guides/setup", i18n)).toBe("en");
+    expect(getLocaleFromPath("/", i18n)).toBe("en");
+  });
+
+  it("returns default locale for unknown locale prefix", () => {
+    expect(getLocaleFromPath("/fr/docs", i18n)).toBe("en");
+  });
+});
+
+describe("removeLocaleFromPath", () => {
+  it("strips known locale prefix", () => {
+    expect(removeLocaleFromPath("/ko/guides/setup", i18n)).toBe("/guides/setup");
+    expect(removeLocaleFromPath("/ja/intro", i18n)).toBe("/intro");
+  });
+
+  it("leaves path unchanged when no locale prefix", () => {
+    expect(removeLocaleFromPath("/guides/setup", i18n)).toBe("/guides/setup");
+  });
+
+  it("leaves path unchanged for unknown locale", () => {
+    expect(removeLocaleFromPath("/fr/docs", i18n)).toBe("/fr/docs");
+  });
+});
+
+describe("getLocalizedPath", () => {
+  it("returns clean path for default locale", () => {
+    expect(getLocalizedPath("/ko/guides/setup", "en", i18n)).toBe("/guides/setup");
+  });
+
+  it("prefixes path with locale for non-default locale", () => {
+    expect(getLocalizedPath("/guides/setup", "ko", i18n)).toBe("/ko/guides/setup");
+  });
+
+  it("swaps locale prefix correctly", () => {
+    expect(getLocalizedPath("/ko/intro", "ja", i18n)).toBe("/ja/intro");
+  });
+});
+
+describe("getLocalizedNavGroup", () => {
+  const item = { group: "Guides", "group:ko": "가이드", pages: [] };
+
+  it("returns default group for default locale", () => {
+    expect(getLocalizedNavGroup(item, "en", "en")).toBe("Guides");
+  });
+
+  it("returns localized group for non-default locale", () => {
+    expect(getLocalizedNavGroup(item, "ko", "en")).toBe("가이드");
+  });
+
+  it("falls back to default group when translation is missing", () => {
+    expect(getLocalizedNavGroup(item, "ja", "en")).toBe("Guides");
+  });
+});
+
+describe("getLocaleLabel", () => {
+  it("returns custom label when provided", () => {
+    expect(getLocaleLabel("ko", { ko: "Korean" })).toBe("Korean");
+  });
+
+  it("returns built-in default label", () => {
+    expect(getLocaleLabel("ko")).toBe("한국어");
+    expect(getLocaleLabel("en")).toBe("English");
+    expect(getLocaleLabel("ja")).toBe("日本語");
+  });
+
+  it("returns uppercased locale code when no label exists", () => {
+    expect(getLocaleLabel("pt")).toBe("PT");
+  });
+});
+
+describe("getAllLocalePaths", () => {
+  it("returns paths for all locales", () => {
+    const paths = getAllLocalePaths("/guides/setup", i18n);
+    expect(paths).toEqual([
+      { locale: "en", path: "/guides/setup" },
+      { locale: "ko", path: "/ko/guides/setup" },
+      { locale: "ja", path: "/ja/guides/setup" },
+    ]);
+  });
+});

--- a/packages/core/src/theme/colors.test.ts
+++ b/packages/core/src/theme/colors.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { generateAccentScale, getGrayScale, generateThemeCSS } from "./colors.js";
+
+describe("generateAccentScale", () => {
+  it("generates a scale with all 11 steps", () => {
+    const scale = generateAccentScale("#0070f3");
+    const steps = ["50", "100", "200", "300", "400", "500", "600", "700", "800", "900", "950"];
+    for (const step of steps) {
+      expect(scale[step]).toBeDefined();
+      expect(scale[step]).toMatch(/^oklch\(/);
+    }
+  });
+
+  it("produces different hues for different colors", () => {
+    const blue = generateAccentScale("#0070f3");
+    const red = generateAccentScale("#ff0000");
+    expect(blue["500"]).not.toBe(red["500"]);
+  });
+
+  it("lighter steps have higher lightness values", () => {
+    const scale = generateAccentScale("#0070f3");
+    const l50 = parseFloat(scale["50"].match(/oklch\(([\d.]+)/)?.[1] ?? "0");
+    const l950 = parseFloat(scale["950"].match(/oklch\(([\d.]+)/)?.[1] ?? "0");
+    expect(l50).toBeGreaterThan(l950);
+  });
+});
+
+describe("getGrayScale", () => {
+  it("returns a scale for known presets", () => {
+    const zinc = getGrayScale("zinc");
+    expect(zinc).not.toBeNull();
+    expect(zinc!["500"]).toBe("#71717a");
+  });
+
+  it("returns null for unknown presets", () => {
+    expect(getGrayScale("nonexistent")).toBeNull();
+  });
+
+  it("supports all built-in presets", () => {
+    for (const preset of ["zinc", "slate", "neutral", "stone", "gray"]) {
+      expect(getGrayScale(preset)).not.toBeNull();
+    }
+  });
+});
+
+describe("generateThemeCSS", () => {
+  it("returns empty string when no theme colors", () => {
+    expect(generateThemeCSS({})).toBe("");
+  });
+
+  it("generates :root block for accent color", () => {
+    const css = generateThemeCSS({ accent: "#0070f3" });
+    expect(css).toContain(":root {");
+    expect(css).toContain("--color-primary-500:");
+  });
+
+  it("generates :root block for gray preset", () => {
+    const css = generateThemeCSS({ gray: "slate" });
+    expect(css).toContain(":root {");
+    expect(css).toContain("--bd-gray-500:");
+  });
+
+  it("generates .dark block for dark accent override", () => {
+    const css = generateThemeCSS({ dark: { accent: "#ff6600" } });
+    expect(css).toContain(".dark {");
+    expect(css).toContain("--color-primary-500:");
+  });
+
+  it("combines accent and gray in one output", () => {
+    const css = generateThemeCSS({ accent: "#0070f3", gray: "zinc" });
+    expect(css).toContain("--color-primary-");
+    expect(css).toContain("--bd-gray-");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   docs:
     dependencies:
@@ -1840,6 +1843,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
 
@@ -1947,6 +1953,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -2043,6 +2052,9 @@ packages:
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -2114,6 +2126,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2177,6 +2218,10 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
@@ -2247,6 +2292,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2746,6 +2795,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -3459,6 +3512,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   ofetch@1.5.1:
     resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
 
@@ -3864,6 +3920,9 @@ packages:
   shiki@3.22.0:
     resolution: {integrity: sha512-LBnhsoYEe0Eou4e1VgJACes+O6S6QC0w71fCSp5Oya79inkwkm15gQ1UF6VtQ8j/taMDh79hAB49WUk8ALQW3g==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3903,6 +3962,12 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
@@ -3995,6 +4060,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
@@ -4005,6 +4073,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -4288,6 +4360,40 @@ packages:
       vite:
         optional: true
 
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
@@ -4318,6 +4424,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@5.0.0:
@@ -5751,6 +5862,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.1.18':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -5844,6 +5957,11 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -5966,6 +6084,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -6042,6 +6162,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -6088,6 +6247,8 @@ snapshots:
   array-iterate@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -6246,6 +6407,8 @@ snapshots:
   caniuse-lite@1.0.30001767: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -6808,6 +6971,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
 
   extend-shallow@2.0.1:
     dependencies:
@@ -7852,6 +8017,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  obug@2.1.1: {}
+
   ofetch@1.5.1:
     dependencies:
       destr: 2.0.5
@@ -8401,6 +8568,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-swizzle@0.2.4:
@@ -8432,6 +8601,10 @@ snapshots:
       signal-exit: 4.1.0
 
   sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   stream-replace-string@2.0.0: {}
 
@@ -8526,6 +8699,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
 
   tinyexec@1.0.2: {}
@@ -8534,6 +8709,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8746,6 +8923,43 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
+  vitest@4.0.18(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 6.4.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.8
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   vscode-jsonrpc@8.2.0: {}
 
   vscode-languageserver-protocol@3.17.5:
@@ -8770,6 +8984,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@5.0.0:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["packages/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

- **Testing**: Set up Vitest with 38 unit tests covering i18n utils, theme colors, and content processing
- **CI Fix**: Remove `|| true` from type-check (errors now fail the build), add `pnpm test` step
- **Docs**: Add migration guide (Docusaurus/GitBook/Mintlify → Barodoc) and troubleshooting guide in EN/KO
- **Blog**: Add 3 sample blog posts; verified blog index + individual post pages render correctly

## Test plan

- [x] `pnpm test` — 38 tests pass (i18n, colors, content)
- [x] Blog index page at `/blog` renders 3 posts sorted by date
- [x] Individual blog post pages render with tags, author, date, reading time
- [x] CI workflow updated with proper type-check and test steps

Closes #67

Made with [Cursor](https://cursor.com)