### PR TITLE
feat: dogfood multi-section and standalone pages on docs site

### DIFF
--- a/docs/barodoc.config.json
+++ b/docs/barodoc.config.json
@@ -17,9 +17,23 @@
   },
   "tabs": [
     { "label": "Docs", "href": "/docs/introduction" },
+    { "label": "Help", "href": "/help/faq" },
     { "label": "Blog", "href": "/blog" },
     { "label": "API Reference", "href": "/docs/api/pet" },
-    { "label": "Changelog", "href": "/changelog" }
+    { "label": "Changelog", "href": "/changelog" },
+    { "label": "About", "href": "/about" }
+  ],
+  "sections": [
+    {
+      "slug": "help",
+      "label": "Help Center",
+      "navigation": [
+        {
+          "group": "Support",
+          "pages": ["faq", "upgrade-guide", "community"]
+        }
+      ]
+    }
   ],
   "navigation": [
     {

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -37,8 +37,29 @@ const changelogCollection = defineCollection({
   }),
 });
 
+const helpCollection = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    related: z.array(z.string()).optional(),
+    difficulty: z.enum(["beginner", "intermediate", "advanced"]).optional(),
+  }),
+});
+
+const pagesCollection = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+  }),
+});
+
 export const collections = {
   docs: docsCollection,
   blog: blogCollection,
   changelog: changelogCollection,
+  help: helpCollection,
+  pages: pagesCollection,
 };

