### PR TITLE
fix(theme-docs): Shiki transformer addClassToHast type

### DIFF
--- a/.changeset/fix-theme-docs-shiki-transformer-type.md
+++ b/.changeset/fix-theme-docs-shiki-transformer-type.md
@@ -1,0 +1,7 @@
+---
+"@barodoc/theme-docs": patch
+---
+
+fix: satisfy Shiki transformer type by adding addClassToHast to line-numbers transformer
+
+Resolves TS2352: the line-numbers transformer now includes addClassToHast so it matches the expected Shiki transformer interface. Implemented addClassToHast helper and attached it to the returned object.

--- a/packages/theme-docs/src/theme.ts
+++ b/packages/theme-docs/src/theme.ts
@@ -50,11 +50,21 @@ function createTrimEmptyLinesTransformer() {
   };
 }
 
+function addClassToHast(node: unknown, cls: string): void {
+  const n = node as { properties?: Record<string, unknown> };
+  if (!n.properties) n.properties = {};
+  const c = n.properties.className;
+  if (Array.isArray(c)) c.push(cls);
+  else if (typeof c === "string") n.properties.className = [c, cls];
+  else n.properties.className = [cls];
+}
+
 function createLineNumbersTransformer() {
   return {
     name: "barodoc-line-numbers",
+    addClassToHast,
     pre(node: { properties?: Record<string, unknown> }) {
-      (this as { addClassToHast: (node: unknown, cls: string) => void }).addClassToHast(node, "line-numbers");
+      addClassToHast(node, "line-numbers");
     },
   };
 }


### PR DESCRIPTION
## Summary
Fix TS2352 in theme-docs: line-numbers transformer must include `addClassToHast` to match Shiki transformer interface.

## Changes
- Add `addClassToHast(node, cls)` helper; attach to transformer return object
- `pre(node)` uses it to add `line-numbers` class

Closes #109

Made with [Cursor](https://cursor.com)