### PR TITLE
docs: explain CLI [dir] argument and auto-detection behavior

### DIFF
--- a/docs/src/content/docs/en/guides/cli.mdx
+++ b/docs/src/content/docs/en/guides/cli.mdx
@@ -8,6 +8,40 @@ difficulty: beginner
 
 Barodoc ships a CLI (`barodoc`) for developing, building, and validating your documentation.
 
+## The `[dir]` argument
+
+Most commands accept an optional `[dir]` argument that specifies which directory contains your documentation content.
+
+```bash
+barodoc serve [dir]
+barodoc build [dir]
+barodoc preview [dir]
+```
+
+**If omitted**, Barodoc auto-detects the content directory by looking for these folders in order:
+
+1. `docs/`
+2. `content/`
+3. `src/content/docs/`
+
+If none are found, it defaults to `docs/`.
+
+This means the following commands are equivalent when a `docs/` directory exists:
+
+```bash
+barodoc serve docs
+barodoc serve          # auto-detects docs/
+```
+
+You can use any directory name for your content:
+
+```bash
+barodoc serve wiki         # uses wiki/ as content directory
+barodoc build knowledge    # uses knowledge/ as content directory
+```
+
+All commands must be run from the project root — the directory containing `barodoc.config.json`.
+
 ## serve
 
 Start a development server with hot reload:

--- a/docs/src/content/docs/en/quickstart.mdx
+++ b/docs/src/content/docs/en/quickstart.mdx
@@ -52,6 +52,8 @@ npx barodoc serve
 
 Opens the site (e.g. `http://localhost:4321`). The CLI creates a temporary Astro project under `.barodoc/` and runs the dev server. You edit only `docs/` and `barodoc.config.json`.
 
+The `[dir]` argument is optional — Barodoc auto-detects `docs/` if it exists. You can also specify a custom content directory: `npx barodoc serve wiki`. See [CLI Commands](/docs/guides/cli#the-dir-argument) for details.
+
 ## Build
 
 ```bash


### PR DESCRIPTION
## Summary

- Add "The `[dir]` argument" section to `cli.mdx` explaining auto-detection order (`docs/` → `content/` → `src/content/docs/`), optional usage, and custom directory names
- Add a note in `quickstart.mdx` that `[dir]` is optional with a link to the CLI guide

Closes #87

## Test plan

- [ ] Verify cli.mdx renders correctly on the docs site
- [ ] Verify quickstart.mdx link to CLI guide works

Made with [Cursor](https://cursor.com)