--- a/docs/src/content/help/en/community.mdx
+++ b/docs/src/content/help/en/community.mdx
@@ -1,0 +1,146 @@
+---
+title: Community & Contributing
+description: Join the Barodoc community and contribute to the project
+tags: [community, contributing, open-source]
+difficulty: beginner
+---
+
+import { Callout, CardGroup, Card } from "@barodoc/theme-docs";
+
+Barodoc is an open-source project built by the community, for the community. There are many ways to get involved.
+
+## Where to Find Us
+
+<CardGroup cols={2}>
+  <Card title="GitHub" icon="💻" href="https://github.com/barocss/barodoc">
+    Source code, issues, and pull requests.
+  </Card>
+  <Card title="Discussions" icon="💬" href="https://github.com/barocss/barodoc/discussions">
+    Questions, ideas, and community conversations.
+  </Card>
+  <Card title="Discord" icon="🎮" href="https://discord.gg/barodoc">
+    Real-time chat with the team and community.
+  </Card>
+  <Card title="Twitter/X" icon="🐦" href="https://twitter.com/barodoc">
+    Updates, tips, and announcements.
+  </Card>
+</CardGroup>
+
+## Reporting Bugs
+
+Found a bug? Help us fix it by opening a GitHub issue with:
+
+1. **Barodoc version** — Run `npx barodoc --version`
+2. **Node.js version** — Run `node --version`
+3. **Operating system** — macOS, Linux, Windows
+4. **Steps to reproduce** — Minimal steps to trigger the bug
+5. **Expected vs actual behavior** — What should happen vs what does happen
+6. **Error messages** — Full error output or screenshots
+
+<Callout type="tip" title="Minimal reproduction">
+  A minimal reproduction (a small project that demonstrates the bug) dramatically speeds up debugging. Consider creating a fresh project with `pnpm create barodoc repro` and adding only the steps needed to trigger the issue.
+</Callout>
+
+## Requesting Features
+
+We love hearing ideas! Open a [GitHub Discussion](https://github.com/barocss/barodoc/discussions/categories/ideas) with:
+
+- **Problem** — What are you trying to do?
+- **Proposed solution** — How would you solve it?
+- **Alternatives** — Other approaches you've considered
+- **Context** — Your use case and why this matters
+
+Popular feature requests get promoted to issues and added to the roadmap.
+
+## Contributing Code
+
+### Getting Started
+
+1. **Fork** the repository on GitHub
+2. **Clone** your fork locally:
+
+```bash
+git clone https://github.com/YOUR_USERNAME/barodoc.git
+cd barodoc
+pnpm install
+```
+
+3. **Build** all packages:
+
+```bash
+pnpm build:packages
+```
+
+4. **Start** the docs dev server to test changes:
+
+```bash
+pnpm dev
+```
+
+### Project Structure
+
+```
+packages/
+├── barodoc/          # CLI (serve, build, create)
+├── core/             # @barodoc/core - Astro integration
+├── theme-docs/       # @barodoc/theme-docs - UI components
+├── create-barodoc/   # Scaffolding CLI
+├── plugin-sitemap/   # Sitemap generation
+├── plugin-search/    # Pagefind search
+├── plugin-rss/       # RSS feeds
+├── plugin-pwa/       # Progressive Web App
+├── plugin-og-image/  # OG image generation
+├── plugin-openapi/   # API docs from OpenAPI
+├── plugin-analytics/ # Analytics integrations
+├── plugin-llms-txt/  # AI-readable summary
+└── plugin-docsearch/ # Algolia DocSearch
+```
+
+### Workflow
+
+1. Create a feature branch from `main`
+2. Make your changes with tests if applicable
+3. Run `pnpm build:packages` to verify the build
+4. Create a PR with a clear description
+5. Add a changeset if your change affects published packages:
+
+```bash
+pnpm changeset
+```
+
+### Code Style
+
+- TypeScript for all packages
+- ESM modules (no CommonJS)
+- Astro components for server-rendered UI
+- React components for interactive islands
+
+## Contributing Documentation
+
+Documentation improvements are always welcome. The docs site lives in `docs/` and uses Full Custom Mode.
+
+To work on docs:
+
+```bash
+pnpm dev        # Start docs dev server
+pnpm build      # Test production build
+```
+
+Content files are in `docs/src/content/docs/en/` (English) and `docs/src/content/docs/ko/` (Korean).
+
+### Translation
+
+We're actively looking for translators! Currently supported:
+
+- **English** (en) — Primary language
+- **Korean** (ko) — Partial translation
+
+To add a new locale, see the [i18n guide](/docs/guides/i18n).
+
+## Code of Conduct
+
+We follow the [Contributor Covenant](https://www.contributor-covenant.org/) code of conduct. Be respectful, inclusive, and constructive in all interactions.
+
+## Recognition
+
+All contributors are recognized in the project's README and release notes. Significant contributions may earn a "Core Contributor" role with write access to the repository.

--- a/docs/src/content/help/en/faq.mdx
+++ b/docs/src/content/help/en/faq.mdx
@@ -1,0 +1,127 @@
+---
+title: Frequently Asked Questions
+description: Answers to the most common questions about Barodoc
+tags: [faq, getting-started]
+difficulty: beginner
+---
+
+import { Callout } from "@barodoc/theme-docs";
+
+Common questions about Barodoc and how it works.
+
+## General
+
+### What is Barodoc?
+
+Barodoc is a documentation framework built on [Astro](https://astro.build) that turns Markdown and MDX files into fast, searchable documentation sites. It supports two modes:
+
+- **Quick Mode** — Zero-config, just Markdown files and `npx barodoc serve`
+- **Full Custom Mode** — Full Astro project with complete control over layouts, components, and pages
+
+### How is Barodoc different from Docusaurus or VitePress?
+
+Barodoc's **Quick Mode** requires no project setup — no `package.json`, no `node_modules`. Just write Markdown and run a single command. Other differentiators:
+
+| Feature | Barodoc | Docusaurus | VitePress |
+|---------|---------|------------|-----------|
+| Zero-config mode | Yes | No | No |
+| Plugin system | 8+ official | Plugin API | Limited |
+| Multi-section docs | Native | Manual | Manual |
+| Built-in search | Pagefind | Algolia required | MiniSearch |
+| API playground | OpenAPI plugin | Separate tool | No |
+
+### Is Barodoc free?
+
+Yes. Barodoc is fully open source under the [MIT license](https://github.com/barocss/barodoc/blob/main/LICENSE). You can use it for personal, commercial, and enterprise projects.
+
+## Quick Mode
+
+### What does Quick Mode actually do?
+
+When you run `npx barodoc serve`, the CLI:
+
+1. Reads your `barodoc.config.json`
+2. Creates a temporary `.barodoc/` directory with an Astro project
+3. Symlinks your content into the project's content collections
+4. Starts Astro's dev server programmatically
+
+No files are installed into your project. The `.barodoc/` directory can be safely added to `.gitignore`.
+
+### Can I use Quick Mode for production?
+
+Absolutely. `npx barodoc build` generates a fully static site in `dist/` that you can deploy anywhere. Many production documentation sites run on Quick Mode.
+
+### When should I switch to Full Custom Mode?
+
+Switch when you need:
+
+- Custom Astro pages beyond docs/blog/changelog
+- Custom React components not available in the standard theme
+- Direct control over the Astro config and build pipeline
+- Custom middleware or server-side logic
+
+<Callout type="tip" title="Eject command">
+  Use `npx barodoc eject` to convert a Quick Mode project into a Full Custom Mode project without losing any content.
+</Callout>
+
+## Content
+
+### Do I need frontmatter in my Markdown files?
+
+No. Barodoc automatically extracts the title from the first `# Heading` and the description from the first paragraph. Frontmatter is only needed for advanced metadata like `tags`, `related`, or `api_reference`.
+
+### Can I mix `.md` and `.mdx` files?
+
+Yes. Use `.md` for standard Markdown content and `.mdx` when you need React components (like `Callout`, `Card`, `Steps`, etc.). Both formats work in the same project.
+
+### How are URLs determined?
+
+Page URLs come from the file path relative to the locale directory:
+
+| File Path | URL |
+|-----------|-----|
+| `docs/en/introduction.md` | `/docs/introduction` |
+| `docs/en/guides/deployment.md` | `/docs/guides/deployment` |
+| `docs/api/users.mdx` | `/docs/api/users` |
+
+## Plugins
+
+### Do I need to install plugins separately?
+
+In **Quick Mode**, no. All official plugins are bundled with the CLI. Just add them to `barodoc.config.json`:
+
+```json
+{
+  "plugins": ["@barodoc/plugin-search", "@barodoc/plugin-sitemap"]
+}
+```
+
+In **Full Custom Mode**, install them as npm dependencies.
+
+### Can I create custom plugins?
+
+Yes. See the plugin API documentation for creating custom plugins using `definePlugin()` from `@barodoc/core`.
+
+### Which analytics providers are supported?
+
+The analytics plugin supports Google Analytics, Plausible, and Umami:
+
+```json
+["@barodoc/plugin-analytics", { "provider": "google", "id": "G-XXXXX" }]
+["@barodoc/plugin-analytics", { "provider": "plausible", "domain": "docs.example.com" }]
+["@barodoc/plugin-analytics", { "provider": "umami", "id": "xxx", "src": "https://..." }]
+```
+
+## Technical
+
+### What Node.js version is required?
+
+Barodoc requires **Node.js 20 or later**. We recommend using the latest LTS version.
+
+### What Astro version does Barodoc use?
+
+Barodoc is built on **Astro 5.x** and uses the Content Layer API with `glob()` loaders.
+
+### Does Barodoc support server-side rendering?
+
+No. Barodoc generates fully static sites (SSG). This keeps sites fast, cheap to host, and deployable to any CDN or static host.

--- a/docs/src/content/help/en/upgrade-guide.mdx
+++ b/docs/src/content/help/en/upgrade-guide.mdx
@@ -1,0 +1,129 @@
+---
+title: Upgrade Guide
+description: How to upgrade between major Barodoc versions
+tags: [upgrade, migration]
+difficulty: intermediate
+---
+
+import { Callout, Steps, Step } from "@barodoc/theme-docs";
+
+This guide covers upgrading between major Barodoc versions. For minor/patch updates, simply update your CLI or dependencies — no migration steps needed.
+
+## Upgrading to v7.x (from v6.x)
+
+Version 7 introduces Quick Mode's new architecture (programmatic Astro API), the plugin system, and multi-section documentation.
+
+### What Changed
+
+| Area | v6.x | v7.x |
+|------|------|------|
+| Quick Mode | Creates `package.json` + `node_modules` | Creates temporary `.barodoc/` directory |
+| Plugins | Built-in only | Configurable plugin system |
+| Content | `docs/` only | `docs/`, `blog/`, `changelog/`, `help/`, `pages/` |
+| Navigation | Single section | Multi-section with `sections` config |
+| Standalone pages | Not supported | `pages/` directory |
+
+### Migration Steps
+
+<Steps>
+  <Step title="Update the CLI">
+    If using Quick Mode, just run the latest version:
+
+    ```bash
+    npx barodoc@latest serve docs
+    ```
+  </Step>
+  <Step title="Clean up old artifacts">
+    Remove the old generated files from your project:
+
+    ```bash
+    rm -rf node_modules package.json package-lock.json
+    ```
+
+    Add `.barodoc/` to your `.gitignore`:
+
+    ```
+    .barodoc/
+    dist/
+    ```
+  </Step>
+  <Step title="Update plugin configuration">
+    Plugins are now declared in `barodoc.config.json` instead of being implicitly enabled:
+
+    ```json
+    {
+      "plugins": [
+        "@barodoc/plugin-sitemap",
+        "@barodoc/plugin-search"
+      ]
+    }
+    ```
+  </Step>
+  <Step title="Test your site">
+    Run the dev server and check that all pages render correctly:
+
+    ```bash
+    npx barodoc serve
+    ```
+  </Step>
+</Steps>
+
+<Callout type="info" title="Content files unchanged">
+  Your Markdown and MDX files don't need any changes. Only the CLI invocation and config format have changed.
+</Callout>
+
+### Full Custom Mode
+
+If you're using Full Custom Mode (with `astro.config.mjs`):
+
+1. Update your dependencies:
+
+```bash
+pnpm update @barodoc/core @barodoc/theme-docs
+```
+
+2. The theme integration API is unchanged — `docsTheme()` works the same way.
+
+3. If you want multi-section support, add `sections` to your `barodoc.config.json` and create matching content collections in `src/content/config.ts`.
+
+## Upgrading to v6.x (from v5.x)
+
+Version 6 upgraded to Astro 5 and introduced the component library.
+
+### What Changed
+
+- **Astro 5** — Content Layer API replaces the old content collections
+- **New components** — `Callout`, `Card`, `Steps`, `CodeGroup`, and more
+- **Dark mode** — Built-in theme toggle
+- **Reading time** — Automatic reading time estimates
+
+### Migration Steps
+
+<Steps>
+  <Step title="Update dependencies">
+    ```bash
+    pnpm update @barodoc/core @barodoc/theme-docs astro
+    ```
+  </Step>
+  <Step title="Update content config">
+    Replace `defineCollection` with the new Astro 5 content config format if you're using Full Custom Mode. The `glob()` loader is now the default.
+  </Step>
+  <Step title="Update component imports">
+    Component imports changed from deep paths to a single entry point:
+
+    ```diff
+    - import Callout from "@barodoc/theme-docs/components/Callout";
+    + import { Callout } from "@barodoc/theme-docs";
+    ```
+  </Step>
+</Steps>
+
+## Version Support Policy
+
+| Version | Status | Node.js | Astro |
+|---------|--------|---------|-------|
+| 7.x | **Current** | 20+ | 5.x |
+| 6.x | Maintenance (security fixes only) | 18+ | 5.x |
+| 5.x | End of life | 16+ | 4.x |
+
+We recommend always running the latest version. Quick Mode users get automatic updates via `npx`.

--- a/docs/src/content/pages/about.mdx
+++ b/docs/src/content/pages/about.mdx
@@ -1,0 +1,62 @@
+---
+title: About Barodoc
+description: The modern documentation framework built on Astro
+---
+
+Barodoc is an open-source documentation framework that turns Markdown into beautiful, production-ready documentation sites. Built on [Astro](https://astro.build), it combines the simplicity of writing Markdown with the power of a modern web framework.
+
+## Our Mission
+
+**Make documentation a joy to write, maintain, and read.**
+
+We believe every software project deserves great documentation — and creating it shouldn't require a degree in frontend engineering. Barodoc removes the friction between writing content and publishing a polished site.
+
+## How It Works
+
+Barodoc operates in two modes to fit any workflow:
+
+**Quick Mode** — Write Markdown files, run `npx barodoc serve`, and you're done. No setup, no configuration, no dependencies to manage. The CLI handles everything behind the scenes using Astro's programmatic API.
+
+**Full Custom Mode** — For teams that need full control, Barodoc provides a standard Astro project structure with reusable components, customizable layouts, and a plugin system.
+
+## What's Included
+
+Every Barodoc site comes with:
+
+- **Full-text search** powered by Pagefind (no external service)
+- **Dark mode** with automatic OS preference detection
+- **MDX support** for interactive components in Markdown
+- **Multi-section documentation** with independent sidebars
+- **Blog and changelog** content collections
+- **Responsive design** optimized for desktop and mobile
+- **Syntax highlighting** with 100+ languages via Shiki
+- **i18n** with multi-locale content support
+
+## Plugin Ecosystem
+
+Extend your site with 8 official plugins:
+
+| Plugin | What It Does |
+|--------|-------------|
+| Search | Client-side full-text search |
+| Sitemap | XML sitemap for SEO |
+| RSS | Atom/RSS feeds for subscriptions |
+| OG Image | Auto-generated social sharing images |
+| PWA | Offline support and installability |
+| OpenAPI | API docs from Swagger/OpenAPI specs |
+| Analytics | Google Analytics, Plausible, Umami |
+| LLMs.txt | AI-readable documentation summary |
+
+## Open Source
+
+Barodoc is [MIT-licensed](https://github.com/barocss/barodoc/blob/main/LICENSE) and developed in the open. Our code, issues, discussions, and roadmap are all public.
+
+We welcome contributions of all kinds — code, documentation, translations, bug reports, and feature ideas. See our [Community page](/help/community) to get involved.
+
+## Links
+
+- [GitHub Repository](https://github.com/barocss/barodoc)
+- [Getting Started Guide](/docs/introduction)
+- [Plugin Documentation](/docs/guides/plugins/search)
+- [Community & Contributing](/help/community)
+- [Roadmap](/roadmap)

--- a/docs/src/content/pages/roadmap.mdx
+++ b/docs/src/content/pages/roadmap.mdx
@@ -1,0 +1,75 @@
+---
+title: Roadmap
+description: What's coming next for Barodoc
+---
+
+This roadmap reflects our current priorities. It's a living document — priorities may shift based on community feedback and contributions.
+
+Want to influence the roadmap? [Start a discussion](https://github.com/barocss/barodoc/discussions/categories/ideas) or vote on existing proposals.
+
+## In Progress
+
+### Versioned Documentation
+
+Maintain multiple versions of your docs side-by-side (e.g., v1.x, v2.x). Users can switch between versions via a dropdown in the header. Each version has its own content directory and navigation.
+
+**Status:** Design phase — evaluating file-based vs branch-based approaches.
+
+### Feedback Widget
+
+A "Was this page helpful?" widget at the bottom of each page. Collects anonymous thumbs-up/thumbs-down feedback and optional text comments. Data can be sent to a configurable webhook or stored locally.
+
+**Status:** Prototype built, refining the UI.
+
+## Planned
+
+### Mermaid Diagrams (built-in)
+
+While Mermaid diagrams already work in Full Custom Mode, we're working on seamless support in Quick Mode with server-side rendering for faster page loads and better SEO.
+
+### TypeScript API Generation
+
+Auto-generate API reference documentation from TypeScript source files. Extract types, interfaces, function signatures, and JSDoc comments into structured documentation pages.
+
+### Visual Diff for Docs
+
+A GitHub Action that generates visual screenshots of documentation changes in PRs, making it easy to review layout and content changes before merging.
+
+### Component Playground
+
+An interactive playground where users can experiment with Barodoc's MDX components (Callout, Card, Steps, etc.) and see live previews of their Markdown.
+
+## Exploring
+
+These ideas are in early exploration. We're gathering feedback before committing to implementation.
+
+### Collaborative Editing
+
+Real-time collaborative editing with live preview, similar to Google Docs but for Markdown documentation. Would integrate with the Git workflow for version control.
+
+### AI-Powered Search
+
+Enhance the built-in search with semantic understanding. Instead of keyword matching, users could ask natural language questions like "How do I deploy to Vercel?" and get relevant results.
+
+### Custom Theme Marketplace
+
+A registry of community-built themes that can be installed with a single command. Each theme would provide its own layout, components, and styling.
+
+### Docs-as-Code CI Pipeline
+
+A GitHub Action that validates documentation quality on every PR: broken links, missing descriptions, orphaned pages, readability scores, and screenshot regression tests.
+
+## Recently Completed
+
+### v7.1 — Multi-Section Docs & Standalone Pages
+Multiple documentation sections with independent sidebars, plus sidebar-free pages for content like About and Pricing.
+
+### v7.0 — Quick Mode & Plugin System
+Zero-install Quick Mode using Astro's programmatic API. Eight official plugins for search, RSS, analytics, and more.
+
+### v6.5 — Component Library & Dark Mode
+Rich MDX components (Callout, Card, Steps, CodeGroup) and built-in dark mode toggle.
+
+---
+
+Last updated: February 2026


### PR DESCRIPTION
## Summary

Dogfood the multi-section and standalone pages features on the official Barodoc docs site, which previously only documented these features but didn't use them.

### New pages

**Help Center section** (`/help/...`) — with its own sidebar:
- `/help/faq` — Frequently asked questions (Quick Mode, plugins, content, technical)
- `/help/upgrade-guide` — Version migration guide (v5→v6→v7) with Steps components
- `/help/community` — Contributing guide, project structure, community links

**Standalone pages** (no sidebar):
- `/about` — Project mission, features overview, plugin ecosystem, open source info
- `/roadmap` — Development roadmap with in-progress, planned, and exploring items

### Config changes

- Added "Help" and "About" tabs to navigation
- Added `sections` config for the help section
- Registered `help` and `pages` content collections in `config.ts`

Closes #91

## Test plan

- [ ] `pnpm build:packages && pnpm build` succeeds
- [ ] `/help/faq` renders with Help Center sidebar
- [ ] `/about` renders without sidebar
- [ ] `/roadmap` renders without sidebar
- [ ] Tab navigation highlights correctly

Made with [Cursor](https://cursor.com)