### PR TITLE
feat: multi-spec OpenAPI, changelog, blog avatars, contributors & docs updates

### DIFF
--- a/.changeset/docs-openapi-changelog-contributors.md
+++ b/.changeset/docs-openapi-changelog-contributors.md
@@ -1,0 +1,15 @@
+---
+"@barodoc/plugin-openapi": minor
+"@barodoc/theme-docs": minor
+---
+
+Add multi-spec OpenAPI support, changelog content type, blog author avatars, contributors display, and comprehensive documentation updates
+
+- **plugin-openapi**: `specFile` now accepts an array of `OpenApiSpecEntry` objects for projects with multiple API specs, each with its own `basePath`, `baseUrl`, and `groupBy`
+- **theme-docs**: Blog posts support `avatar` field in frontmatter, displayed next to author name on index and post pages
+- **theme-docs**: Contributors section at page footer shows most recent editor avatar with +N count badge for additional contributors
+- **theme-docs**: Fix contributors file path resolution so git history is properly read
+- **theme-docs**: Fix code copy button styling on blog pages by including CodeCopy component in BlogLayout
+- **docs**: Add changelog content with 6 sample entries (v0.1.0–v0.6.0) and Changelog tab in header
+- **docs**: Comprehensive OpenAPI plugin guide with multi-spec examples and full options reference
+- **docs**: Updated content structure and configuration guides covering all new features (EN/KO)

