### PR TITLE
fix(plugin-rss): astro:content type declaration and getCollection types

### DIFF
--- a/.changeset/fix-plugin-rss-astro-content-types.md
+++ b/.changeset/fix-plugin-rss-astro-content-types.md
@@ -1,0 +1,7 @@
+---
+"@barodoc/plugin-rss": patch
+---
+
+fix: add ambient type declaration for `astro:content` and type getCollection in feed
+
+Resolves TS2307 (Cannot find module 'astro:content') when type-checking plugin-rss. The virtual module is declared in `src/astro-env.d.ts`; feed.ts now passes explicit generics to getCollection for blog/changelog entry data.

--- a/packages/plugin-rss/src/astro-env.d.ts
+++ b/packages/plugin-rss/src/astro-env.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Ambient declaration for Astro virtual modules.
+ * Resolved at runtime when the feed runs inside an Astro app.
+ */
+declare module "astro:content" {
+  type CollectionEntry<T = Record<string, unknown>> = {
+    id: string;
+    slug: string;
+    data: T;
+    body: string;
+  };
+  export function getCollection<T = Record<string, unknown>>(
+    collection: string
+  ): Promise<Array<CollectionEntry<T>>>;
+}

--- a/packages/plugin-rss/src/feed.ts
+++ b/packages/plugin-rss/src/feed.ts
@@ -15,7 +15,7 @@ export async function GET(context: APIContext) {
     const { getCollection } = await import("astro:content");
 
     try {
-      const blogs = await getCollection("blog");
+      const blogs = await getCollection<{ title: string; date?: string; description?: string; excerpt?: string }>("blog");
       for (const post of blogs) {
         items.push({
           title: post.data.title,
@@ -27,7 +27,7 @@ export async function GET(context: APIContext) {
     } catch {}
 
     try {
-      const changelogs = await getCollection("changelog");
+      const changelogs = await getCollection<{ version: string; title?: string; date: string }>("changelog");
       for (const entry of changelogs) {
         items.push({
           title: `${entry.data.version}${entry.data.title ? ` - ${entry.data.title}` : ""}`,


### PR DESCRIPTION
## Summary
Resolves `TS2307: Cannot find module 'astro:content'` in `packages/plugin-rss`.

## Changes
- **`src/astro-env.d.ts`** (new): Ambient declaration for virtual module `astro:content` and `getCollection` type
- **`src/feed.ts`**: Pass explicit type params to `getCollection('blog')` and `getCollection('changelog')` so `post.data` / `entry.data` are typed

Closes #106

Made with [Cursor](https://cursor.com)