### PR TITLE
fix: add rst-compiler to docs deps and sync lockfile for CI

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,8 @@
     "@barodoc/theme-docs": "workspace:*",
     "astro": "^5.0.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "rst-compiler": "^0.5.7"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      rst-compiler:
+        specifier: ^0.5.7
+        version: 0.5.7
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.18


### PR DESCRIPTION
Closes #118

- Add `rst-compiler` to docs/package.json so lockfile and package.json match
- Sync pnpm-lock.yaml (fixes `pnpm install --frozen-lockfile` in CI)

Made with [Cursor](https://cursor.com)