--- a/docs/barodoc.config.json
+++ b/docs/barodoc.config.json
@@ -18,7 +18,8 @@
   "tabs": [
     { "label": "Docs", "href": "/docs/introduction" },
     { "label": "Blog", "href": "/blog" },
-    { "label": "API Reference", "href": "/docs/api/pet" }
+    { "label": "API Reference", "href": "/docs/api/pet" },
+    { "label": "Changelog", "href": "/changelog" }
   ],
   "navigation": [
     {

--- a/docs/src/content/blog/introducing-barodoc.mdx
+++ b/docs/src/content/blog/introducing-barodoc.mdx
@@ -4,6 +4,7 @@ description: "Zero-config documentation framework built on Astro — beautiful d
 excerpt: "Meet Barodoc, the Mintlify-style documentation framework that lets you focus on content, not configuration."
 date: 2025-12-01
 author: "Barodoc Team"
+avatar: "https://github.com/barocss.png"
 image: "/logo.svg"
 tags: ["announcement", "release"]
 ---

--- a/docs/src/content/blog/writing-great-docs.mdx
+++ b/docs/src/content/blog/writing-great-docs.mdx
@@ -4,6 +4,7 @@ description: "Practical advice for creating documentation that developers actual
 excerpt: "Learn the principles behind effective technical documentation and how to apply them."
 date: 2026-02-10
 author: "Barodoc Team"
+avatar: "https://github.com/barocss.png"
 tags: ["guide", "writing"]
 ---
 

--- a/docs/src/content/changelog/v0.1.0.mdx
+++ b/docs/src/content/changelog/v0.1.0.mdx
@@ -1,0 +1,14 @@
+---
+version: "0.1.0"
+date: 2025-12-20
+title: "Initial Release"
+---
+
+### New Features
+
+- **Core framework** — Astro-based documentation generator with `@barodoc/core` integration and `@barodoc/theme-docs` theme.
+- **Markdown & MDX** — Full markdown support with MDX for interactive components.
+- **Navigation** — Configurable sidebar with grouped pages.
+- **Dark mode** — System-aware theme with manual toggle.
+- **Code highlighting** — Syntax highlighting with line numbers and copy button.
+- **Responsive design** — Mobile-first layout with desktop sidebar.

--- a/docs/src/content/changelog/v0.2.0.mdx
+++ b/docs/src/content/changelog/v0.2.0.mdx
@@ -1,0 +1,17 @@
+---
+version: "0.2.0"
+date: 2026-01-10
+title: "Quick Mode & CLI"
+---
+
+### New Features
+
+- **Quick mode** — Zero-config documentation from just markdown files. No `package.json` or `node_modules` needed.
+- **CLI commands** — `barodoc serve`, `barodoc build`, `barodoc preview` for quick mode.
+- **Project scaffolding** — `barodoc create` / `pnpm create barodoc` to generate new projects.
+- **Auto frontmatter** — Title extracted from first `# Heading`, description from first paragraph.
+
+### Improvements
+
+- Configurable theme colors via `barodoc.config.json`.
+- GitHub link in topbar.

--- a/docs/src/content/changelog/v0.3.0.mdx
+++ b/docs/src/content/changelog/v0.3.0.mdx
@@ -1,0 +1,18 @@
+---
+version: "0.3.0"
+date: 2026-01-25
+title: "i18n & Component Library"
+---
+
+### New Features
+
+- **Internationalization (i18n)** — Multi-language support with locale-aware routing, navigation labels, and language switcher.
+- **MDX components** — Callout, Card, Tabs, Accordion, Steps, CodeGroup, Columns, Badge, Tooltip, Expandable, and more.
+- **Mermaid diagrams** — Native support for Mermaid diagram rendering in markdown.
+- **Image zoom** — Click-to-zoom for images in docs.
+
+### Improvements
+
+- Responsive sidebar with mobile navigation drawer.
+- Breadcrumb navigation for nested docs.
+- Table of contents (TOC) on each page.

--- a/docs/src/content/changelog/v0.4.0.mdx
+++ b/docs/src/content/changelog/v0.4.0.mdx
@@ -1,0 +1,18 @@
+---
+version: "0.4.0"
+date: 2026-02-10
+title: "OpenAPI Playground & Plugin System"
+---
+
+### New Features
+
+- **OpenAPI plugin** — Auto-generate API documentation from OpenAPI/Swagger specs with full parameter tables, response schemas, and cURL examples.
+- **API Playground** — Interactive endpoint testing with auth support (Bearer, API Key, Basic), request history, and code snippet generation.
+- **Plugin system** — Extensible architecture with hooks for `config:loaded`, `content:transform`, `build:start`, and `build:done`.
+- **Search plugin** — Full-text search powered by Pagefind.
+- **Sitemap plugin** — Auto-generated sitemap.xml for SEO.
+
+### Improvements
+
+- Added `editLink` and `lastUpdated` support for docs pages.
+- Improved dark mode consistency across all components.

--- a/docs/src/content/changelog/v0.5.0.mdx
+++ b/docs/src/content/changelog/v0.5.0.mdx
@@ -1,0 +1,17 @@
+---
+version: "0.5.0"
+date: 2026-02-20
+title: "Blog Support & New Logo"
+---
+
+### New Features
+
+- **Blog content type** — Full blog support with listing page, individual post pages, tags, reading time, and author display.
+- **New logo** — Modern gradient SVG logo replacing the old monochrome design.
+- **Migration guide** — Step-by-step guides for migrating from Docusaurus, GitBook, and Mintlify.
+- **Troubleshooting guide** — Common issues and solutions for Barodoc projects.
+
+### Improvements
+
+- **CI pipeline** — Type check errors now fail the build (removed `|| true`). Added test runner step.
+- **Unit tests** — Initial test suite covering i18n utilities, theme color generation, and markdown processing.

--- a/docs/src/content/changelog/v0.6.0.mdx
+++ b/docs/src/content/changelog/v0.6.0.mdx
@@ -1,0 +1,22 @@
+---
+version: "0.6.0"
+date: 2026-02-24
+title: "Multi-spec OpenAPI, Author Avatars & Header Tabs"
+---
+
+### New Features
+
+- **Multiple OpenAPI specs** — `specFile` now accepts an array of spec entries, each with its own `basePath`, `baseUrl`, and `groupBy`. Perfect for projects with separate public, admin, and webhook APIs.
+- **Author avatars in blog** — Blog posts now support an `avatar` field in frontmatter. Avatars appear on both the blog index and individual post pages.
+- **Header tabs navigation** — New `tabs` config option adds top-level navigation links (Docs, Blog, API, Changelog) in the header, visible on both desktop and mobile.
+
+### Improvements
+
+- **Content structure guide** — Comprehensive documentation covering how Docs, Blog, API Reference, and Changelog content types work together.
+- **OpenAPI plugin docs** — Expanded with quick start guide, multi-spec examples, and full options reference.
+- **Configuration guide** — Added `tabs` configuration documentation.
+
+### Bug Fixes
+
+- Fixed code copy button styling broken on blog pages (missing `CodeCopy` component in `BlogLayout`).
+- Fixed Callout component import path in MDX files.

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -22,6 +22,7 @@ const blogCollection = defineCollection({
     excerpt: z.string().optional(),
     date: z.coerce.date().optional(),
     author: z.string().optional(),
+    avatar: z.string().optional(),
     image: z.string().optional(),
     tags: z.array(z.string()).optional(),
   }),

--- a/docs/src/content/docs/en/guides/configuration.mdx
+++ b/docs/src/content/docs/en/guides/configuration.mdx
@@ -112,6 +112,25 @@ Override heading and body fonts:
 
 Border radius for UI elements (e.g. `"0.5rem"`, `"8px"`).
 
+### tabs
+
+Add top-level navigation links in the header for switching between content sections (Docs, Blog, API, Changelog, etc.):
+
+```json
+{
+  "tabs": [
+    { "label": "Docs", "href": "/docs/introduction" },
+    { "label": "Blog", "href": "/blog" },
+    { "label": "API Reference", "href": "/docs/api/pet" },
+    { "label": "Changelog", "href": "/changelog" }
+  ]
+}
+```
+
+Each tab has a `label` (display text) and `href` (link target). The active tab is highlighted based on the current URL. Tabs appear on desktop in the header and in the mobile navigation drawer. Optional — omit to show only the logo and topbar icons.
+
+See [Content Structure](/docs/guides/content-structure) for details on how tabs connect different content types.
+
 ### navigation
 
 Define the sidebar navigation structure. Use `group` for the default locale and `group:LOCALE` for translated group names (see [I18n](/docs/guides/i18n)):
@@ -203,6 +222,12 @@ When `true`, shows a git-based "Last updated" timestamp in the page footer:
   "lastUpdated": true
 }
 ```
+
+### Page contributors
+
+Contributors are shown automatically at the bottom of every docs page — no configuration needed. Barodoc reads Git history to display the most recent editor's avatar, with a **+N** badge for additional contributors. Hover the badge to see their names.
+
+Avatars are fetched from GitHub (for noreply emails) or Gravatar. This feature requires the project to be a Git repository with commit history. See [Content Structure](/docs/guides/content-structure) for details.
 
 ### announcement
 

--- a/docs/src/content/docs/en/guides/content-structure.mdx
+++ b/docs/src/content/docs/en/guides/content-structure.mdx
@@ -1,14 +1,65 @@
 ---
 title: Content Structure
-description: Where to put content and how URLs are built
-tags: [content, structure, frontmatter]
-related: [guides/configuration, guides/i18n]
+description: How docs, blog, API reference, and changelog content types work together
+tags: [content, structure, frontmatter, blog, api, changelog]
+related: [guides/configuration, guides/i18n, guides/plugins/openapi]
 difficulty: beginner
 ---
 
-Barodoc content is organized by locale; the folder structure becomes the URL path. In **CLI (zero-config)** mode, content lives under **`docs/`** (e.g. `docs/en/`, `docs/ko/`). In **manual Astro** mode, it lives under **`src/content/docs/`** (e.g. `src/content/docs/en/`). The rules below apply to both.
+import Callout from "@barodoc/theme-docs/components/mdx/Callout.astro";
 
-## Directory layout
+Barodoc supports four content types out of the box: **Docs**, **Blog**, **API Reference**, and **Changelog**. Each has its own directory, schema, and routing — but they share the same site shell (header, theme, search).
+
+## Overview
+
+```
+my-project/
+├── src/content/
+│   ├── docs/           # Documentation pages (sidebar navigation)
+│   │   ├── en/
+│   │   └── ko/
+│   ├── blog/           # Blog posts (card grid, date-sorted)
+│   └── changelog/      # Release notes (timeline view)
+├── public/             # Static assets (images, logo, favicon)
+├── barodoc.config.json # Site config, navigation, tabs
+└── openapi.yaml        # OpenAPI spec (if using API reference)
+```
+
+| Content type | Directory | Route | Layout |
+|---|---|---|---|
+| Docs | `src/content/docs/{locale}/` | `/docs/{slug}` | Sidebar + table of contents |
+| Blog | `src/content/blog/` | `/blog/{slug}` | Single-column article |
+| API Reference | Auto-generated from OpenAPI spec | `/docs/api/{slug}` | Sidebar + playground |
+| Changelog | `src/content/changelog/` | `/changelog` | Timeline |
+
+## Connecting content types with tabs
+
+Use the `tabs` config to add top-level navigation links in the header so users can switch between content types:
+
+```json
+{
+  "tabs": [
+    { "label": "Docs", "href": "/docs/introduction" },
+    { "label": "Blog", "href": "/blog" },
+    { "label": "API Reference", "href": "/docs/api/pet" },
+    { "label": "Changelog", "href": "/changelog" }
+  ]
+}
+```
+
+Tabs appear in the header on desktop and in the mobile navigation drawer. The active tab is highlighted based on the current URL.
+
+<Callout type="info">
+`tabs` is optional. If omitted, only the logo and topbar icons appear in the header. Add it when your site has more than just docs.
+</Callout>
+
+---
+
+## Docs
+
+Documentation is the primary content type. It uses locale-based folders and a sidebar defined in `barodoc.config.json`.
+
+### Directory layout
 
 **CLI mode** (`docs/` at project root):
 
@@ -26,36 +77,46 @@ docs/
 
 ```
 src/content/docs/
-├── en/                        # Default locale (e.g. /docs/...)
+├── en/
 │   ├── introduction.mdx       # /docs/introduction
-│   ├── quickstart.mdx         # /docs/quickstart
+│   ├── quickstart.mdx          # /docs/quickstart
 │   └── guides/
-│       ├── installation.mdx   # /docs/guides/installation
-│       └── deployment.mdx     # /docs/guides/deployment
-└── ko/                        # Second locale (e.g. /ko/docs/...)
-    ├── introduction.mdx       # /ko/docs/introduction
+│       ├── installation.mdx    # /docs/guides/installation
+│       └── deployment.mdx      # /docs/guides/deployment
+└── ko/
+    ├── introduction.mdx        # /ko/docs/introduction
     └── guides/
-        └── installation.mdx   # /ko/docs/guides/installation
+        └── installation.mdx    # /ko/docs/guides/installation
 ```
 
-- **Locale folder** (`en`, `ko`, etc.) is required. Even single-language docs use one (e.g. `en/`).
-- **File path = URL slug**: `guides/installation.mdx` → `/docs/guides/installation` (or `/[locale]/docs/guides/installation` when i18n is used).
-- Use **lowercase** and **hyphens** for file names (e.g. `code-group.mdx`, not `CodeGroup.mdx`) so URLs stay consistent.
+- **Locale folder** (`en`, `ko`, etc.) is required — even single-language sites need one.
+- **File path = URL slug**: `guides/installation.mdx` → `/docs/guides/installation`.
+- Use **lowercase** and **hyphens** for file names (`code-group.mdx`, not `CodeGroup.mdx`).
 
-## Page slug and navigation
+### Sidebar navigation
 
-In `barodoc.config.json`, `navigation.pages` use the **slug without locale and without `.mdx`**:
+In `barodoc.config.json`, the `navigation` array defines the sidebar. Use slugs **without locale and without `.mdx`**:
 
-- File: `src/content/docs/en/guides/installation.mdx`  
-  Slug for nav: `guides/installation`
-- File: `src/content/docs/en/components/accordion.mdx`  
-  Slug for nav: `components/accordion`
+```json
+{
+  "navigation": [
+    {
+      "group": "Getting Started",
+      "group:ko": "시작하기",
+      "pages": ["introduction", "quickstart"]
+    },
+    {
+      "group": "Guides",
+      "group:ko": "가이드",
+      "pages": ["guides/installation", "guides/configuration"]
+    }
+  ]
+}
+```
 
-The same slug is used for all locales; each locale has its own file under its folder (`en/...`, `ko/...`).
+The same slug is shared across all locales — each locale has its own file under its folder.
 
-## Frontmatter
-
-Every doc page should have a title in frontmatter. Additional fields are available for classification, linking, and AI consumption:
+### Frontmatter
 
 ```mdx
 ---
@@ -65,35 +126,248 @@ tags: [setup, cli]
 related: [quickstart, guides/configuration]
 category: guides
 difficulty: beginner
-api_reference: false
 ---
-
-# Installation
-...
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `title` | `string` | Page title. Shown in browser tab, sidebar, and meta. |
-| `description` | `string` | Meta description and previews. |
-| `tags` | `string[]` | Classification tags for search and AI agent filtering. |
-| `related` | `string[]` | Slugs of related pages. `barodoc check` validates these point to real pages. |
-| `category` | `string` | Explicit category override. Auto-detected from navigation group if omitted. |
-| `difficulty` | `"beginner" \| "intermediate" \| "advanced"` | Content difficulty level. |
+| `title` | `string` | Page title (browser tab, sidebar, meta). |
+| `description` | `string` | Meta description. |
+| `tags` | `string[]` | Classification tags for search and filtering. |
+| `related` | `string[]` | Slugs of related pages. |
+| `category` | `string` | Category override (auto-detected from nav group if omitted). |
+| `difficulty` | `"beginner" \| "intermediate" \| "advanced"` | Content difficulty. |
 | `api_reference` | `boolean` | Marks the page as API reference content. |
-| `lastUpdated` | `date` | Manual override for last-updated timestamp. |
+| `lastUpdated` | `date` | Manual last-updated timestamp override. |
+
+---
+
+## Blog
+
+Blog posts live in `src/content/blog/` (no locale subfolders). They are date-sorted and displayed in a card grid at `/blog`.
+
+### Directory layout
+
+```
+src/content/blog/
+├── introducing-barodoc.mdx    → /blog/introducing-barodoc
+├── v6-release.mdx             → /blog/v6-release
+└── writing-great-docs.mdx     → /blog/writing-great-docs
+```
+
+### Creating a blog post
+
+Create an `.mdx` (or `.md`) file in `src/content/blog/`:
+
+```mdx
+---
+title: "Introducing Barodoc"
+description: "Zero-config documentation framework built on Astro."
+excerpt: "Beautiful docs in seconds."
+date: 2026-02-01
+author: "Barodoc Team"
+image: "/images/blog-cover.png"
+tags: ["announcement", "release"]
+---
+
+Your blog content here. You can use all the same MDX components
+(Callout, Tabs, CodeGroup, etc.) available in docs.
+```
+
+### Frontmatter
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | `string` | Post title (required). |
+| `description` | `string` | Meta description. |
+| `excerpt` | `string` | Short summary shown on the blog index cards. |
+| `date` | `date` | Publication date. Used for sorting. |
+| `author` | `string` | Author name. |
+| `avatar` | `string` | Author avatar image URL. Shown next to the author name on the index and post pages. |
+| `image` | `string` | Cover image path (shown on index card and post page). |
+| `tags` | `string[]` | Tags shown as badges on the card and post header. |
+
+<Callout type="tip">
+The blog index page at `/blog` is generated automatically. You don't need to create it — just add posts to `src/content/blog/` and they appear.
+</Callout>
+
+---
+
+## API Reference
+
+API reference pages can be created two ways: **auto-generated from an OpenAPI spec** (recommended) or **manually written** using API components.
+
+### Option 1: OpenAPI plugin (recommended)
+
+The `@barodoc/plugin-openapi` reads your OpenAPI spec and generates pages automatically with an interactive playground. You can use a single spec file or multiple specs:
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-openapi", {
+      "specFile": "openapi.yaml",
+      "basePath": "api",
+      "groupBy": "tags",
+      "playground": true
+    }]
+  ],
+  "navigation": [
+    {
+      "group": "API Reference",
+      "pages": ["api/pet", "api/store", "api/user"]
+    }
+  ]
+}
+```
+
+For projects with multiple APIs, pass an array to `specFile`:
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-openapi", {
+      "specFile": [
+        { "file": "api/public.yaml", "basePath": "api/public" },
+        { "file": "api/admin.yaml", "basePath": "api/admin" }
+      ],
+      "playground": true
+    }]
+  ]
+}
+```
+
+Generated pages appear under `/docs/api/...` and are listed in the sidebar alongside regular docs. See the [OpenAPI plugin guide](/docs/guides/plugins/openapi) for full setup including multi-spec configuration.
+
+### Option 2: Manual API components
+
+For custom API documentation, use the `ApiEndpoint`, `ApiParams`, `ApiParam`, and `ApiResponse` components directly in MDX. See [API Reference Components](/docs/components/api-reference).
+
+---
+
+## Changelog
+
+Changelog entries live in `src/content/changelog/`. They are displayed as a timeline at `/changelog`.
+
+### Directory layout
+
+```
+src/content/changelog/
+├── v2.0.0.mdx    → shown on /changelog
+├── v1.5.0.mdx
+└── v1.0.0.mdx
+```
+
+### Creating a changelog entry
+
+```mdx
+---
+version: "2.0.0"
+date: 2026-02-15
+title: "Header tabs & blog improvements"
+---
+
+### New features
+- Configurable header tabs for top-level navigation
+- Code copy button in blog posts
+
+### Bug fixes
+- Fixed mobile navigation scroll behavior
+```
+
+### Frontmatter
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | `string` | Version number (required). |
+| `date` | `date` | Release date (required). Used for sorting. |
+| `title` | `string` | Optional release title. |
+
+---
+
+## Putting it all together
+
+A typical Barodoc site with all content types configured:
+
+```json
+{
+  "name": "My Project",
+  "logo": "/logo.svg",
+
+  "tabs": [
+    { "label": "Docs", "href": "/docs/introduction" },
+    { "label": "Blog", "href": "/blog" },
+    { "label": "API", "href": "/docs/api/overview" },
+    { "label": "Changelog", "href": "/changelog" }
+  ],
+
+  "navigation": [
+    {
+      "group": "Getting Started",
+      "pages": ["introduction", "quickstart"]
+    },
+    {
+      "group": "API Reference",
+      "pages": ["api/overview", "api/users", "api/auth"]
+    }
+  ],
+
+  "plugins": [
+    "@barodoc/plugin-sitemap",
+    ["@barodoc/plugin-openapi", { "specFile": "openapi.yaml", "basePath": "api" }]
+  ]
+}
+```
+
+```
+my-project/
+├── src/content/
+│   ├── docs/en/              # ← Sidebar docs
+│   │   ├── introduction.mdx
+│   │   └── guides/...
+│   ├── blog/                 # ← Blog posts
+│   │   ├── hello-world.mdx
+│   │   └── v2-release.mdx
+│   └── changelog/            # ← Release notes
+│       ├── v2.0.0.mdx
+│       └── v1.0.0.mdx
+├── openapi.yaml              # ← API spec
+├── barodoc.config.json
+└── public/
+    └── logo.svg
+```
+
+### Content type independence
+
+Each content type is **optional and independent**:
+
+- **Docs only** — Don't create `blog/` or `changelog/` folders, omit `tabs`. This is the default.
+- **Docs + Blog** — Add `src/content/blog/` and a `tabs` entry for Blog.
+- **Docs + API** — Add the OpenAPI plugin and include API pages in `navigation`.
+- **All four** — Create all folders and configure `tabs` for full navigation.
+
+The theme automatically handles missing collections gracefully — if `blog/` doesn't exist, `/blog` shows "No posts yet" instead of an error.
+
+## Page contributors
+
+Barodoc automatically displays a **Contributors** section at the bottom of every docs page, showing who has edited the file based on Git history.
+
+- The **most recent contributor's** avatar is shown
+- If there are additional contributors, a **+N** count badge appears next to the avatar
+- Hovering the count badge shows the names of the other contributors
+- Avatars are fetched from GitHub (for `@users.noreply.github.com` emails) or Gravatar
+
+This feature works automatically — no configuration needed. It reads from `git log` at build time, so the repository must be a Git repo with commit history.
 
 ## MDX and components
 
