### PR TITLE
fix(theme-docs): add prepublishOnly to ensure dist is built before publish

### DIFF
--- a/.changeset/fix-theme-docs-dist.md
+++ b/.changeset/fix-theme-docs-dist.md
@@ -1,0 +1,9 @@
+---
+"@barodoc/theme-docs": patch
+---
+
+fix: ensure dist/theme.js is included in published package
+
+Added `prepublishOnly` script to guarantee the theme build output is present
+before publishing. The 8.0.0 release was missing `dist/theme.js` because
+`theme-docs` was not included in `build:packages` at that time.

--- a/packages/theme-docs/package.json
+++ b/packages/theme-docs/package.json
@@ -24,7 +24,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "tsup"
   },
   "dependencies": {
     "@barodoc/core": "workspace:*",


### PR DESCRIPTION
## Summary

- `@barodoc/theme-docs@8.0.0` npm 패키지에 `dist/theme.js`가 누락되어 `@barodoc/theme-docs/theme` import가 실패하는 문제 수정
- `prepublishOnly` 스크립트 추가로 publish 전 반드시 빌드가 실행되도록 safeguard 추가

## Root Cause

8.0.0 릴리스 시점에 루트 `build:packages` 스크립트에 `@barodoc/theme-docs`가 포함되지 않아 빌드 없이 publish됨. 이후 #90에서 수정되었지만 이미 8.0.0은 배포된 상태였음.

## Changes

- `packages/theme-docs/package.json`: `prepublishOnly: "tsup"` 스크립트 추가
- Changeset: `@barodoc/theme-docs` patch 릴리스 (8.0.1)

Closes #93

Made with [Cursor](https://cursor.com)