### PR TITLE
Release: plugin-raw-md dev .md fix, collections default, barodoc quick-mode dir fix

### DIFF
--- a/.changeset/add-plugin-raw-md.md
+++ b/.changeset/add-plugin-raw-md.md
@@ -1,0 +1,14 @@
+---
+"@barodoc/plugin-raw-md": minor
+---
+
+feat: add @barodoc/plugin-raw-md — serve raw markdown via .md URL suffix
+
+Append `.md` to any page URL to get the raw markdown source instead of HTML.
+AI agents can fetch clean markdown directly, enabling faster and more accurate
+content consumption without HTML parsing.
+
+- Build mode: generates static `.md` files in the output directory
+- Dev mode: Vite middleware intercepts `.md` requests and serves source files
+- Cleans MDX component tags while preserving markdown formatting and code blocks
+- Supports i18n locales and custom sections

--- a/.changeset/raw-md-dev-and-cli-fix.md
+++ b/.changeset/raw-md-dev-and-cli-fix.md
@@ -1,0 +1,11 @@
+---
+"@barodoc/plugin-raw-md": patch
+"barodoc": patch
+---
+
+**@barodoc/plugin-raw-md**
+- Fix dev server: serve `.md` URLs by prepending middleware (post hook) so requests are handled before Astro/Vite
+- When `collections` is omitted, run for all collections: custom mode = all dirs under `src/content/`, quick mode = docs + blog + changelog + configured sections that exist
+
+**barodoc**
+- Quick mode: treat `dir` missing or `"."` as "auto-detect docs dir" to avoid "copy to subdirectory of itself" when running `barodoc serve` or `barodoc build .` from project root