-- You can use **Markdown** and **MDX** (JSX in Markdown).
-- To use theme components (Tabs, Accordion, ParamField, etc.), import them at the top of the file. In development, use the component path (e.g. `@barodoc/theme-docs/components/mdx/DocAccordion.tsx`). See [Components](/docs/components/accordion) for examples.
-- Interactive components need the `client:load` directive so they hydrate on the client (e.g. `<Tabs client:load ... />`).
+- Use **Markdown** (`.md`) or **MDX** (`.mdx`) for all content types.
+- Theme components (Tabs, Accordion, Callout, etc.) work in docs and blog posts alike.
+- Interactive components need `client:load` for hydration (e.g. `<Tabs client:load ... />`).
+- See [Components](/docs/components/accordion) for the full list.
 
 ## Static assets
 
-Put images and other static files in **`public/`**. Reference them by path from the site root:
+Put images and other static files in **`public/`**. Reference by path from the site root:
 
 - `public/logo.svg` → `/logo.svg`
 - `public/images/diagram.png` → `/images/diagram.png`
-
-Use these paths in `barodoc.config.json` (e.g. `logo`, `favicon`) and in MDX/Markdown (e.g. `![alt](/images/diagram.png)`).

--- a/docs/src/content/docs/en/guides/plugins/openapi.mdx
+++ b/docs/src/content/docs/en/guides/plugins/openapi.mdx
@@ -1,10 +1,13 @@
 ---
 title: OpenAPI Plugin
 description: Generate API documentation from OpenAPI/Swagger specs
+tags: [api, openapi, swagger, plugin]
+related: [guides/content-structure, components/api-reference]
 ---
 import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+import Callout from "@barodoc/theme-docs/components/mdx/Callout.astro";
 
-The OpenAPI plugin automatically generates API documentation pages from an OpenAPI (Swagger) specification file. It includes an interactive API Playground for testing endpoints directly from the docs.
+The OpenAPI plugin reads your OpenAPI (Swagger) spec files and auto-generates full API documentation pages — complete with parameter tables, response examples, cURL snippets, and an interactive playground for testing endpoints live.
 
 ## Installation
 
@@ -12,9 +15,18 @@ The OpenAPI plugin automatically generates API documentation pages from an OpenA
 pnpm add @barodoc/plugin-openapi@latest
 ```
 
-## Configuration
+## Quick Start
 
-Add the plugin to `barodoc.config.json`:
+1. Place your OpenAPI spec file in the project root:
+
+```
+my-docs/
+├── openapi.yaml          ← your spec
+├── barodoc.config.json
+└── src/content/docs/...
+```
+
+2. Add the plugin to `barodoc.config.json`:
 
 ```json
 {
@@ -30,75 +42,208 @@ Add the plugin to `barodoc.config.json`:
 }
 ```
 
-## Spec File
-
-Place your OpenAPI spec file (YAML or JSON) in the docs root directory:
-
-```
-docs/
-├── openapi.yaml    ← spec file
-├── barodoc.config.json
-└── src/
-```
-
-The plugin supports OpenAPI 3.0+ specs. It reads paths, operations, parameters, request bodies, response schemas, and examples.
-
-## Generated Output
-
-The plugin generates MDX pages grouped by tags (or paths). Each page includes:
-
-- **Endpoint header** with method badge, path, and description
-- **Endpoint TOC** at the top for quick navigation
-- **Parameters table** with name, type, required status, and enum values
-- **Request body schema** with field descriptions
-- **Response examples** auto-generated from schemas
-- **cURL request examples**
-- **Interactive API Playground** (when `playground: true`)
-
-## API Playground Features
-
-The generated playground supports:
-
-- **Multiple auth types**: Bearer Token, API Key, and Basic Auth
-- **Enum dropdowns**: Parameters with enum values render as `<select>` dropdowns
-- **JSON body validation**: Request body is validated before sending
-- **Code snippets**: cURL, JavaScript, Python, and Node.js
-- **Response inspector**: Body with JSON syntax highlighting, headers, status, time, and size
-- **Request history**: Last 5 requests stored in IndexedDB
-
-## Navigation
-
-Add the generated pages to your navigation:
+3. Add the generated pages to your navigation:
 
 ```json
 {
   "navigation": [
     {
       "group": "API Reference",
-      "pages": ["api/pet", "api/store", "api/user"]
+      "pages": ["api/users", "api/auth", "api/billing"]
     }
   ]
 }
 ```
 
-Page slugs match the tag names from your spec, lowercased and hyphenated.
+Page slugs are derived from your spec's **tag names** — lowercased and hyphenated. For example, a tag named `User Management` becomes `api/user-management`.
 
-## Options
+4. (Optional) Add a tab for quick access:
+
+```json
+{
+  "tabs": [
+    { "label": "Docs", "href": "/docs/introduction" },
+    { "label": "API", "href": "/docs/api/users" }
+  ]
+}
+```
+
+## How It Works
+
+At build time, the plugin:
+
+1. Reads your OpenAPI 3.0+ spec file (YAML or JSON)
+2. Groups endpoints by `tags` (or `paths`)
+3. Generates `.mdx` files into `src/content/docs/{basePath}/`
+4. Each file includes imports for API components and playground
+
+The generated pages are regular docs pages — they appear in the sidebar, support search, and share the same theme.
+
+## Multiple API Specs
+
+If your project has multiple APIs (e.g. public API, admin API, webhooks), pass an array to `specFile`:
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-openapi", {
+      "specFile": [
+        {
+          "file": "api/public.yaml",
+          "basePath": "api/public",
+          "baseUrl": "https://api.example.com/v1"
+        },
+        {
+          "file": "api/admin.yaml",
+          "basePath": "api/admin",
+          "baseUrl": "https://admin.example.com"
+        },
+        {
+          "file": "api/webhooks.yaml",
+          "basePath": "api/webhooks",
+          "groupBy": "paths"
+        }
+      ],
+      "playground": true
+    }]
+  ]
+}
+```
+
+Each entry generates its own set of pages under its own `basePath`. Add them to navigation separately:
+
+```json
+{
+  "navigation": [
+    {
+      "group": "Public API",
+      "pages": ["api/public/users", "api/public/products"]
+    },
+    {
+      "group": "Admin API",
+      "pages": ["api/admin/dashboard", "api/admin/settings"]
+    },
+    {
+      "group": "Webhooks",
+      "pages": ["api/webhooks/events"]
+    }
+  ]
+}
+```
+
+<Callout type="info">
+When using an array, each entry can override `basePath`, `baseUrl`, and `groupBy` individually. The top-level values serve as defaults.
+</Callout>
+
+### Project structure with multiple specs
+
+```
+my-docs/
+├── api/
+│   ├── public.yaml        ← Public API spec
+│   ├── admin.yaml         ← Admin API spec
+│   └── webhooks.yaml      ← Webhooks spec
+├── barodoc.config.json
+└── src/content/docs/
+    ├── en/
+    │   └── ...            ← your docs
+    └── api/               ← auto-generated (don't edit)
+        ├── public/
+        │   ├── users.mdx
+        │   └── products.mdx
+        ├── admin/
+        │   ├── dashboard.mdx
+        │   └── settings.mdx
+        └── webhooks/
+            └── events.mdx
+```
+
+<Callout type="warning">
+Files under `src/content/docs/{basePath}/` are **auto-generated** and overwritten on each build. Don't edit them by hand — modify your OpenAPI spec instead.
+</Callout>
+
+## Generated Output
+
+Each generated page includes:
+
+| Section | Description |
+|---------|-------------|
+| **API Overview** | Base URL, content type, and spec version |
+| **Endpoint TOC** | Quick-nav list of all endpoints on the page |
+| **Endpoint Header** | Method badge (GET/POST/...), path, summary |
+| **Parameters** | Name, type, required/optional, description, enum values |
+| **Request Body** | Content type, field schema with descriptions |
+| **Responses** | Status codes with descriptions and auto-generated JSON examples |
+| **cURL Example** | Ready-to-copy request example |
+| **API Playground** | Interactive form to test the endpoint live |
+
+## API Playground
+
+When `playground: true` (default), each endpoint gets an interactive playground:
+
+- **Authentication** — Bearer Token, API Key (header/query), Basic Auth
+- **Parameter inputs** — Text fields, enum dropdowns, required field validation
+- **Request body editor** — JSON editor with auto-generated example body
+- **Code snippets** — cURL, JavaScript (fetch), Python (requests), Node.js
+- **Response viewer** — Syntax-highlighted JSON body, headers, status, timing, size
+- **Request history** — Last 5 requests stored in IndexedDB for quick re-testing
+
+Set `playground: false` to generate documentation-only pages without the interactive form.
+
+## Options Reference
+
+### Single spec (string)
 
 <ParamFieldGroup>
   <ParamField name="specFile" type="string" required>
