### PR TITLE
fix: enable MDX component imports in Quick Mode

### DIFF
--- a/.changeset/fix-quickmode-mdx-imports.md
+++ b/.changeset/fix-quickmode-mdx-imports.md
@@ -1,0 +1,5 @@
+---
+"barodoc": patch
+---
+
+Fix MDX component imports in Quick Mode by enabling Vite preserveSymlinks

--- a/packages/barodoc/src/runtime/project.ts
+++ b/packages/barodoc/src/runtime/project.ts
@@ -282,6 +282,11 @@ export default defineConfig({${siteLine}${baseLine}
       theme: docsTheme(),
     }),
   ],
+  vite: {
+    resolve: {
+      preserveSymlinks: true,
+    },
+  },
 });
 `;
 }


### PR DESCRIPTION
## Summary

- Fix `Cannot find module '@barodoc/theme-docs'` error when using MDX component imports in Quick Mode projects
- Add `vite.resolve.preserveSymlinks: true` to the generated Astro config

## Problem

Quick Mode symlinks the user's `docs/` directory into `.barodoc/src/content/docs/`. Without `preserveSymlinks`, Vite resolves symlinks to their real paths, so module resolution starts from the original `docs/` directory where `node_modules` doesn't exist.

## Test plan

- [ ] Create Quick Mode project with MDX file importing `@barodoc/theme-docs` components
- [ ] Run `barodoc serve` and verify components render correctly

Made with [Cursor](https://cursor.com)