### PR TITLE
fix: add @barodoc/theme-docs to build:packages script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "pnpm --filter docs dev",
     "dev:docs": "pnpm --filter docs dev",
     "build": "pnpm --filter docs build",
-    "build:packages": "pnpm --filter @barodoc/core --filter barodoc --filter create-barodoc --filter @barodoc/plugin-sitemap --filter @barodoc/plugin-search --filter @barodoc/plugin-analytics --filter @barodoc/plugin-openapi --filter @barodoc/plugin-rss --filter @barodoc/plugin-pwa --filter @barodoc/plugin-llms-txt --filter @barodoc/plugin-og-image --filter @barodoc/plugin-docsearch build",
+    "build:packages": "pnpm --filter @barodoc/core --filter @barodoc/theme-docs --filter barodoc --filter create-barodoc --filter @barodoc/plugin-sitemap --filter @barodoc/plugin-search --filter @barodoc/plugin-analytics --filter @barodoc/plugin-openapi --filter @barodoc/plugin-rss --filter @barodoc/plugin-pwa --filter @barodoc/plugin-llms-txt --filter @barodoc/plugin-og-image --filter @barodoc/plugin-docsearch build",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "pnpm -r typecheck",


### PR DESCRIPTION
## Summary

- Add `--filter @barodoc/theme-docs` to the `build:packages` script in root `package.json`
- PR #85 added `tsup.config.ts` to theme-docs, making `dist/theme.js` required, but forgot to include it in the build pipeline

Closes #89

## Test plan

- [ ] CI build passes (docs build no longer fails with "Cannot find module")

Made with [Cursor](https://cursor.com)