-    Path to the OpenAPI spec file (YAML or JSON), relative to the docs root
+    Path to the OpenAPI spec file (YAML or JSON), relative to the project root.
   </ParamField>
   <ParamField name="basePath" type="string">
-    Base path for generated API doc pages. Default: `"api"`
+    Directory for generated pages inside `src/content/docs/`. Default: `"api"`
   </ParamField>
   <ParamField name="groupBy" type="'tags' | 'paths'">
-    Group endpoints by tags or paths. Default: `"tags"`
+    How to group endpoints into pages. `"tags"` creates one page per tag, `"paths"` groups all endpoints into a single page. Default: `"tags"`
   </ParamField>
   <ParamField name="baseUrl" type="string">
-    Base URL for API requests in the playground. Default: `""`
+    Base URL prepended to endpoint paths in the playground and cURL examples. Default: `""`
   </ParamField>
   <ParamField name="playground" type="boolean">
-    Enable the interactive API Playground. Default: `true`
+    Enable the interactive API Playground on each endpoint. Default: `true`
   </ParamField>
 </ParamFieldGroup>
+
+### Multiple specs (array)
+
+When `specFile` is an array, each entry supports:
+
+<ParamFieldGroup>
+  <ParamField name="file" type="string" required>
+    Path to the OpenAPI spec file, relative to the project root.
+  </ParamField>
+  <ParamField name="basePath" type="string">
+    Directory for this spec's generated pages. Overrides the top-level `basePath`.
+  </ParamField>
+  <ParamField name="groupBy" type="'tags' | 'paths'">
+    Grouping strategy for this spec. Overrides the top-level `groupBy`.
+  </ParamField>
+  <ParamField name="baseUrl" type="string">
+    Base URL for this spec's playground. Overrides the top-level `baseUrl`.
+  </ParamField>
+</ParamFieldGroup>
+
+## Supported Spec Features
+
+The plugin reads the following from your OpenAPI spec:
+
+- `info` — title, version, description (used in API overview)
+- `paths` — all operations with their HTTP methods
+- `parameters` — query, path, header, cookie params with types and descriptions
+- `requestBody` — content types and JSON schema
+- `responses` — status codes, descriptions, and response schemas
+- `components/schemas` — `$ref` resolution for nested schemas
+- `tags` — used for grouping endpoints into pages
+- Enum values, format hints (`date`, `email`, `int64`), and nested objects
+
+<Callout type="tip">
+Your spec doesn't need to be complete — the plugin gracefully handles missing descriptions, schemas, or examples by generating sensible defaults.
+</Callout>

--- a/docs/src/content/docs/ko/guides/configuration.mdx
+++ b/docs/src/content/docs/ko/guides/configuration.mdx
@@ -73,6 +73,25 @@ difficulty: intermediate
 }
 ```
 
+## 탭 (tabs)
+
+헤더에 최상위 네비게이션 링크를 추가하여 콘텐츠 섹션(Docs, Blog, API, Changelog 등) 간 전환할 수 있습니다:
+
+```json
+{
+  "tabs": [
+    { "label": "Docs", "href": "/docs/introduction" },
+    { "label": "Blog", "href": "/blog" },
+    { "label": "API Reference", "href": "/docs/api/pet" },
+    { "label": "Changelog", "href": "/changelog" }
+  ]
+}
+```
+
+각 탭은 `label`(표시 텍스트)과 `href`(링크 대상)를 가집니다. 현재 URL에 따라 활성 탭이 하이라이트됩니다. 탭은 데스크톱 헤더와 모바일 네비게이션 드로어에 표시됩니다. 선택 사항 — 생략하면 로고와 topbar 아이콘만 표시합니다.
+
+자세한 내용은 [Content Structure](/docs/guides/content-structure)에서 각 콘텐츠 타입이 어떻게 연결되는지 확인하세요.
+
 ## 네비게이션
 
 사이드바 구조를 정의합니다:
@@ -172,6 +191,12 @@ UI 요소의 border radius (예: `"0.5rem"`, `"8px"`).
   "lastUpdated": true
 }
 ```
+
+## 페이지 기여자
+
+문서 페이지 하단에 기여자가 자동으로 표시됩니다 — 별도 설정이 필요 없습니다. Barodoc이 Git 히스토리를 읽어 가장 최근 수정자의 아바타를 보여주고, 추가 기여자가 있으면 **+N** 배지로 표시합니다. 배지에 마우스를 올리면 이름이 표시됩니다.
+
+아바타는 GitHub (noreply 이메일) 또는 Gravatar에서 가져옵니다. 이 기능은 프로젝트가 커밋 히스토리가 있는 Git 저장소여야 합니다. 자세한 내용은 [콘텐츠 구조](/docs/guides/content-structure)를 참고하세요.
 
 ## announcement
 

--- a/docs/src/content/docs/ko/guides/content-structure.mdx
+++ b/docs/src/content/docs/ko/guides/content-structure.mdx
@@ -1,14 +1,65 @@
 ---
 title: Content Structure
-description: 콘텐츠 위치와 URL 구조
-tags: [content, structure, frontmatter]
-related: [guides/configuration, guides/i18n]
+description: docs, blog, API 레퍼런스, changelog 콘텐츠 타입이 어떻게 동작하는지
+tags: [content, structure, frontmatter, blog, api, changelog]
+related: [guides/configuration, guides/i18n, guides/plugins/openapi]
 difficulty: beginner
 ---
 
-Barodoc 콘텐츠는 locale별로 정리되며, 폴더 구조가 URL 경로가 됩니다. **CLI(제로 설정)** 모드에서는 **`docs/`** 아래에 두고(예: `docs/en/`, `docs/ko/`), **수동 Astro** 모드에서는 **`src/content/docs/`** 아래에 둡니다(예: `src/content/docs/en/`). 아래 규칙은 두 방식 모두에 적용됩니다.
+import Callout from "@barodoc/theme-docs/components/mdx/Callout.astro";
 
-## 디렉터리 구조
+Barodoc는 네 가지 콘텐츠 타입을 기본 제공합니다: **Docs**, **Blog**, **API Reference**, **Changelog**. 각각 별도의 디렉터리, 스키마, 라우팅을 가지지만 — 동일한 사이트 셸(헤더, 테마, 검색)을 공유합니다.
+
+## 전체 구조
+
+```
+my-project/
+├── src/content/
+│   ├── docs/           # 문서 페이지 (사이드바 네비게이션)
+│   │   ├── en/
+│   │   └── ko/
+│   ├── blog/           # 블로그 포스트 (카드 그리드, 날짜순)
+│   └── changelog/      # 릴리스 노트 (타임라인 뷰)
+├── public/             # 정적 파일 (이미지, 로고, 파비콘)
+├── barodoc.config.json # 사이트 설정, 네비게이션, 탭
+└── openapi.yaml        # OpenAPI 스펙 (API 레퍼런스 사용 시)
+```
+
+| 콘텐츠 타입 | 디렉터리 | 라우트 | 레이아웃 |
+|---|---|---|---|
+| Docs | `src/content/docs/{locale}/` | `/docs/{slug}` | 사이드바 + 목차 |
+| Blog | `src/content/blog/` | `/blog/{slug}` | 단일 컬럼 아티클 |
+| API Reference | OpenAPI 스펙에서 자동 생성 | `/docs/api/{slug}` | 사이드바 + 플레이그라운드 |
+| Changelog | `src/content/changelog/` | `/changelog` | 타임라인 |
+
+## 탭으로 콘텐츠 타입 연결하기
+
+`tabs` 설정으로 헤더에 최상위 네비게이션 링크를 추가하여 콘텐츠 타입 간 전환할 수 있습니다:
+
+```json
+{
+  "tabs": [
+    { "label": "Docs", "href": "/docs/introduction" },
+    { "label": "Blog", "href": "/blog" },
+    { "label": "API Reference", "href": "/docs/api/pet" },
+    { "label": "Changelog", "href": "/changelog" }
+  ]
+}
+```
+
+탭은 데스크톱 헤더와 모바일 네비게이션 드로어에 표시됩니다. 현재 URL에 따라 활성 탭이 하이라이트됩니다.
+
+<Callout type="info">
+`tabs`는 선택 사항입니다. 생략하면 헤더에 로고와 topbar 아이콘만 표시됩니다. docs 외에 다른 콘텐츠 타입이 있을 때 추가하세요.
+</Callout>
+
+---
+
+## Docs
+
+문서는 기본 콘텐츠 타입입니다. locale 기반 폴더를 사용하며 사이드바는 `barodoc.config.json`에서 정의합니다.
+
+### 디렉터리 구조
 
 **CLI 모드** (프로젝트 루트의 `docs/`):
 
@@ -26,36 +77,46 @@ docs/
 
 ```
 src/content/docs/
-├── en/                        # 기본 locale (예: /docs/...)
+├── en/
 │   ├── introduction.mdx       # /docs/introduction
-│   ├── quickstart.mdx         # /docs/quickstart
+│   ├── quickstart.mdx          # /docs/quickstart
 │   └── guides/
-│       ├── installation.mdx   # /docs/guides/installation
-│       └── deployment.mdx     # /docs/guides/deployment
-└── ko/                        # 두 번째 locale (예: /ko/docs/...)
-    ├── introduction.mdx       # /ko/docs/introduction
+│       ├── installation.mdx    # /docs/guides/installation
+│       └── deployment.mdx      # /docs/guides/deployment
+└── ko/
+    ├── introduction.mdx        # /ko/docs/introduction
     └── guides/
-        └── installation.mdx   # /ko/docs/guides/installation
+        └── installation.mdx    # /ko/docs/guides/installation
 ```
 
