### PR TITLE
chore: add changeset for theme-docs 8.0.2

### DIFF
--- a/.changeset/remove-prepublishonly.md
+++ b/.changeset/remove-prepublishonly.md
@@ -1,0 +1,9 @@
+---
+"@barodoc/theme-docs": patch
+---
+
+chore: remove redundant prepublishOnly script
+
+The release pipeline already runs `build:packages` before `changeset publish`,
+so per-package prepublishOnly was causing a duplicate build. Removed to align
+with the convention used by all other packages.


### PR DESCRIPTION
## Summary

- `@barodoc/theme-docs` patch changeset 추가 (prepublishOnly 제거 반영)
- 머지 후 릴리즈 PR 자동 생성 → 8.0.2 배포

Made with [Cursor](https://cursor.com)