### PR TITLE
feat: add header tabs navigation for section switching

### DIFF
--- a/.changeset/header-tabs-nav.md
+++ b/.changeset/header-tabs-nav.md
@@ -1,0 +1,6 @@
+---
+"@barodoc/core": minor
+"@barodoc/theme-docs": minor
+---
+
+Add configurable header tabs navigation for top-level section switching (Docs, Blog, API Reference, etc.)

--- a/docs/barodoc.config.json
+++ b/docs/barodoc.config.json
@@ -15,6 +15,11 @@
       "ko": "한국어"
     }
   },
+  "tabs": [
+    { "label": "Docs", "href": "/docs/introduction" },
+    { "label": "Blog", "href": "/blog" },
+    { "label": "API Reference", "href": "/docs/api/pet" }
+  ],
   "navigation": [
     {
       "group": "Getting Started",

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -98,6 +98,11 @@ export const versionConfigSchema = z.object({
 
 export const versionsSchema = z.array(versionConfigSchema).optional();
 
+export const tabSchema = z.object({
+  label: z.string(),
+  href: z.string(),
+});
+
 export const barodocConfigSchema = z.object({
   name: z.string(),
   logo: z.string().optional(),
@@ -107,6 +112,7 @@ export const barodocConfigSchema = z.object({
   theme: themeConfigSchema,
   i18n: i18nConfigSchema,
   navigation: z.array(navItemSchema),
+  tabs: z.array(tabSchema).optional(),
   topbar: topbarSchema,
   search: searchSchema,
   lineNumbers: lineNumbersSchema,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -49,6 +49,11 @@ export interface BarodocConfig {
   
   navigation: BarodocNavItem[];
   
+  tabs?: {
+    label: string;
+    href: string;
+  }[];
+
   topbar?: {
     github?: string;
     discord?: string;

--- a/packages/theme-docs/src/components/DocHeader.tsx
+++ b/packages/theme-docs/src/components/DocHeader.tsx
@@ -10,9 +10,15 @@ import {
 } from "./ui/tooltip";
 import { cn } from "../lib/utils";
 
+interface TabItem {
+  label: string;
+  href: string;
+}
+
 interface DocHeaderProps {
   siteName: string;
   logo?: string;
+  tabs?: TabItem[];
   githubUrl?: string;
   hasMultipleLocales?: boolean;
   currentLocale?: string;
@@ -46,6 +52,7 @@ function getLocalizedUrl(
 export function DocHeader({
   siteName,
   logo,
+  tabs = [],
   githubUrl,
   hasMultipleLocales,
   currentLocale = "en",
@@ -92,7 +99,7 @@ export function DocHeader({
     <TooltipProvider>
       <header className="sticky top-0 z-50 w-full min-w-0 border-b border-[var(--bd-border)] bg-[var(--bd-bg)]/95 backdrop-blur-md supports-[backdrop-filter]:bg-[var(--bd-bg)]/80">
         <div className="flex h-14 items-center justify-between gap-2 px-4 sm:px-6 max-w-[1280px] mx-auto min-w-0">
-          {/* Logo */}
+          {/* Logo + Tabs */}
           <div className="flex items-center gap-6 min-w-0 shrink">
             <a
               href="/"
@@ -101,6 +108,27 @@ export function DocHeader({
               {logo && <img src={logo} alt={siteName} className="h-7 w-7 shrink-0" />}
               <span className="text-[15px] tracking-tight truncate">{siteName}</span>
             </a>
+            {tabs.length > 0 && (
+              <nav className="hidden md:flex items-center gap-1">
+                {tabs.map((tab) => {
+                  const isActive = currentPath === tab.href || currentPath.startsWith(tab.href + "/");
+                  return (
+                    <a
+                      key={tab.href}
+                      href={tab.href}
+                      className={cn(
+                        "px-3 py-1.5 text-[13px] font-medium rounded-lg transition-colors",
+                        isActive
+                          ? "text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-950/50"
+                          : "text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] hover:bg-[var(--bd-bg-subtle)]"
+                      )}
+                    >
+                      {tab.label}
+                    </a>
+                  );
+                })}
+              </nav>
+            )}
           </div>
 
           {/* Right side actions */}

--- a/packages/theme-docs/src/components/Header.astro
+++ b/packages/theme-docs/src/components/Header.astro
@@ -18,6 +18,7 @@ const localeLabels: Record<string, string> = config.i18n?.labels || {};
   client:load
   siteName={config.name}
   logo={config.logo}
+  tabs={config.tabs}
   githubUrl={config.topbar?.github}
   hasMultipleLocales={hasMultipleLocales}
   currentLocale={currentLocale}

--- a/packages/theme-docs/src/components/MobileNav.astro
+++ b/packages/theme-docs/src/components/MobileNav.astro
@@ -58,4 +58,6 @@ const groups = config.navigation.map((group) => ({
   groups={groups} 
   siteName={config.name}
   logo={config.logo}
+  tabs={config.tabs}
+  currentPath={currentPath}
 />

--- a/packages/theme-docs/src/components/MobileNavSheet.tsx
+++ b/packages/theme-docs/src/components/MobileNavSheet.tsx
@@ -21,13 +21,20 @@ interface NavGroup {
   defaultOpen?: boolean;
 }
 
+interface TabItem {
+  label: string;
+  href: string;
+}
+
 interface MobileNavSheetProps {
   groups: NavGroup[];
   siteName: string;
   logo?: string;
+  tabs?: TabItem[];
+  currentPath?: string;
 }
 
-export function MobileNavSheet({ groups, siteName, logo }: MobileNavSheetProps) {
+export function MobileNavSheet({ groups, siteName, logo, tabs = [], currentPath = "" }: MobileNavSheetProps) {
   const [open, setOpen] = React.useState(false);
 
   React.useEffect(() => {
@@ -61,6 +68,27 @@ export function MobileNavSheet({ groups, siteName, logo }: MobileNavSheetProps) 
           </SheetTitle>
         </SheetHeader>
         <ScrollArea className="h-[calc(100vh-65px)]">
+          {tabs.length > 0 && (
+            <div className="px-4 pt-4 pb-2 flex flex-col gap-1 border-b border-[var(--bd-border)]">
+              {tabs.map((tab) => {
+                const isActive = currentPath === tab.href || currentPath.startsWith(tab.href + "/");
+                return (
+                  <a
+                    key={tab.href}
+                    href={tab.href}
+                    className={cn(
+                      "px-3 py-2 text-sm font-medium rounded-lg transition-colors",
+                      isActive
+                        ? "text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-950/50"
+                        : "text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] hover:bg-[var(--bd-bg-subtle)]"
+                    )}
+                  >
+                    {tab.label}
+                  </a>
+                );
+              })}
+            </div>
+          )}
           <div className="px-2 py-4">
             <DocsSidebar groups={groups} />
           </div>

--- a/packages/theme-docs/src/pages/index.astro
+++ b/packages/theme-docs/src/pages/index.astro
@@ -43,10 +43,24 @@ const features = [
     <header class="sticky top-0 z-50 border-b border-[var(--bd-border)] bg-[var(--bd-bg)]/95 backdrop-blur-md">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex h-16 items-center justify-between">
-          <a href="/" class="flex items-center gap-2.5 font-semibold text-[var(--bd-text)]">
-            {config.logo && <img src={config.logo} alt={config.name} class="h-7 w-7" />}
-            <span class="text-lg">{config.name}</span>
-          </a>
+          <div class="flex items-center gap-6">
+            <a href="/" class="flex items-center gap-2.5 font-semibold text-[var(--bd-text)]">
+              {config.logo && <img src={config.logo} alt={config.name} class="h-7 w-7" />}
+              <span class="text-lg">{config.name}</span>
+            </a>
+            {config.tabs && config.tabs.length > 0 && (
+              <nav class="hidden md:flex items-center gap-1">
+                {config.tabs.map((tab: { label: string; href: string }) => (
+                  <a
+                    href={tab.href}
+                    class="px-3 py-1.5 text-sm font-medium rounded-lg text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] hover:bg-[var(--bd-bg-subtle)] transition-colors"
+                  >
+                    {tab.label}
+                  </a>
+                ))}
+              </nav>
+            )}
+          </div>
           <div class="flex items-center gap-2">
             {config.topbar?.github && (
               <a


### PR DESCRIPTION
## Summary

- Add `tabs` config option for top-level section navigation (Docs, Blog, API Reference, etc.)
- Tabs render in header between logo and right-side actions with active state highlighting
- Works on landing page, docs pages, blog pages, and mobile navigation sheet

## Test plan

- [x] Landing page shows Docs / Blog / API Reference tabs
- [x] Docs page highlights "Docs" tab as active
- [x] Blog page highlights "Blog" tab as active
- [x] Tabs are clickable and navigate correctly
- [x] Desktop and mobile layouts verified

Closes #70

Made with [Cursor](https://cursor.com)