-- **locale 폴더**(`en`, `ko` 등)는 필수입니다. 단일 언어 문서도 하나를 사용합니다(예: `en/`).
-- **파일 경로 = URL slug**: `guides/installation.mdx` → `/docs/guides/installation` (i18n 사용 시 `/[locale]/docs/guides/installation`).
-- 파일명은 **소문자**와 **하이픈** 사용을 권장합니다(예: `code-group.mdx`). URL이 일관되게 유지됩니다.
+- **locale 폴더**(`en`, `ko` 등)는 필수입니다 — 단일 언어 사이트도 하나 필요합니다.
+- **파일 경로 = URL slug**: `guides/installation.mdx` → `/docs/guides/installation`.
+- 파일명은 **소문자**와 **하이픈** 사용 권장 (`code-group.mdx`, `CodeGroup.mdx` X).
 
-## 페이지 slug와 네비게이션
+### 사이드바 네비게이션
 
-`barodoc.config.json`의 `navigation.pages`에는 **locale과 `.mdx`를 뺀 slug**를 넣습니다:
+`barodoc.config.json`의 `navigation` 배열로 사이드바를 정의합니다. **locale과 `.mdx`를 뺀 slug**를 사용합니다:
 
-- 파일: `src/content/docs/en/guides/installation.mdx`  
-  nav slug: `guides/installation`
-- 파일: `src/content/docs/en/components/accordion.mdx`  
-  nav slug: `components/accordion`
+```json
+{
+  "navigation": [
+    {
+      "group": "Getting Started",
+      "group:ko": "시작하기",
+      "pages": ["introduction", "quickstart"]
+    },
+    {
+      "group": "Guides",
+      "group:ko": "가이드",
+      "pages": ["guides/installation", "guides/configuration"]
+    }
+  ]
+}
+```
 
-동일한 slug를 모든 locale에 쓰고, 각 locale 폴더(`en/...`, `ko/...`)에 해당 파일을 둡니다.
+동일한 slug를 모든 locale에서 공유하며, 각 locale 폴더에 해당 파일을 둡니다.
 
-## Frontmatter
-
-각 문서 상단에 `title`을 둡니다. 분류, 연관 문서 링크, AI 소비를 위한 추가 필드를 사용할 수 있습니다:
+### Frontmatter
 
 ```mdx
 ---
@@ -65,35 +126,248 @@ tags: [setup, cli]
 related: [quickstart, guides/configuration]
 category: guides
 difficulty: beginner
-api_reference: false
 ---
-
-# Installation
-...
 ```
 
 | 필드 | 타입 | 설명 |
 |------|------|------|
-| `title` | `string` | 페이지 제목. 브라우저 탭, 사이드바, 메타에 사용. |
-| `description` | `string` | 메타 설명과 미리보기에 사용. |
-| `tags` | `string[]` | 검색 및 AI 에이전트 필터링용 분류 태그. |
-| `related` | `string[]` | 관련 페이지의 slug. `barodoc check`가 유효성을 검증. |
-| `category` | `string` | 카테고리 직접 지정. 생략 시 navigation 그룹에서 자동 감지. |
+| `title` | `string` | 페이지 제목 (브라우저 탭, 사이드바, 메타). |
+| `description` | `string` | 메타 설명. |
+| `tags` | `string[]` | 검색 및 필터링용 분류 태그. |
+| `related` | `string[]` | 관련 페이지 slug. |
+| `category` | `string` | 카테고리 직접 지정 (생략 시 nav 그룹에서 자동 감지). |
 | `difficulty` | `"beginner" \| "intermediate" \| "advanced"` | 콘텐츠 난이도. |
 | `api_reference` | `boolean` | API 레퍼런스 문서 표시. |
 | `lastUpdated` | `date` | 최종 수정일 수동 지정. |
 
+---
+
+## Blog
+
+블로그 포스트는 `src/content/blog/`에 둡니다 (locale 하위 폴더 없음). 날짜순 정렬되어 `/blog`에 카드 그리드로 표시됩니다.
+
+### 디렉터리 구조
+
+```
+src/content/blog/
+├── introducing-barodoc.mdx    → /blog/introducing-barodoc
+├── v6-release.mdx             → /blog/v6-release
+└── writing-great-docs.mdx     → /blog/writing-great-docs
+```
+
+### 블로그 포스트 만들기
+
+`src/content/blog/`에 `.mdx` (또는 `.md`) 파일을 생성합니다:
+
+```mdx
+---
+title: "Barodoc 소개"
+description: "Astro 기반 제로 설정 문서 프레임워크."
+excerpt: "몇 초 만에 아름다운 문서를."
+date: 2026-02-01
+author: "Barodoc Team"
+image: "/images/blog-cover.png"
+tags: ["announcement", "release"]
+---
+
+블로그 콘텐츠를 작성합니다. docs에서 쓰는 MDX 컴포넌트
+(Callout, Tabs, CodeGroup 등)를 모두 사용할 수 있습니다.
+```
+
+### Frontmatter
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `title` | `string` | 포스트 제목 (필수). |
+| `description` | `string` | 메타 설명. |
+| `excerpt` | `string` | 블로그 인덱스 카드에 표시되는 요약. |
+| `date` | `date` | 게시 날짜. 정렬에 사용. |
+| `author` | `string` | 작성자 이름. |
+| `avatar` | `string` | 작성자 아바타 이미지 URL. 인덱스와 포스트 페이지에서 작성자 이름 옆에 표시. |
+| `image` | `string` | 커버 이미지 경로 (인덱스 카드와 포스트 페이지에 표시). |
+| `tags` | `string[]` | 카드와 포스트 헤더에 배지로 표시되는 태그. |
+
+<Callout type="tip">
+`/blog` 인덱스 페이지는 자동 생성됩니다. 직접 만들 필요 없이 `src/content/blog/`에 포스트를 추가하면 바로 표시됩니다.
+</Callout>
+
+---
+
+## API Reference
+
+API 레퍼런스 페이지는 두 가지 방법으로 만들 수 있습니다: **OpenAPI 스펙에서 자동 생성** (권장) 또는 API 컴포넌트를 사용한 **수동 작성**.
+
+### 방법 1: OpenAPI 플러그인 (권장)
+
+`@barodoc/plugin-openapi`가 OpenAPI 스펙을 읽고 인터랙티브 플레이그라운드가 포함된 페이지를 자동 생성합니다. 단일 스펙 또는 여러 스펙을 사용할 수 있습니다:
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-openapi", {
+      "specFile": "openapi.yaml",
+      "basePath": "api",
+      "groupBy": "tags",
+      "playground": true
+    }]
+  ],
+  "navigation": [
+    {
+      "group": "API Reference",
+      "pages": ["api/pet", "api/store", "api/user"]
+    }
+  ]
+}
+```
+
+여러 API가 있는 프로젝트는 `specFile`에 배열을 전달합니다:
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-openapi", {
+      "specFile": [
+        { "file": "api/public.yaml", "basePath": "api/public" },
+        { "file": "api/admin.yaml", "basePath": "api/admin" }
+      ],
+      "playground": true
+    }]
+  ]
+}
+```
+
+생성된 페이지는 `/docs/api/...` 경로에 나타나며 일반 docs와 함께 사이드바에 표시됩니다. 멀티 스펙 설정을 포함한 전체 설정은 [OpenAPI 플러그인 가이드](/docs/guides/plugins/openapi)를 참고하세요.
+
+### 방법 2: 수동 API 컴포넌트
+
+커스텀 API 문서에는 `ApiEndpoint`, `ApiParams`, `ApiParam`, `ApiResponse` 컴포넌트를 MDX에서 직접 사용합니다. [API Reference Components](/docs/components/api-reference)를 참고하세요.
+
+---
+
+## Changelog
+
+체인지로그 항목은 `src/content/changelog/`에 둡니다. `/changelog`에 타임라인으로 표시됩니다.
+
+### 디렉터리 구조
+
+```
+src/content/changelog/
+├── v2.0.0.mdx    → /changelog에 표시
+├── v1.5.0.mdx
+└── v1.0.0.mdx
+```
+
+### 체인지로그 항목 만들기
+
+```mdx
+---
+version: "2.0.0"
+date: 2026-02-15
+title: "헤더 탭 & 블로그 개선"
+---
+
+### 새로운 기능
+- 최상위 네비게이션을 위한 설정 가능한 헤더 탭
+- 블로그 포스트의 코드 복사 버튼
+
+### 버그 수정
+- 모바일 네비게이션 스크롤 동작 수정
+```
+
+### Frontmatter
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `version` | `string` | 버전 번호 (필수). |
+| `date` | `date` | 릴리스 날짜 (필수). 정렬에 사용. |
+| `title` | `string` | 선택적 릴리스 제목. |
+
+---
+
+## 종합 예제
+
+모든 콘텐츠 타입을 설정한 일반적인 Barodoc 사이트:
+
+```json
+{
+  "name": "My Project",
+  "logo": "/logo.svg",
+
+  "tabs": [
+    { "label": "Docs", "href": "/docs/introduction" },
+    { "label": "Blog", "href": "/blog" },
+    { "label": "API", "href": "/docs/api/overview" },
+    { "label": "Changelog", "href": "/changelog" }
+  ],
+
+  "navigation": [
+    {
+      "group": "Getting Started",
+      "pages": ["introduction", "quickstart"]
+    },
+    {
+      "group": "API Reference",
+      "pages": ["api/overview", "api/users", "api/auth"]
+    }
+  ],
+
+  "plugins": [
+    "@barodoc/plugin-sitemap",
+    ["@barodoc/plugin-openapi", { "specFile": "openapi.yaml", "basePath": "api" }]
+  ]
+}
+```
+
+```
+my-project/
+├── src/content/
+│   ├── docs/en/              # ← 사이드바 문서
+│   │   ├── introduction.mdx
+│   │   └── guides/...
+│   ├── blog/                 # ← 블로그 포스트
+│   │   ├── hello-world.mdx
+│   │   └── v2-release.mdx
+│   └── changelog/            # ← 릴리스 노트
+│       ├── v2.0.0.mdx
+│       └── v1.0.0.mdx
+├── openapi.yaml              # ← API 스펙
+├── barodoc.config.json
+└── public/
+    └── logo.svg
+```
+
+### 콘텐츠 타입 독립성
+
+각 콘텐츠 타입은 **선택적이고 독립적**입니다:
+
+- **Docs만** — `blog/`나 `changelog/` 폴더를 만들지 않고 `tabs`도 생략. 기본값입니다.
+- **Docs + Blog** — `src/content/blog/`를 추가하고 Blog `tabs` 항목 추가.
+- **Docs + API** — OpenAPI 플러그인을 추가하고 API 페이지를 `navigation`에 포함.
+- **네 가지 모두** — 모든 폴더를 만들고 `tabs`로 전체 네비게이션 설정.
+
+테마는 없는 컬렉션을 자동으로 처리합니다 — `blog/`가 없으면 `/blog`에서 에러 대신 "No posts yet"을 표시합니다.
+
+## 페이지 기여자
+
+Barodoc은 모든 문서 페이지 하단에 Git 히스토리 기반으로 **Contributors** 섹션을 자동 표시합니다.
+
+- **가장 최근 수정자**의 아바타가 표시됩니다
+- 추가 기여자가 있으면 아바타 옆에 **+N** 카운트 배지가 나타납니다
+- 카운트 배지에 마우스를 올리면 나머지 기여자 이름이 표시됩니다
+- 아바타는 GitHub (`@users.noreply.github.com` 이메일) 또는 Gravatar에서 가져옵니다
+
+별도 설정 없이 자동으로 동작합니다. 빌드 시 `git log`에서 읽기 때문에 Git 저장소에 커밋 히스토리가 있어야 합니다.
+
 ## MDX와 컴포넌트
 
