### PR TITLE
chore(theme-docs): remove redundant prepublishOnly script

### DIFF
--- a/packages/theme-docs/package.json
+++ b/packages/theme-docs/package.json
@@ -24,8 +24,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "typecheck": "tsc --noEmit",
-    "prepublishOnly": "tsup"
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@barodoc/core": "workspace:*",


### PR DESCRIPTION
## Summary

- `@barodoc/theme-docs`에서 `prepublishOnly: "tsup"` 스크립트 제거
- 릴리즈 파이프라인(`build:packages && changeset publish`)이 이미 모든 패키지를 빌드하므로 중복 제거
- 다른 12개 패키지와 동일한 컨벤션으로 통일

Closes #96

Made with [Cursor](https://cursor.com)