--- a/docs/barodoc.config.json
+++ b/docs/barodoc.config.json
@@ -101,7 +101,11 @@
   },
   "lastUpdated": true,
   "plugins": [
-    "@barodoc/plugin-raw-md",
+    ["@barodoc/plugin-raw-md", {
+      "clean": true,
+      "includeFrontmatter": true,
+      "collections": ["docs", "help"]
+    }],
     ["@barodoc/plugin-openapi", {
       "specFile": "openapi.yaml",
       "basePath": "api",

--- a/packages/barodoc/src/commands/build.ts
+++ b/packages/barodoc/src/commands/build.ts
@@ -38,7 +38,8 @@ export async function build(dir: string, options: BuildOptions): Promise<void> {
 
   console.log(pc.dim("Quick mode - creating temporary project..."));
 
-  const docsDir = dir || findDocsDir(root);
+  const docsDir =
+    !dir || dir === "." ? findDocsDir(root) : path.resolve(root, dir);
   const { config } = await loadProjectConfig(root, options.config);
 
   const projectDir = await createProject({

--- a/packages/barodoc/src/commands/serve.ts
+++ b/packages/barodoc/src/commands/serve.ts
@@ -41,7 +41,8 @@ export async function serve(dir: string, options: ServeOptions): Promise<void> {
 
   console.log(pc.dim("Quick mode - creating temporary project..."));
 
-  const docsDir = dir || findDocsDir(root);
+  const docsDir =
+    !dir || dir === "." ? findDocsDir(root) : path.resolve(root, dir);
   const { config } = await loadProjectConfig(root, options.config);
 
   const projectDir = await createProject({

--- a/packages/plugin-raw-md/src/index.ts
+++ b/packages/plugin-raw-md/src/index.ts
@@ -19,7 +19,9 @@ export interface RawMdPluginOptions {
 
   /**
    * Which content collections to generate .md files for.
-   * Defaults to ["docs"] plus any configured sections.
+   * When omitted, all collections are included: in custom mode every directory
+   * under `src/content/`, in quick mode `docs`, `blog`, `changelog`, and any
+   * configured sections that exist on disk.
    */
   collections?: string[];
 }
@@ -122,6 +124,35 @@ function scanCollection(
   return pages;
 }
 
+/**
+ * Resolve which collection slugs to process when `collections` option is not set.
+ * Custom mode: all directories under src/content/.
+ * Quick mode: docs, blog, changelog, and configured sections that exist.
+ */
+function getDefaultCollectionSlugs(
+  root: string,
+  config: { sections?: Array<{ slug: string }> }
+): string[] {
+  const customModeBase = path.join(root, "src", "content");
+  if (fs.existsSync(customModeBase)) {
+    return fs
+      .readdirSync(customModeBase, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
+  }
+  const quickSlugs = [
+    "docs",
+    "blog",
+    "changelog",
+    ...((config.sections ?? []).map((s) => s.slug) ?? []),
+  ];
+  const unique = [...new Set(quickSlugs)];
+  return unique.filter((slug) => {
+    const dir = path.join(root, slug === "docs" ? "docs" : slug);
+    return fs.existsSync(dir);
+  });
+}
+
 function prepareContent(
   raw: string,
   clean: boolean,
@@ -154,14 +185,8 @@ export default definePlugin<RawMdPluginOptions>((options = {}) => {
         const defaultLocale = (config as any).i18n?.defaultLocale ?? "en";
         const locales: string[] = (config as any).i18n?.locales ?? ["en"];
 
-        const sections = [
-          { slug: "docs" },
-          ...((config as any).sections ?? []).map((s: any) => ({
-            slug: s.slug,
-          })),
-        ];
-
-        const targetSlugs = collections ?? sections.map((s) => s.slug);
+        const targetSlugs =
+          collections ?? getDefaultCollectionSlugs(root, config as any);
 
         const customModeBase = path.join(root, "src", "content");
         const quickModeBase = root;
@@ -208,13 +233,8 @@ export default definePlugin<RawMdPluginOptions>((options = {}) => {
           const defaultLocale = (config as any).i18n?.defaultLocale ?? "en";
           const locales: string[] = (config as any).i18n?.locales ?? ["en"];
 
-          const sections = [
-            { slug: "docs" },
-            ...((config as any).sections ?? []).map((s: any) => ({
-              slug: s.slug,
-            })),
-          ];
-          const targetSlugs = collections ?? sections.map((s) => s.slug);
+          const targetSlugs =
+            collections ?? getDefaultCollectionSlugs(root, config as any);
 
           const customModeBase = path.join(root, "src", "content");
           const quickModeBase = root;
@@ -225,74 +245,84 @@ export default definePlugin<RawMdPluginOptions>((options = {}) => {
               plugins: [
                 {
                   name: "barodoc-raw-md-dev",
+                  enforce: "pre" as const,
                   configureServer(server: any) {
-                    server.middlewares.use(
-                      (
-                        req: IncomingMessage,
-                        res: ServerResponse,
-                        next: () => void
-                      ) => {
-                        const url = req.url;
-                        if (!url || !url.endsWith(".md")) return next();
+                    const rawMdMiddleware = (
+                      req: IncomingMessage,
+                      res: ServerResponse,
+                      next: () => void
+                    ) => {
+                      const rawUrl = req.url ?? "";
+                      const url = rawUrl.replace(/\?[^#]*/, "").replace(/#.*$/, "");
+                      if (!url || !url.endsWith(".md")) return next();
 
-                        const urlPath = url.slice(1, -3); // strip leading / and trailing .md
-                        const parts = urlPath.split("/");
-                        if (parts.length < 2) return next();
+                      const urlPath = url.slice(1, -3);
+                      const parts = urlPath.split("/");
+                      if (parts.length < 2) return next();
 
-                        const sectionSlug = parts[0];
-                        if (!targetSlugs.includes(sectionSlug)) return next();
+                      const sectionSlug = parts[0];
+                      if (!targetSlugs.includes(sectionSlug)) return next();
 
-                        const restPath = parts.slice(1).join("/");
+                      const restPath = parts.slice(1).join("/");
 
-                        const collectionDir = isCustomMode
-                          ? path.join(customModeBase, sectionSlug)
-                          : path.join(
-                              quickModeBase,
-                              sectionSlug === "docs" ? "docs" : sectionSlug
-                            );
-
-                        if (!fs.existsSync(collectionDir)) return next();
-
-                        // Try to find the source file — handle locale prefix
-                        const candidates: string[] = [];
-                        const restParts = restPath.split("/");
-
-                        if (locales.includes(restParts[0]) && restParts[0] !== defaultLocale) {
-                          const locale = restParts[0];
-                          const innerSlug = restParts.slice(1).join("/");
-                          candidates.push(
-                            path.join(collectionDir, locale, `${innerSlug}.mdx`),
-                            path.join(collectionDir, locale, `${innerSlug}.md`)
+                      const collectionDir = isCustomMode
+                        ? path.join(customModeBase, sectionSlug)
+                        : path.join(
+                            quickModeBase,
+                            sectionSlug === "docs" ? "docs" : sectionSlug
                           );
-                        } else {
-                          candidates.push(
-                            path.join(collectionDir, defaultLocale, `${restPath}.mdx`),
-                            path.join(collectionDir, defaultLocale, `${restPath}.md`),
-                            path.join(collectionDir, `${restPath}.mdx`),
-                            path.join(collectionDir, `${restPath}.md`)
-                          );
-                        }
 
-                        for (const filePath of candidates) {
-                          if (fs.existsSync(filePath)) {
-                            const raw = fs.readFileSync(filePath, "utf-8");
-                            const content = prepareContent(
-                              raw,
-                              clean,
-                              includeFrontmatter
-                            );
-                            res.setHeader(
-                              "Content-Type",
-                              "text/markdown; charset=utf-8"
-                            );
-                            res.end(content);
-                            return;
-                          }
-                        }
+                      if (!fs.existsSync(collectionDir)) return next();
 
-                        next();
+                      const candidates: string[] = [];
+                      const restParts = restPath.split("/");
+
+                      if (locales.includes(restParts[0]) && restParts[0] !== defaultLocale) {
+                        const locale = restParts[0];
+                        const innerSlug = restParts.slice(1).join("/");
+                        candidates.push(
+                          path.join(collectionDir, locale, `${innerSlug}.mdx`),
+                          path.join(collectionDir, locale, `${innerSlug}.md`)
+                        );
+                      } else {
+                        candidates.push(
+                          path.join(collectionDir, defaultLocale, `${restPath}.mdx`),
+                          path.join(collectionDir, defaultLocale, `${restPath}.md`),
+                          path.join(collectionDir, `${restPath}.mdx`),
+                          path.join(collectionDir, `${restPath}.md`)
+                        );
                       }
-                    );
+
+                      for (const filePath of candidates) {
+                        if (fs.existsSync(filePath)) {
+                          const raw = fs.readFileSync(filePath, "utf-8");
+                          const content = prepareContent(
+                            raw,
+                            clean,
+                            includeFrontmatter
+                          );
+                          res.setHeader(
+                            "Content-Type",
+                            "text/markdown; charset=utf-8"
+                          );
+                          res.end(content);
+                          return;
+                        }
+                      }
+
+                      next();
+                    };
+
+                    // Run after internal (and Astro) middlewares are installed, then
+                    // prepend our middleware so .md requests are served first.
+                    return () => {
+                      const app = server.middlewares as { stack?: Array<{ route: string; handle: (req: IncomingMessage, res: ServerResponse, next: () => void) => void }> };
+                      if (Array.isArray(app.stack)) {
+                        app.stack.unshift({ route: "", handle: rawMdMiddleware });
+                      } else {
+                        server.middlewares.use(rawMdMiddleware);
+                      }
+                    };
                   },
                 },
               ],


### PR DESCRIPTION
## Summary
- **@barodoc/plugin-raw-md**: Fix dev server .md serving (prepend middleware via post hook); default `collections` to all when omitted
- **barodoc**: Quick mode: treat `dir` missing or `.` as auto-detect docs dir (avoids copy-into-itself)

## Changes
- `packages/plugin-raw-md/src/index.ts`: post-hook middleware + getDefaultCollectionSlugs()
- `packages/barodoc/src/commands/build.ts`, `serve.ts`: docsDir when !dir || dir === "."
- `docs/barodoc.config.json`: plugin-raw-md options for testing
- `.changeset/add-plugin-raw-md.md`, `.changeset/raw-md-dev-and-cli-fix.md`

Closes #103

Made with [Cursor](https://cursor.com)