-- **Markdown**과 **MDX**(JSX 포함)를 사용할 수 있습니다.
-- 테마 컴포넌트(Tabs, Accordion, ParamField 등)는 파일 상단에서 import합니다. 개발 환경에서는 컴포넌트 경로를 사용합니다(예: `@barodoc/theme-docs/components/mdx/DocAccordion.tsx`). 예시는 [Components](/docs/components/accordion)를 참고하세요.
-- 인터랙티브 컴포넌트는 클라이언트에서 hydration되도록 `client:load` 디렉티브가 필요합니다(예: `<Tabs client:load ... />`).
+- **Markdown** (`.md`) 또는 **MDX** (`.mdx`)를 모든 콘텐츠 타입에 사용할 수 있습니다.
+- 테마 컴포넌트(Tabs, Accordion, Callout 등)는 docs와 블로그 포스트 모두에서 동작합니다.
+- 인터랙티브 컴포넌트는 hydration을 위해 `client:load`가 필요합니다 (예: `<Tabs client:load ... />`).
+- 전체 목록은 [Components](/docs/components/accordion)를 참고하세요.
 
 ## 정적 파일
 
-이미지 등 정적 파일은 **`public/`**에 두고, 사이트 루트 기준 경로로 참조합니다:
+이미지 등 정적 파일은 **`public/`**에 두고 사이트 루트 기준 경로로 참조합니다:
 
 - `public/logo.svg` → `/logo.svg`
 - `public/images/diagram.png` → `/images/diagram.png`
-
-이 경로를 `barodoc.config.json`(예: `logo`, `favicon`)과 MDX/Markdown(예: `![alt](/images/diagram.png)`)에서 사용하면 됩니다.

--- a/docs/src/content/docs/ko/guides/plugins/openapi.mdx
+++ b/docs/src/content/docs/ko/guides/plugins/openapi.mdx
@@ -1,10 +1,13 @@
 ---
 title: OpenAPI 플러그인
 description: OpenAPI/Swagger 스펙에서 API 문서를 자동 생성
+tags: [api, openapi, swagger, plugin]
+related: [guides/content-structure, components/api-reference]
 ---
 import { ParamField, ParamFieldGroup } from "@barodoc/theme-docs/components/mdx/ParamField.tsx";
+import Callout from "@barodoc/theme-docs/components/mdx/Callout.astro";
 
-OpenAPI 플러그인은 OpenAPI (Swagger) 스펙 파일에서 API 문서 페이지를 자동으로 생성합니다. 문서에서 직접 엔드포인트를 테스트할 수 있는 인터랙티브 API Playground가 포함됩니다.
+OpenAPI 플러그인은 OpenAPI (Swagger) 스펙 파일을 읽어서 API 문서 페이지를 자동으로 생성합니다. 파라미터 테이블, 응답 예제, cURL 스니펫, 그리고 엔드포인트를 바로 테스트할 수 있는 인터랙티브 플레이그라운드까지 포함됩니다.
 
 ## 설치
 
@@ -12,9 +15,18 @@ OpenAPI 플러그인은 OpenAPI (Swagger) 스펙 파일에서 API 문서 페이�
 pnpm add @barodoc/plugin-openapi@latest
 ```
 
-## 설정
+## 빠른 시작
 
-`barodoc.config.json`에 플러그인을 추가합니다:
+1. 프로젝트 루트에 OpenAPI 스펙 파일을 배치합니다:
+
+```
+my-docs/
+├── openapi.yaml          ← 스펙 파일
+├── barodoc.config.json
+└── src/content/docs/...
+```
+
+2. `barodoc.config.json`에 플러그인을 추가합니다:
 
 ```json
 {
@@ -30,75 +42,208 @@ pnpm add @barodoc/plugin-openapi@latest
 }
 ```
 
-## 스펙 파일
-
-OpenAPI 스펙 파일 (YAML 또는 JSON)을 docs 루트 디렉토리에 배치합니다:
-
-```
-docs/
-├── openapi.yaml    ← 스펙 파일
-├── barodoc.config.json
-└── src/
-```
-
-OpenAPI 3.0+ 스펙을 지원합니다. 경로, 오퍼레이션, 파라미터, 요청 본문, 응답 스키마, 예제를 읽습니다.
-
-## 생성되는 결과물
-
-플러그인은 태그(또는 경로)별로 그룹화된 MDX 페이지를 생성합니다. 각 페이지에는 다음이 포함됩니다:
-
-- **엔드포인트 헤더**: 메서드 배지, 경로, 설명
-- **엔드포인트 목차**: 상단에서 빠른 네비게이션
-- **파라미터 테이블**: 이름, 타입, 필수 여부, enum 값
-- **요청 본문 스키마**: 필드 설명 포함
-- **응답 예제**: 스키마에서 자동 생성
-- **cURL 요청 예제**
-- **인터랙티브 API Playground** (`playground: true` 설정 시)
-
-## API Playground 기능
-
-생성된 Playground는 다음을 지원합니다:
-
-- **다중 인증 방식**: Bearer Token, API Key, Basic Auth
-- **Enum 드롭다운**: enum 값이 있는 파라미터는 `<select>` 드롭다운으로 렌더링
-- **JSON 본문 유효성 검증**: 전송 전 요청 본문 검증
-- **코드 스니펫**: cURL, JavaScript, Python, Node.js
-- **응답 인스펙터**: JSON 구문 강조, 헤더, 상태, 시간, 크기 표시
-- **요청 히스토리**: 최근 5건의 요청을 IndexedDB에 저장
-
-## 네비게이션
-
-생성된 페이지를 네비게이션에 추가합니다:
+3. 생성된 페이지를 네비게이션에 추가합니다:
 
 ```json
 {
   "navigation": [
     {
       "group": "API Reference",
-      "pages": ["api/pet", "api/store", "api/user"]
+      "pages": ["api/users", "api/auth", "api/billing"]
     }
   ]
 }
 ```
 
-페이지 슬러그는 스펙의 태그 이름을 소문자로 변환하고 하이픈으로 연결한 값입니다.
+페이지 슬러그는 스펙의 **태그 이름**에서 파생됩니다 — 소문자로 변환하고 하이픈으로 연결합니다. 예를 들어 `User Management` 태그는 `api/user-management`이 됩니다.
 
-## 옵션
+4. (선택) 빠른 접근을 위한 탭 추가:
+
+```json
+{
+  "tabs": [
+    { "label": "Docs", "href": "/docs/introduction" },
+    { "label": "API", "href": "/docs/api/users" }
+  ]
+}
+```
+
+## 동작 원리
+
+빌드 시 플러그인이 수행하는 작업:
+
+1. OpenAPI 3.0+ 스펙 파일(YAML 또는 JSON)을 읽습니다
+2. 엔드포인트를 `tags` (또는 `paths`) 기준으로 그룹화합니다
+3. `src/content/docs/{basePath}/` 에 `.mdx` 파일을 생성합니다
+4. 각 파일에 API 컴포넌트와 플레이그라운드 임포트가 포함됩니다
+
+생성된 페이지는 일반 문서 페이지와 동일합니다 — 사이드바에 표시되고, 검색을 지원하며, 같은 테마를 공유합니다.
+
+## 여러 API 스펙 사용
+
+프로젝트에 여러 API가 있는 경우(예: 공개 API, 관리자 API, 웹훅), `specFile`에 배열을 전달합니다:
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-openapi", {
+      "specFile": [
+        {
+          "file": "api/public.yaml",
+          "basePath": "api/public",
+          "baseUrl": "https://api.example.com/v1"
+        },
+        {
+          "file": "api/admin.yaml",
+          "basePath": "api/admin",
+          "baseUrl": "https://admin.example.com"
+        },
+        {
+          "file": "api/webhooks.yaml",
+          "basePath": "api/webhooks",
+          "groupBy": "paths"
+        }
+      ],
+      "playground": true
+    }]
+  ]
+}
+```
+
+각 항목은 자체 `basePath` 아래에 별도의 페이지 세트를 생성합니다. 네비게이션에도 따로 추가합니다:
+
+```json
+{
+  "navigation": [
+    {
+      "group": "Public API",
+      "pages": ["api/public/users", "api/public/products"]
+    },
+    {
+      "group": "Admin API",
+      "pages": ["api/admin/dashboard", "api/admin/settings"]
+    },
+    {
+      "group": "Webhooks",
+      "pages": ["api/webhooks/events"]
+    }
+  ]
+}
+```
+
+<Callout type="info">
+배열을 사용할 때 각 항목에서 `basePath`, `baseUrl`, `groupBy`를 개별적으로 재정의할 수 있습니다. 최상위 값이 기본값으로 사용됩니다.
+</Callout>
+
+### 여러 스펙을 사용할 때의 프로젝트 구조
+
+```
+my-docs/
+├── api/
+│   ├── public.yaml        ← 공개 API 스펙
+│   ├── admin.yaml         ← 관리자 API 스펙
+│   └── webhooks.yaml      ← 웹훅 스펙
+├── barodoc.config.json
+└── src/content/docs/
+    ├── ko/
+    │   └── ...            ← 문서
+    └── api/               ← 자동 생성 (수정 금지)
+        ├── public/
+        │   ├── users.mdx
+        │   └── products.mdx
+        ├── admin/
+        │   ├── dashboard.mdx
+        │   └── settings.mdx
+        └── webhooks/
+            └── events.mdx
+```
+
+<Callout type="warning">
+`src/content/docs/{basePath}/` 아래의 파일은 **자동 생성**되며 매 빌드마다 덮어쓰여집니다. 직접 편집하지 말고, OpenAPI 스펙 파일을 수정하세요.
+</Callout>
+
+## 생성되는 결과물
+
+각 생성된 페이지에 포함되는 내용:
+
+| 섹션 | 설명 |
+|------|------|
+| **API 개요** | Base URL, 콘텐츠 타입, 스펙 버전 |
+| **엔드포인트 목차** | 페이지 내 모든 엔드포인트 빠른 이동 |
+| **엔드포인트 헤더** | 메서드 배지 (GET/POST/...), 경로, 요약 |
+| **파라미터** | 이름, 타입, 필수/선택, 설명, enum 값 |
+| **요청 본문** | 콘텐츠 타입, 필드 스키마 및 설명 |
+| **응답** | 상태 코드, 설명, 자동 생성된 JSON 예제 |
+| **cURL 예제** | 바로 복사 가능한 요청 예제 |
+| **API Playground** | 엔드포인트를 바로 테스트할 수 있는 인터랙티브 폼 |
+
+## API Playground
+
+`playground: true` (기본값)로 설정하면 각 엔드포인트에 인터랙티브 플레이그라운드가 생성됩니다:
+
+- **인증** — Bearer Token, API Key (헤더/쿼리), Basic Auth
+- **파라미터 입력** — 텍스트 필드, enum 드롭다운, 필수 필드 유효성 검증
+- **요청 본문 편집기** — 자동 생성된 예제 본문이 포함된 JSON 편집기
+- **코드 스니펫** — cURL, JavaScript (fetch), Python (requests), Node.js
+- **응답 뷰어** — JSON 구문 강조, 헤더, 상태, 응답 시간, 크기
+- **요청 히스토리** — 최근 5건의 요청을 IndexedDB에 저장하여 빠른 재테스트
+
+`playground: false`로 설정하면 인터랙티브 폼 없이 문서 전용 페이지를 생성합니다.
+
+## 옵션 레퍼런스
+
+### 단일 스펙 (string)
 
 <ParamFieldGroup>
   <ParamField name="specFile" type="string" required>
