### PR TITLE
feat: add @barodoc/plugin-raw-md — serve raw markdown via .md URL suffix

### DIFF
--- a/.changeset/add-plugin-raw-md.md
+++ b/.changeset/add-plugin-raw-md.md
@@ -1,0 +1,14 @@
+---
+"@barodoc/plugin-raw-md": minor
+---
+
+feat: add @barodoc/plugin-raw-md — serve raw markdown via .md URL suffix
+
+Append `.md` to any page URL to get the raw markdown source instead of HTML.
+AI agents can fetch clean markdown directly, enabling faster and more accurate
+content consumption without HTML parsing.
+
+- Build mode: generates static `.md` files in the output directory
+- Dev mode: Vite middleware intercepts `.md` requests and serves source files
+- Cleans MDX component tags while preserving markdown formatting and code blocks
+- Supports i18n locales and custom sections

--- a/docs/barodoc.config.json
+++ b/docs/barodoc.config.json
@@ -101,6 +101,7 @@
   },
   "lastUpdated": true,
   "plugins": [
+    "@barodoc/plugin-raw-md",
     ["@barodoc/plugin-openapi", {
       "specFile": "openapi.yaml",
       "basePath": "api",

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
     "@astrojs/mdx": "^4.0.0",
     "@astrojs/react": "^4.0.0",
     "@barodoc/core": "workspace:*",
+    "@barodoc/plugin-raw-md": "workspace:*",
     "@barodoc/theme-docs": "workspace:*",
     "astro": "^5.0.0",
     "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "pnpm --filter docs dev",
     "dev:docs": "pnpm --filter docs dev",
     "build": "pnpm --filter docs build",
-    "build:packages": "pnpm --filter @barodoc/core --filter @barodoc/theme-docs --filter barodoc --filter create-barodoc --filter @barodoc/plugin-sitemap --filter @barodoc/plugin-search --filter @barodoc/plugin-analytics --filter @barodoc/plugin-openapi --filter @barodoc/plugin-rss --filter @barodoc/plugin-pwa --filter @barodoc/plugin-llms-txt --filter @barodoc/plugin-og-image --filter @barodoc/plugin-docsearch build",
+    "build:packages": "pnpm --filter @barodoc/core --filter @barodoc/theme-docs --filter barodoc --filter create-barodoc --filter @barodoc/plugin-sitemap --filter @barodoc/plugin-search --filter @barodoc/plugin-analytics --filter @barodoc/plugin-openapi --filter @barodoc/plugin-rss --filter @barodoc/plugin-pwa --filter @barodoc/plugin-llms-txt --filter @barodoc/plugin-og-image --filter @barodoc/plugin-docsearch --filter @barodoc/plugin-raw-md build",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "pnpm -r typecheck",

--- a/packages/plugin-raw-md/package.json
+++ b/packages/plugin-raw-md/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@barodoc/plugin-raw-md",
+  "version": "0.1.0",
+  "description": "Serve raw markdown for each page via .md URL suffix — AI agent friendly",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean",
+    "dev": "tsup src/index.ts --format esm --dts --watch"
+  },
+  "peerDependencies": {
+    "@barodoc/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@barodoc/core": "workspace:*",
+    "@types/node": "^22.0.0",
+    "tsup": "^8.3.0",
+    "typescript": "^5.7.0"
+  },
+  "keywords": [
+    "barodoc",
+    "plugin",
+    "markdown",
+    "raw-md",
+    "ai-agent",
+    "llm"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/barocss/barodoc.git",
+    "directory": "packages/plugin-raw-md"
+  }
+}

--- a/packages/plugin-raw-md/src/index.ts
+++ b/packages/plugin-raw-md/src/index.ts
@@ -1,0 +1,305 @@
+import fs from "node:fs";
+import path from "node:path";
+import { definePlugin } from "@barodoc/core";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export interface RawMdPluginOptions {
+  /**
+   * Whether to strip MDX component tags from the output.
+   * When true, only pure markdown remains. When false, serves the source as-is.
+   * Defaults to true.
+   */
+  clean?: boolean;
+
+  /**
+   * Whether to include YAML frontmatter in the output.
+   * Defaults to true.
+   */
+  includeFrontmatter?: boolean;
+
+  /**
+   * Which content collections to generate .md files for.
+   * Defaults to ["docs"] plus any configured sections.
+   */
+  collections?: string[];
+}
+
+interface PageFile {
+  /** URL path the page is served at (e.g. "docs/en/introduction") */
+  urlPath: string;
+  /** Raw file content */
+  raw: string;
+}
+
+// ---------------------------------------------------------------------------
+// Markdown utilities
+// ---------------------------------------------------------------------------
+
+function extractFrontmatter(content: string): { frontmatter: string; body: string } {
+  if (!content.startsWith("---")) return { frontmatter: "", body: content };
+  const end = content.indexOf("---", 3);
+  if (end === -1) return { frontmatter: "", body: content };
+  return {
+    frontmatter: content.slice(0, end + 3),
+    body: content.slice(end + 3).trimStart(),
+  };
+}
+
+/**
+ * Minimal MDX cleaning — removes import statements and MDX component tags
+ * while preserving markdown formatting and code blocks.
+ */
+function cleanMdx(md: string): string {
+  const codeBlocks: string[] = [];
+  let cleaned = md.replace(/```[\s\S]*?```/g, (match) => {
+    codeBlocks.push(match);
+    return `__CODE_BLOCK_${codeBlocks.length - 1}__`;
+  });
+
+  cleaned = cleaned
+    .replace(/import\s+.*?from\s+["'].*?["'];?\s*\n?/g, "")
+    .replace(/<\/?(?:Callout|Steps|Step|Card|CardGroup|CodeGroup|CodeItem|ParamField|ParamFieldGroup|Tabs|Tab|Accordion|AccordionItem|Badge|Columns|Column|Expandable|Frame|FileTree|Tooltip|ResponseField|ApiReference|ApiEndpoint|ApiParams|ApiParam|ApiResponse|SimpleAccordion)[^>]*>/g, "")
+    .replace(/\n{3,}/g, "\n\n");
+
+  for (let i = 0; i < codeBlocks.length; i++) {
+    cleaned = cleaned.replace(`__CODE_BLOCK_${i}__`, codeBlocks[i]);
+  }
+
+  return cleaned.trim();
+}
+
+// ---------------------------------------------------------------------------
+// File system scanning
+// ---------------------------------------------------------------------------
+
+function walkMdFiles(dir: string, base: string = dir): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const results: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkMdFiles(full, base));
+    } else if (/\.(md|mdx)$/.test(entry.name)) {
+      results.push(path.relative(base, full));
+    }
+  }
+  return results;
+}
+
+/**
+ * Scan a content collection directory and build a list of page files
+ * with their corresponding URL paths.
+ */
+function scanCollection(
+  collectionDir: string,
+  sectionSlug: string,
+  locales: string[],
+  defaultLocale: string
+): PageFile[] {
+  const files = walkMdFiles(collectionDir);
+  const pages: PageFile[] = [];
+
+  for (const relPath of files) {
+    const raw = fs.readFileSync(path.join(collectionDir, relPath), "utf-8");
+    const slug = relPath.replace(/\.(mdx?)$/, "").replace(/\\/g, "/");
+    const parts = slug.split("/");
+
+    let urlPath: string;
+    if (locales.includes(parts[0])) {
+      const locale = parts[0];
+      const innerSlug = parts.slice(1).join("/");
+      urlPath =
+        locale === defaultLocale
+          ? `${sectionSlug}/${innerSlug}`
+          : `${sectionSlug}/${locale}/${innerSlug}`;
+    } else {
+      urlPath = `${sectionSlug}/${slug}`;
+    }
+
+    pages.push({ urlPath, raw });
+  }
+
+  return pages;
+}
+
+function prepareContent(
+  raw: string,
+  clean: boolean,
+  includeFrontmatter: boolean
+): string {
+  const { frontmatter, body } = extractFrontmatter(raw);
+  const processedBody = clean ? cleanMdx(body) : body;
+
+  if (includeFrontmatter && frontmatter) {
+    return `${frontmatter}\n\n${processedBody}\n`;
+  }
+  return `${processedBody}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+export default definePlugin<RawMdPluginOptions>((options = {}) => {
+  const { clean = true, includeFrontmatter = true, collections } = options;
+
+  return {
+    name: "@barodoc/plugin-raw-md",
+
+    hooks: {
+      "build:done": async (buildContext, context) => {
+        const { outDir } = buildContext;
+        const { config, root } = context;
+
+        const defaultLocale = (config as any).i18n?.defaultLocale ?? "en";
+        const locales: string[] = (config as any).i18n?.locales ?? ["en"];
+
+        const sections = [
+          { slug: "docs" },
+          ...((config as any).sections ?? []).map((s: any) => ({
+            slug: s.slug,
+          })),
+        ];
+
+        const targetSlugs = collections ?? sections.map((s) => s.slug);
+
+        const customModeBase = path.join(root, "src", "content");
+        const quickModeBase = root;
+        const isCustomMode = fs.existsSync(customModeBase);
+
+        let totalCount = 0;
+
+        for (const slug of targetSlugs) {
+          const collectionDir = isCustomMode
+            ? path.join(customModeBase, slug)
+            : path.join(quickModeBase, slug === "docs" ? "docs" : slug);
+
+          if (!fs.existsSync(collectionDir)) continue;
+
+          const pages = scanCollection(collectionDir, slug, locales, defaultLocale);
+
+          for (const page of pages) {
+            const content = prepareContent(page.raw, clean, includeFrontmatter);
+            const outPath = path.join(outDir, `${page.urlPath}.md`);
+
+            fs.mkdirSync(path.dirname(outPath), { recursive: true });
+            fs.writeFileSync(outPath, content, "utf-8");
+            totalCount++;
+          }
+        }
+
+        if (totalCount > 0) {
+          console.log(
+            `[@barodoc/plugin-raw-md] Generated ${totalCount} raw .md files`
+          );
+        } else {
+          console.log(
+            "[@barodoc/plugin-raw-md] No pages found, skipping .md generation."
+          );
+        }
+      },
+    },
+
+    astroIntegration: (context) => ({
+      name: "@barodoc/plugin-raw-md",
+      hooks: {
+        "astro:config:setup": ({ updateConfig }) => {
+          const { config, root } = context;
+          const defaultLocale = (config as any).i18n?.defaultLocale ?? "en";
+          const locales: string[] = (config as any).i18n?.locales ?? ["en"];
+
+          const sections = [
+            { slug: "docs" },
+            ...((config as any).sections ?? []).map((s: any) => ({
+              slug: s.slug,
+            })),
+          ];
+          const targetSlugs = collections ?? sections.map((s) => s.slug);
+
+          const customModeBase = path.join(root, "src", "content");
+          const quickModeBase = root;
+          const isCustomMode = fs.existsSync(customModeBase);
+
+          updateConfig({
+            vite: {
+              plugins: [
+                {
+                  name: "barodoc-raw-md-dev",
+                  configureServer(server: any) {
+                    server.middlewares.use(
+                      (
+                        req: IncomingMessage,
+                        res: ServerResponse,
+                        next: () => void
+                      ) => {
+                        const url = req.url;
+                        if (!url || !url.endsWith(".md")) return next();
+
+                        const urlPath = url.slice(1, -3); // strip leading / and trailing .md
+                        const parts = urlPath.split("/");
+                        if (parts.length < 2) return next();
+
+                        const sectionSlug = parts[0];
+                        if (!targetSlugs.includes(sectionSlug)) return next();
+
+                        const restPath = parts.slice(1).join("/");
+
+                        const collectionDir = isCustomMode
+                          ? path.join(customModeBase, sectionSlug)
+                          : path.join(
+                              quickModeBase,
+                              sectionSlug === "docs" ? "docs" : sectionSlug
+                            );
+
+                        if (!fs.existsSync(collectionDir)) return next();
+
+                        // Try to find the source file — handle locale prefix
+                        const candidates: string[] = [];
+                        const restParts = restPath.split("/");
+
+                        if (locales.includes(restParts[0]) && restParts[0] !== defaultLocale) {
+                          const locale = restParts[0];
+                          const innerSlug = restParts.slice(1).join("/");
+                          candidates.push(
+                            path.join(collectionDir, locale, `${innerSlug}.mdx`),
+                            path.join(collectionDir, locale, `${innerSlug}.md`)
+                          );
+                        } else {
+                          candidates.push(
+                            path.join(collectionDir, defaultLocale, `${restPath}.mdx`),
+                            path.join(collectionDir, defaultLocale, `${restPath}.md`),
+                            path.join(collectionDir, `${restPath}.mdx`),
+                            path.join(collectionDir, `${restPath}.md`)
+                          );
+                        }
+
+                        for (const filePath of candidates) {
+                          if (fs.existsSync(filePath)) {
+                            const raw = fs.readFileSync(filePath, "utf-8");
+                            const content = prepareContent(
+                              raw,
+                              clean,
+                              includeFrontmatter
+                            );
+                            res.setHeader(
+                              "Content-Type",
+                              "text/markdown; charset=utf-8"
+                            );
+                            res.end(content);
+                            return;
+                          }
+                        }
+
+                        next();
+                      }
+                    );
+                  },
+                },
+              ],
+            },
+          });
+        },
+      },
+    }),
+  };
+});

--- a/packages/plugin-raw-md/tsconfig.json
+++ b/packages/plugin-raw-md/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@barodoc/core':
         specifier: workspace:*
         version: link:../packages/core
+      '@barodoc/plugin-raw-md':
+        specifier: workspace:*
+        version: link:../packages/plugin-raw-md
       '@barodoc/theme-docs':
         specifier: workspace:*
         version: link:../packages/theme-docs
@@ -296,6 +299,21 @@ importers:
       astro:
         specifier: ^5.0.0
         version: 5.17.1(@types/node@22.19.8)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
+  packages/plugin-raw-md:
+    devDependencies:
+      '@barodoc/core':
+        specifier: workspace:*
+        version: link:../core
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.8
       tsup:
         specifier: ^8.3.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)


### PR DESCRIPTION
## Summary

- New plugin `@barodoc/plugin-raw-md` that serves raw markdown when `.md` is appended to any page URL
- AI agents (Claude, ChatGPT, etc.) can fetch clean markdown directly instead of parsing HTML
- **Build mode**: generates static `.md` files alongside HTML in the output directory (86 files for docs site)
- **Dev mode**: Vite middleware intercepts `.md` requests and serves source files on-the-fly
- Strips MDX component tags while preserving markdown formatting and code blocks
- Supports i18n locales and custom sections

## Usage

```json
{
  "plugins": ["@barodoc/plugin-raw-md"]
}
```

## Examples

```
/docs/introduction        → HTML page (existing)
/docs/introduction.md     → raw markdown (new)
/docs/ko/introduction.md  → Korean markdown (new)
/help/faq.md              → Help section markdown (new)
```

## Test plan

- [x] Build generates 86 .md files with correct paths
- [x] Content-Type: text/markdown returned correctly
- [x] Frontmatter preserved, MDX components stripped
- [x] i18n paths (ko) work in both build and dev
- [x] Custom sections (help) work in both build and dev
- [x] Dev middleware serves .md files on localhost:4321

Made with [Cursor](https://cursor.com)