### PR TITLE
ci: generate Astro types for docs before typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Build packages
         run: pnpm build:packages
 
+      - name: Generate Astro types (docs)
+        run: pnpm --filter docs exec astro sync
+
       - name: Type check
         run: pnpm -r exec tsc --noEmit
 


### PR DESCRIPTION
## Summary
Fix CI Type check failure: `Cannot find module 'astro:content'` in `docs/src/content/config.ts`.

## Cause
`astro:content` types are generated by Astro into `.astro/`. Locally they exist after `astro dev`/build; in CI we never run astro, so types are missing.

## Solution
Add step before "Type check": `pnpm --filter docs exec astro sync`.

Closes #111

Made with [Cursor](https://cursor.com)