-    docs 루트 기준 OpenAPI 스펙 파일 경로 (YAML 또는 JSON)
+    OpenAPI 스펙 파일 경로 (YAML 또는 JSON), 프로젝트 루트 기준 상대 경로.
   </ParamField>
   <ParamField name="basePath" type="string">
-    생성될 API 문서 페이지의 기본 경로. 기본값: `"api"`
+    `src/content/docs/` 내에서 생성될 페이지 디렉토리. 기본값: `"api"`
   </ParamField>
   <ParamField name="groupBy" type="'tags' | 'paths'">
-    엔드포인트 그룹화 방식. 기본값: `"tags"`
+    엔드포인트를 페이지로 그룹화하는 방식. `"tags"`는 태그당 하나의 페이지를 생성하고, `"paths"`는 모든 엔드포인트를 단일 페이지로 그룹화합니다. 기본값: `"tags"`
   </ParamField>
   <ParamField name="baseUrl" type="string">
-    Playground에서 API 요청에 사용할 기본 URL. 기본값: `""`
+    플레이그라운드와 cURL 예제에서 엔드포인트 경로 앞에 붙는 기본 URL. 기본값: `""`
   </ParamField>
   <ParamField name="playground" type="boolean">
-    인터랙티브 API Playground 활성화 여부. 기본값: `true`
+    각 엔드포인트에 인터랙티브 API Playground를 활성화합니다. 기본값: `true`
   </ParamField>
 </ParamFieldGroup>
+
+### 여러 스펙 (array)
+
+`specFile`이 배열일 때 각 항목에서 지원하는 속성:
+
+<ParamFieldGroup>
+  <ParamField name="file" type="string" required>
+    OpenAPI 스펙 파일 경로, 프로젝트 루트 기준 상대 경로.
+  </ParamField>
+  <ParamField name="basePath" type="string">
+    이 스펙의 생성 페이지 디렉토리. 최상위 `basePath`를 재정의합니다.
+  </ParamField>
+  <ParamField name="groupBy" type="'tags' | 'paths'">
+    이 스펙의 그룹화 방식. 최상위 `groupBy`를 재정의합니다.
+  </ParamField>
+  <ParamField name="baseUrl" type="string">
+    이 스펙의 플레이그라운드 기본 URL. 최상위 `baseUrl`을 재정의합니다.
+  </ParamField>
+</ParamFieldGroup>
+
+## 지원하는 스펙 기능
+
+플러그인이 OpenAPI 스펙에서 읽어오는 항목:
+
+- `info` — 제목, 버전, 설명 (API 개요에 사용)
+- `paths` — HTTP 메서드별 모든 오퍼레이션
+- `parameters` — query, path, header, cookie 파라미터와 타입, 설명
+- `requestBody` — 콘텐츠 타입과 JSON 스키마
+- `responses` — 상태 코드, 설명, 응답 스키마
+- `components/schemas` — 중첩 스키마에 대한 `$ref` 해석
+- `tags` — 엔드포인트를 페이지로 그룹화하는 데 사용
+- enum 값, 포맷 힌트 (`date`, `email`, `int64`), 중첩 객체
+
+<Callout type="tip">
+스펙이 완전하지 않아도 됩니다 — 설명, 스키마, 예제가 없어도 플러그인이 합리적인 기본값을 생성합니다.
+</Callout>

--- a/packages/plugin-openapi/src/index.ts
+++ b/packages/plugin-openapi/src/index.ts
@@ -4,8 +4,15 @@ import fs from "node:fs";
 import path from "node:path";
 import { parse as parseYaml } from "yaml";
 
+export interface OpenApiSpecEntry {
+  file: string;
+  basePath?: string;
+  groupBy?: "tags" | "paths";
+  baseUrl?: string;
+}
+
 export interface OpenApiPluginOptions {
-  specFile: string;
+  specFile: string | OpenApiSpecEntry[];
   basePath?: string;
   groupBy?: "tags" | "paths";
   baseUrl?: string;
@@ -300,38 +307,120 @@ function generateMdxForOperation(
   return lines.join("\n");
 }
 
+function processSpec(
+  root: string,
+  entry: { file: string; basePath: string; groupBy: string; baseUrl: string },
+  playground: boolean,
+  importBlock: string,
+) {
+  const specPath = path.resolve(root, entry.file);
+
+  if (!fs.existsSync(specPath)) {
+    console.warn(`[plugin-openapi] Spec file not found: ${specPath}`);
+    return;
+  }
+
+  const raw = fs.readFileSync(specPath, "utf-8");
+  const spec: OpenApiSpec = specPath.endsWith(".yaml") || specPath.endsWith(".yml")
+    ? parseYaml(raw)
+    : JSON.parse(raw);
+
+  if (!spec.paths) return;
+
+  const genOpts: GenerateOptions = { playground, baseUrl: entry.baseUrl };
+
+  const pagesDir = path.join(root, "src/content/docs");
+  const apiDir = path.join(pagesDir, entry.basePath.replace(/^\//, ""));
+  fs.mkdirSync(apiDir, { recursive: true });
+
+  const apiOverview = buildApiOverview(spec, entry.baseUrl);
+
+  if (entry.groupBy === "tags") {
+    const tagMap = new Map<string, { method: string; path: string; summary: string }[]>();
+    const tagOps = new Map<string, string[]>();
+
+    for (const [urlPath, methods] of Object.entries(spec.paths)) {
+      for (const [method, op] of Object.entries(methods)) {
+        const tags = op.tags?.length ? op.tags : ["default"];
+        const mdx = generateMdxForOperation(method, urlPath, op, spec, genOpts);
+        for (const tag of tags) {
+          if (!tagMap.has(tag)) tagMap.set(tag, []);
+          if (!tagOps.has(tag)) tagOps.set(tag, []);
+          tagMap.get(tag)!.push({ method: method.toUpperCase(), path: urlPath, summary: op.summary || "" });
+          tagOps.get(tag)!.push(mdx);
+        }
+      }
+    }
+
+    for (const [tag, endpoints] of tagMap) {
+      const slug = tag.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+      const toc = buildEndpointToc(endpoints);
+      const content = [
+        "---",
+        `title: "${tag}"`,
+        `description: "API endpoints for ${tag}"`,
+        "api_reference: true",
+        "---",
+        importBlock,
+        apiOverview,
+        toc,
+        ...tagOps.get(tag)!,
+      ].join("\n");
+      fs.writeFileSync(path.join(apiDir, `${slug}.mdx`), content);
+    }
+  } else {
+    const allOps: string[] = [];
+    const allEndpoints: { method: string; path: string; summary: string }[] = [];
+    for (const [urlPath, methods] of Object.entries(spec.paths)) {
+      for (const [method, op] of Object.entries(methods)) {
+        allOps.push(generateMdxForOperation(method, urlPath, op, spec, genOpts));
+        allEndpoints.push({ method: method.toUpperCase(), path: urlPath, summary: op.summary || "" });
+      }
+    }
+    const toc = buildEndpointToc(allEndpoints);
+    const content = [
+      "---",
+      `title: "API Reference"`,
+      `description: "Auto-generated from OpenAPI spec"`,
+      "api_reference: true",
+      "---",
+      importBlock,
+      apiOverview,
+      toc,
+      ...allOps,
+    ].join("\n");
+    fs.writeFileSync(path.join(apiDir, "index.mdx"), content);
+  }
+}
+
 export default definePlugin<OpenApiPluginOptions>((options) => {
   const {
     specFile,
-    basePath = "/api",
+    basePath = "api",
     groupBy = "tags",
     baseUrl = "",
     playground = true,
   } = options;
 
+  const entries: { file: string; basePath: string; groupBy: string; baseUrl: string }[] =
+    Array.isArray(specFile)
+      ? specFile.map((s) => ({
+          file: s.file,
+          basePath: s.basePath ?? basePath,
+          groupBy: s.groupBy ?? groupBy,
+          baseUrl: s.baseUrl ?? baseUrl,
+        }))
+      : [{ file: specFile, basePath, groupBy, baseUrl }];
+
   return {
     name: "@barodoc/plugin-openapi",
-    astroIntegration: (context) => {
+    astroIntegration: () => {
       const integration: AstroIntegration = {
         name: "@barodoc/plugin-openapi",
         hooks: {
-          "astro:config:setup": ({ injectRoute, config: astroConfig }) => {
+          "astro:config:setup": ({ config: astroConfig }) => {
             const root = astroConfig.root.pathname;
-            const specPath = path.resolve(root, specFile);
 
-            if (!fs.existsSync(specPath)) {
-              console.warn(`[plugin-openapi] Spec file not found: ${specPath}`);
-              return;
-            }
-
-            const raw = fs.readFileSync(specPath, "utf-8");
-            const spec: OpenApiSpec = specPath.endsWith(".yaml") || specPath.endsWith(".yml")
-              ? parseYaml(raw)
-              : JSON.parse(raw);
-
-            if (!spec.paths) return;
-
-            const genOpts: GenerateOptions = { playground, baseUrl };
             const imports: string[] = [];
             imports.push(`import { ApiEndpoint } from "@barodoc/theme-docs/components";`);
             if (playground) {
@@ -339,67 +428,8 @@ export default definePlugin<OpenApiPluginOptions>((options) => {
             }
             const importBlock = imports.join("\n") + "\n";
 
-            const pagesDir = path.join(root, "src/content/docs");
-            const apiDir = path.join(pagesDir, basePath.replace(/^\//, ""));
-            fs.mkdirSync(apiDir, { recursive: true });
-
-            const apiOverview = buildApiOverview(spec, baseUrl);
-
-            if (groupBy === "tags") {
-              const tagMap = new Map<string, { method: string; path: string; summary: string }[]>();
-              const tagOps = new Map<string, string[]>();
-
-              for (const [urlPath, methods] of Object.entries(spec.paths)) {
-                for (const [method, op] of Object.entries(methods)) {
-                  const tags = op.tags?.length ? op.tags : ["default"];
-                  const mdx = generateMdxForOperation(method, urlPath, op, spec, genOpts);
-                  for (const tag of tags) {
-                    if (!tagMap.has(tag)) tagMap.set(tag, []);
-                    if (!tagOps.has(tag)) tagOps.set(tag, []);
-                    tagMap.get(tag)!.push({ method: method.toUpperCase(), path: urlPath, summary: op.summary || "" });
-                    tagOps.get(tag)!.push(mdx);
-                  }
-                }
-              }
-
-              for (const [tag, endpoints] of tagMap) {
-                const slug = tag.toLowerCase().replace(/[^a-z0-9]+/g, "-");
-                const toc = buildEndpointToc(endpoints);
-                const content = [
-                  "---",
-                  `title: "${tag}"`,
-                  `description: "API endpoints for ${tag}"`,
-                  "api_reference: true",
-                  "---",
-                  importBlock,
-                  apiOverview,
-                  toc,
-                  ...tagOps.get(tag)!,
-                ].join("\n");
-                fs.writeFileSync(path.join(apiDir, `${slug}.mdx`), content);
-              }
-            } else {
-              const allOps: string[] = [];
-              const allEndpoints: { method: string; path: string; summary: string }[] = [];
-              for (const [urlPath, methods] of Object.entries(spec.paths)) {
-                for (const [method, op] of Object.entries(methods)) {
-                  allOps.push(generateMdxForOperation(method, urlPath, op, spec, genOpts));
-                  allEndpoints.push({ method: method.toUpperCase(), path: urlPath, summary: op.summary || "" });
-                }
-              }
-              const toc = buildEndpointToc(allEndpoints);
-              const content = [
-                "---",
-                `title: "API Reference"`,
-                `description: "Auto-generated from OpenAPI spec"`,
-                "api_reference: true",
-                "---",
-                importBlock,
-                apiOverview,
-                toc,
-                ...allOps,
-              ].join("\n");
-              fs.writeFileSync(path.join(apiDir, "index.mdx"), content);
+            for (const entry of entries) {
+              processSpec(root, entry, playground, importBlock);
             }
           },
         },

--- a/packages/theme-docs/src/components/Contributors.astro
+++ b/packages/theme-docs/src/components/Contributors.astro
@@ -27,11 +27,21 @@ if (filePath) {
       for (const line of raw.split("\n")) {
         const [name, email] = line.split("|");
         if (!name || seen.has(email)) continue;
-        const hash = email.trim().toLowerCase();
-        seen.set(email, {
-          name: name.trim(),
-          email: email.trim(),
-          avatarUrl: `https://gravatar.com/avatar/${await computeHash(hash)}?s=64&d=mp`,
+
+        const trimmedEmail = email.trim();
+        const trimmedName = name.trim();
+
+        const noreplyMatch = trimmedEmail.match(
+          /^(\d+\+)?([^@]+)@users\.noreply\.github\.com$/
+        );
+        const avatarUrl = noreplyMatch
+          ? `https://github.com/${noreplyMatch[2]}.png?size=64`
+          : `https://gravatar.com/avatar/${await computeHash(trimmedEmail.toLowerCase())}?s=64&d=mp`;
+
+        seen.set(trimmedEmail, {
+          name: trimmedName,
+          email: trimmedEmail,
+          avatarUrl,
         });
       }
       contributors = Array.from(seen.values());
@@ -55,17 +65,23 @@ async function computeHash(input: string): Promise<string> {
   <div class="bd-contributors">
     <span class="bd-contributors-label">Contributors</span>
     <div class="bd-contributors-avatars">
-      {contributors.map((c) => (
-        <img
-          src={c.avatarUrl}
-          alt={c.name}
-          title={c.name}
-          class="bd-contributor-avatar"
-          loading="lazy"
-          width="28"
-          height="28"
-        />
-      ))}
+      <img
+        src={contributors[0].avatarUrl}
+        alt={contributors[0].name}
+        title={contributors[0].name}
+        class="bd-contributor-avatar"
+        loading="lazy"
+        width="28"
+        height="28"
+      />
+      {contributors.length > 1 && (
+        <span
+          class="bd-contributor-count"
+          title={contributors.slice(1).map((c) => c.name).join(", ")}
+        >
+          +{contributors.length - 1}
+        </span>
+      )}
     </div>
   </div>
 )}

--- a/packages/theme-docs/src/layouts/BlogLayout.astro
+++ b/packages/theme-docs/src/layouts/BlogLayout.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "./BaseLayout.astro";
 import Header from "../components/Header.astro";
 import Banner from "../components/Banner.astro";
+import CodeCopy from "../components/CodeCopy.astro";
 import { defaultLocale } from "virtual:barodoc/i18n";
 import { getLocaleFromPath } from "@barodoc/core";
 
@@ -10,12 +11,13 @@ interface Props {
   description?: string;
   date?: Date;
   author?: string;
+  avatar?: string;
   image?: string;
   tags?: string[];
   readingTime?: string;
 }
 
-const { title, description, date, author, image, tags = [], readingTime } = Astro.props;
+const { title, description, date, author, avatar, image, tags = [], readingTime } = Astro.props;
 const currentPath = Astro.url.pathname;
 const i18nConfig = { defaultLocale, locales: [defaultLocale] };
 const currentLocale = getLocaleFromPath(currentPath, i18nConfig);
@@ -47,7 +49,18 @@ const currentLocale = getLocaleFromPath(currentPath, i18nConfig);
           </p>
         )}
         <div class="mt-4 flex items-center gap-3 text-sm text-[var(--bd-text-muted)]">
-          {author && <span>{author}</span>}
+          {author && (
+            <span class="flex items-center gap-2">
+              {avatar && (
+                <img
+                  src={avatar}
+                  alt={author}
+                  class="w-6 h-6 rounded-full object-cover ring-1 ring-[var(--bd-border)]"
+                />
+              )}
+              <span>{author}</span>
+            </span>
+          )}
           {author && date && <span class="text-[var(--bd-border)]">&middot;</span>}
           {date && (
             <time datetime={date.toISOString()}>
@@ -75,6 +88,7 @@ const currentLocale = getLocaleFromPath(currentPath, i18nConfig);
       <div class="prose prose-gray dark:prose-invert max-w-none">
         <slot />
       </div>
+      <CodeCopy />
 
       <!-- Back to blog -->
       <div class="mt-12 pt-8 border-t border-[var(--bd-border)]">

--- a/packages/theme-docs/src/pages/blog/[...slug].astro
+++ b/packages/theme-docs/src/pages/blog/[...slug].astro
@@ -31,6 +31,7 @@ const readTime = readingTime(post.body ?? "");
   description={post.data.description || post.data.excerpt}
   date={post.data.date ? new Date(post.data.date) : undefined}
   author={post.data.author}
+  avatar={post.data.avatar}
   image={post.data.image}
   tags={post.data.tags}
   readingTime={readTime.text}

--- a/packages/theme-docs/src/pages/blog/index.astro
+++ b/packages/theme-docs/src/pages/blog/index.astro
@@ -74,7 +74,18 @@ const sortedPosts = posts.sort((a, b) => {
                   </p>
                 )}
                 <div class="mt-auto pt-2 flex items-center gap-2 text-xs text-[var(--bd-text-muted)]">
-                  {post.data.author && <span>{post.data.author}</span>}
+                  {post.data.author && (
+                    <span class="flex items-center gap-1.5">
+                      {post.data.avatar && (
+                        <img
+                          src={post.data.avatar}
+                          alt={post.data.author}
+                          class="w-4 h-4 rounded-full object-cover"
+                        />
+                      )}
+                      <span>{post.data.author}</span>
+                    </span>
+                  )}
                   {post.data.author && post.data.date && <span>&middot;</span>}
                   {post.data.date && (
                     <time datetime={new Date(post.data.date).toISOString()}>

--- a/packages/theme-docs/src/pages/docs/[...slug].astro
+++ b/packages/theme-docs/src/pages/docs/[...slug].astro
@@ -125,7 +125,7 @@ breadcrumbs.push({ label: doc.data.title });
   lastUpdated={lastUpdated}
   breadcrumbs={breadcrumbs}
   readingTime={readTime.text}
-  filePath={doc.id}
+  filePath={`src/content/docs/${doc.id}`}
 >
   {category && (
     <p class="text-xs font-semibold uppercase tracking-widest text-primary-600 dark:text-primary-400 mb-3">

--- a/packages/theme-docs/src/styles/global.css
+++ b/packages/theme-docs/src/styles/global.css
@@ -983,6 +983,22 @@
   margin-left: 0;
 }
 
+.bd-contributor-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 9999px;
+  border: 2px solid var(--bd-bg);
+  margin-left: -0.375rem;
+  background: var(--bd-bg-subtle);
+  color: var(--bd-text-muted);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  cursor: default;
+}
+
 /* ==========================================================================
    Version Switcher
    ========================================================================== */


### PR DESCRIPTION
## Summary

- **Multi-spec OpenAPI** — `specFile` accepts an array of spec entries for multiple APIs
- **Changelog** — Timeline-based changelog at `/changelog` with sample entries (v0.1.0–v0.6.0)
- **Blog avatars** — `avatar` field in blog frontmatter, shown on index and post pages
- **Contributors** — Git-based contributor display at page footer (most recent avatar + count badge)
- **Bug fixes** — Contributors path resolution, code copy button on blog pages
- **Docs** — Comprehensive OpenAPI guide, updated content structure & configuration guides (EN/KO)

## Test plan

- [ ] Verify `/changelog` renders timeline with all 6 entries
- [ ] Verify OpenAPI plugin accepts array `specFile` config
- [ ] Verify blog posts show author avatar when `avatar` is set
- [ ] Verify docs pages show contributors at footer
- [ ] Verify code copy button works on blog pages
- [ ] Verify docs render correctly in both EN and KO

Closes #72

Made with [Cursor](https://cursor.com)