### PR TITLE
feat: Sidebar hierarchy (nested nav) in barodoc.config.json

### DIFF
--- a/.changeset/sidebar-hierarchy.md
+++ b/.changeset/sidebar-hierarchy.md
@@ -1,0 +1,14 @@
+---
+"@barodoc/core": minor
+"@barodoc/theme-docs": minor
+"barodoc": minor
+"@barodoc/plugin-og-image": patch
+"@barodoc/plugin-llms-txt": minor
+---
+
+feat: sidebar hierarchy (nested nav) in barodoc.config.json
+
+- `navigation[].pages` supports `{ label, pages }` for expandable sidebar groups (Mintlify-style)
+- Use `label:ko` etc. for localized labels
+- Sidebar: item-level collapse, full-width docs layout; prev/next and category use flattened slugs
+- Header.astro mobile nav and plugins/CLI updated for nested config. Closes #128

--- a/.cursor/skills/barodoc-config/SKILL.md
+++ b/.cursor/skills/barodoc-config/SKILL.md
@@ -168,7 +168,10 @@ See [barodoc-i18n skill](../barodoc-i18n/SKILL.md) for detailed documentation.
 
 ### navigation
 
-Defines sidebar structure:
+Defines sidebar structure. Each group has `group` (and optional `group:ko` etc.) and `pages`. **Pages** can be a mix of:
+
+- **string** — page slug (flat link)
+- **object** — `{ label, pages }` for an expandable sidebar row (Mintlify-style hierarchy)
 
 ```json
 {
@@ -182,8 +185,8 @@ Defines sidebar structure:
       "group": "Guides",
       "group:ko": "가이드",
       "pages": [
-        "guides/installation",
-        "guides/configuration",
+        { "label": "Setup", "label:ko": "설정", "pages": ["guides/installation", "guides/configuration"] },
+        "guides/content-structure",
         "guides/deployment"
       ]
     }
@@ -195,11 +198,13 @@ Defines sidebar structure:
 |-------|------|-------------|
 | `group` | string | Group name (default locale) |
 | `group:LOCALE` | string | Localized group name |
-| `pages` | string[] | Page slugs (without locale prefix) |
+| `pages` | (string \| object)[] | Page slugs, or `{ label, label:ko?, pages: string[] }` for expandable rows |
 
 Page slugs map to files:
 - `introduction` → `docs/en/introduction.md`
 - `guides/installation` → `docs/en/guides/installation.md`
+
+Expandable entry: `{ "label": "Setup", "pages": ["guides/installation", "guides/configuration"] }` renders as a collapsible sidebar item with child links.
 
 ### topbar
 

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ docs/public/pagefind/
 # Git worktrees
 .worktrees/
 
+# Quick mode temporary project (barodoc serve from external dir)
+.barodoc/
+
 # Generated outputs (barodoc manifest / barodoc schema)
 docs-manifest.json
 docs-manifest-chunks.jsonl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ interface BarodocConfig {
   navigation: Array<{
     group: string;
     "group:ko"?: string;
-    pages: string[];
+    pages: Array<string | { label: string; "label:ko"?: string; pages: string[] }>;
   }>;
   
   plugins?: Array<string | [string, object]>;

--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ Configure your site via `barodoc.config.json` at the project root:
     { "slug": "help", "label": "Help Center", "navigation": [{ "group": "Support", "pages": ["faq", "contact"] }] }
   ],
   "navigation": [
-    { "group": "Getting Started", "group:ko": "시작하기", "pages": ["introduction", "quickstart"] }
+    { "group": "Getting Started", "group:ko": "시작하기", "pages": ["introduction", "quickstart"] },
+    { "group": "Guides", "pages": [{ "label": "Setup", "pages": ["guides/installation", "guides/configuration"] }, "guides/deployment"] }
   ],
   "topbar": { "github": "https://github.com/user/repo", "discord": "https://discord.gg/...", "twitter": "https://twitter.com/..." },
   "search": { "enabled": true },
@@ -208,6 +209,8 @@ Configure your site via `barodoc.config.json` at the project root:
   ]
 }
 ```
+
+**Sidebar hierarchy:** In `navigation[].pages`, you can use `{ "label": "Group name", "pages": ["slug1", "slug2"] }` to create an expandable sidebar section (Mintlify-style). Use `label:ko` etc. for localized labels.
 
 See the documentation in the repo's `docs/` folder for all options.
 

--- a/docs/barodoc.config.json
+++ b/docs/barodoc.config.json
@@ -44,7 +44,19 @@
     {
       "group": "Guides",
       "group:ko": "가이드",
-      "pages": ["guides/installation", "guides/configuration", "guides/content-structure", "guides/sections", "guides/standalone-pages", "guides/cli", "guides/overrides", "guides/deployment", "guides/i18n", "guides/migration", "guides/troubleshooting", "guides/ai-and-agents"]
+      "pages": [
+        { "label": "Setup", "label:ko": "설정", "pages": ["guides/installation", "guides/configuration"] },
+        "guides/content-structure",
+        "guides/sections",
+        "guides/standalone-pages",
+        "guides/cli",
+        "guides/overrides",
+        "guides/deployment",
+        "guides/i18n",
+        "guides/migration",
+        "guides/troubleshooting",
+        "guides/ai-and-agents"
+      ]
     },
     {
       "group": "Components",

--- a/docs/src/content/docs/en/guides/configuration.mdx
+++ b/docs/src/content/docs/en/guides/configuration.mdx
@@ -133,7 +133,9 @@ See [Content Structure](/docs/guides/content-structure) for details on how tabs 
 
 ### navigation
 
-Define the sidebar navigation structure. Use `group` for the default locale and `group:LOCALE` for translated group names (see [I18n](/docs/guides/i18n)):
+Define the sidebar navigation structure. Use `group` for the default locale and `group:LOCALE` for translated group names (see [I18n](/docs/guides/i18n)).
+
+**Flat list** — each entry in `pages` is a page slug:
 
 ```json
 {
@@ -146,6 +148,27 @@ Define the sidebar navigation structure. Use `group` for the default locale and 
   ]
 }
 ```
+
+**Sidebar hierarchy** — an entry in `pages` can be an object with `label` and `pages` to show an expandable group in the sidebar (Mintlify-style). Use `label:LOCALE` for translated labels:
+
+```json
+{
+  "navigation": [
+    {
+      "group": "Guides",
+      "group:ko": "가이드",
+      "pages": [
+        { "label": "Setup", "label:ko": "설정", "pages": ["guides/installation", "guides/configuration"] },
+        "guides/deployment",
+        "guides/i18n"
+      ]
+    }
+  ]
+}
+```
+
+- **Page slugs** map to files: `introduction` → `docs/en/introduction.md`, `guides/installation` → `docs/en/guides/installation.md`.
+- **Expandable item**: `{ "label": "Setup", "pages": ["guides/installation", "guides/configuration"] }` renders as a collapsible row "Setup" with two child links. The first child’s URL is used when the row is clicked.
 
 ### sections
 
@@ -325,7 +348,7 @@ Quick reference for all supported keys. Optional keys can be omitted.
 | `base` | `string` | `"/"` | Base path for subdirectory deploys (e.g. `"/docs"`). |
 | `theme` | `object` | — | `colors` (accent, gray, light/dark), `fonts` (heading, body, code), `radius`. |
 | `i18n` | `object` | — | `defaultLocale`, `locales`, optional `labels`. |
-| `navigation` | `array` | — | **Required.** Sidebar groups and pages for `/docs/`. |
+| `navigation` | `array` | — | **Required.** Sidebar groups and pages for `/docs/`. Each group has `group`, `group:ko` (optional), and `pages` (slugs or `{ label, pages }` for expandable rows). |
 | `sections` | `array` | — | Extra sections (slug, label, navigation) e.g. Help, Guides. |
 | `tabs` | `array` | — | Header tabs: `{ label, href }` for Docs, Blog, Changelog, etc. |
 | `topbar` | `object` | — | `github`, `discord`, `twitter` URLs. |

--- a/docs/src/content/docs/ko/guides/configuration.mdx
+++ b/docs/src/content/docs/ko/guides/configuration.mdx
@@ -94,7 +94,7 @@ difficulty: intermediate
 
 ## 네비게이션
 
-사이드바 구조를 정의합니다:
+사이드바 구조를 정의합니다. `pages`에는 페이지 슬러그 문자열 또는 `{ "label": "이름", "pages": ["slug1", "slug2"] }` 형태의 접기 항목을 넣을 수 있습니다 (Mintlify 스타일 계층). `label:en` 등으로 다국어 라벨 지원.
 
 ```json
 {
@@ -107,7 +107,10 @@ difficulty: intermediate
     {
       "group": "가이드",
       "group:en": "Guides",
-      "pages": ["guides/installation", "guides/configuration"]
+      "pages": [
+        { "label": "설정", "label:en": "Setup", "pages": ["guides/installation", "guides/configuration"] },
+        "guides/deployment"
+      ]
     }
   ]
 }

--- a/packages/barodoc/src/commands/check.ts
+++ b/packages/barodoc/src/commands/check.ts
@@ -76,9 +76,12 @@ function getNavSlugs(config: any): Map<string, Set<string>> {
   }
 
   for (const group of config.navigation ?? []) {
-    for (const page of group.pages ?? []) {
-      for (const locale of locales) {
-        result.get(locale)!.add(page);
+    for (const entry of group.pages ?? []) {
+      const slugs = typeof entry === "string" ? [entry] : entry.pages;
+      for (const page of slugs) {
+        for (const locale of locales) {
+          result.get(locale)!.add(page);
+        }
       }
     }
   }

--- a/packages/barodoc/src/commands/manifest.ts
+++ b/packages/barodoc/src/commands/manifest.ts
@@ -218,9 +218,18 @@ function countWords(content: string): number {
   return stripped.split(/\s+/).filter((w) => w.length > 0).length;
 }
 
-function findCategory(slug: string, navigation: Array<{ group: string; pages: string[] }>): string | null {
+function flatPages(pages: Array<string | { pages: string[] }>): string[] {
+  const out: string[] = [];
+  for (const entry of pages) {
+    if (typeof entry === "string") out.push(entry);
+    else out.push(...entry.pages);
+  }
+  return out;
+}
+
+function findCategory(slug: string, navigation: Array<{ group: string; pages: Array<string | { pages: string[] }> }>): string | null {
   for (const group of navigation) {
-    if (group.pages.includes(slug)) return group.group;
+    if (flatPages(group.pages).includes(slug)) return group.group;
   }
   return null;
 }

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -1,8 +1,17 @@
 import { z } from "zod";
 
+/** A single page path, or an expandable group with label and child pages (sidebar hierarchy). */
+export const navPageEntrySchema = z.union([
+  z.string(),
+  z.object({
+    label: z.string(),
+    pages: z.array(z.string()),
+  }).passthrough(), // Allow label:ko, label:ja, etc.
+]);
+
 export const navItemSchema = z.object({
   group: z.string(),
-  pages: z.array(z.string()),
+  pages: z.array(navPageEntrySchema),
 }).passthrough(); // Allow group:ko, group:ja, etc.
 
 export const i18nConfigSchema = z.object({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,12 +1,17 @@
 import type { AstroIntegration } from "astro";
 import type { PluginConfig } from "./plugins/types.js";
 
+/** A single page path or an expandable sidebar group with label and child pages. */
+export type BarodocNavPageEntry =
+  | string
+  | { label: string; "label:ko"?: string; "label:ja"?: string; [key: `label:${string}`]: string | undefined; pages: string[] };
+
 export interface BarodocNavItem {
   group: string;
   "group:ko"?: string;
   "group:ja"?: string;
   [key: `group:${string}`]: string | undefined;
-  pages: string[];
+  pages: BarodocNavPageEntry[];
 }
 
 export interface BarodocI18nConfig {

--- a/packages/plugin-llms-txt/src/index.ts
+++ b/packages/plugin-llms-txt/src/index.ts
@@ -120,13 +120,14 @@ function scanDocs(
   docsDir: string,
   locales: string[],
   defaultLocale: string,
-  navigation: Array<{ pages: string[] }>
+  navigation: Array<{ pages: Array<string | { pages: string[] }> }>
 ): PageEntry[] {
   const orderedSlugs: string[] = [];
   for (const group of navigation) {
-    for (const slug of group.pages ?? []) {
-      if (!orderedSlugs.includes(slug)) {
-        orderedSlugs.push(slug);
+    for (const entry of group.pages ?? []) {
+      const slugs: string[] = typeof entry === "string" ? [entry] : entry.pages;
+      for (const slug of slugs) {
+        if (!orderedSlugs.includes(slug)) orderedSlugs.push(slug);
       }
     }
   }

--- a/packages/plugin-og-image/src/index.ts
+++ b/packages/plugin-og-image/src/index.ts
@@ -141,7 +141,12 @@ export default definePlugin<OgImagePluginOptions>((options = {}) => {
 
         let count = 0;
         for (const group of config.navigation) {
-          for (const page of group.pages) {
+          const pageSlugs: string[] = [];
+          for (const entry of group.pages) {
+            if (typeof entry === "string") pageSlugs.push(entry);
+            else pageSlugs.push(...entry.pages);
+          }
+          for (const page of pageSlugs) {
             const slug = page.replace(/\//g, "-");
             const title = page
               .split("/")

--- a/packages/theme-docs/src/components/DocHeader.tsx
+++ b/packages/theme-docs/src/components/DocHeader.tsx
@@ -102,7 +102,7 @@ export function DocHeader({
   return (
     <TooltipProvider>
       <header className="sticky top-0 z-50 w-full min-w-0 border-b border-[var(--bd-border)] bg-[var(--bd-bg)]/95 backdrop-blur-md supports-[backdrop-filter]:bg-[var(--bd-bg)]/80">
-        <div className="flex h-14 items-center justify-between gap-2 px-4 sm:px-6 max-w-[1280px] mx-auto min-w-0">
+        <div className="flex h-14 items-center justify-between gap-2 px-4 sm:px-6 lg:px-8 w-full min-w-0">
           {/* Left: hamburger (mobile) + logo + tabs */}
           <div className="flex items-center gap-3 md:gap-6 min-w-0 shrink">
             {/* Mobile menu — left so it matches sheet sliding from left */}

--- a/packages/theme-docs/src/components/DocsSidebar.tsx
+++ b/packages/theme-docs/src/components/DocsSidebar.tsx
@@ -11,6 +11,8 @@ interface NavItem {
   title: string;
   href: string;
   isActive?: boolean;
+  /** Nested items (Mintlify-style: only these expand/collapse, not the group) */
+  children?: NavItem[];
 }
 
 interface NavGroup {
@@ -26,7 +28,7 @@ interface DocsSidebarProps {
 
 export function DocsSidebar({ groups, className }: DocsSidebarProps) {
   return (
-    <nav className={cn("space-y-5", className)}>
+    <nav className={cn("space-y-7", className)}>
       {groups.map((group, index) => (
         <SidebarGroup key={index} group={group} />
       ))}
@@ -34,41 +36,61 @@ export function DocsSidebar({ groups, className }: DocsSidebarProps) {
   );
 }
 
+/** Mintlify-style: group is always visible (no collapse). Only items with children expand/collapse. */
 function SidebarGroup({ group }: { group: NavGroup }) {
-  const [isOpen, setIsOpen] = React.useState(group.defaultOpen ?? true);
-
   return (
-    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <CollapsibleTrigger className="group flex w-full items-center gap-1.5 py-1.5 text-[13px] font-semibold text-[var(--bd-text)] hover:text-[var(--bd-text-heading)] transition-colors">
-        <ChevronRight
-          className={cn(
-            "h-3.5 w-3.5 text-[var(--bd-text-muted)] transition-transform duration-200",
-            isOpen && "rotate-90"
-          )}
-        />
-        {group.title}
-      </CollapsibleTrigger>
-      <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
-        <ul className="mt-1 space-y-px border-l border-[var(--bd-border)] ml-2">
-          {group.items.map((item, index) => (
-            <SidebarItem key={index} item={item} />
-          ))}
-        </ul>
-      </CollapsibleContent>
-    </Collapsible>
+    <div>
+      <div className="py-1 text-[14px] font-bold text-[var(--bd-text)]">
+        <span className="truncate">{group.title}</span>
+      </div>
+      <ul className="mt-2 space-y-1">
+        {group.items.map((item, index) => (
+          <SidebarItem key={index} item={item} depth={0} />
+        ))}
+      </ul>
+    </div>
   );
 }
 
-function SidebarItem({ item }: { item: NavItem }) {
+function SidebarItem({ item, depth = 0 }: { item: NavItem; depth?: number }) {
+  const hasChildren = item.children && item.children.length > 0;
+  const [open, setOpen] = React.useState(true);
+
+  if (hasChildren) {
+    return (
+      <li>
+        <Collapsible open={open} onOpenChange={setOpen}>
+          <CollapsibleTrigger className="flex w-full items-center py-1.5 px-2 text-[14px] rounded-md transition-colors font-normal text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)]">
+            <span className="truncate flex-1 text-left">{item.title}</span>
+            <ChevronRight
+              className={cn(
+                "h-4 w-4 text-[var(--bd-text-muted)] transition-transform duration-200 shrink-0 ml-1",
+                open && "rotate-90"
+              )}
+            />
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <ul className="mt-1 space-y-1 pl-4">
+              {item.children!.map((child, i) => (
+                <SidebarItem key={i} item={child} depth={depth + 1} />
+              ))}
+            </ul>
+          </CollapsibleContent>
+        </Collapsible>
+      </li>
+    );
+  }
+
   return (
-    <li className="relative">
+    <li>
       <a
         href={item.href}
         className={cn(
-          "block pl-4 pr-2 py-1.5 text-[13px] rounded-r-md transition-all duration-150 -ml-px border-l-2",
+          "block py-1.5 px-2 text-[14px] rounded-md transition-colors",
+          depth > 0 && "pl-2",
           item.isActive
-            ? "border-[var(--bd-sidebar-active-border)] text-[var(--bd-sidebar-active-text)] font-medium bg-[var(--bd-sidebar-active-bg)]"
-            : "border-transparent text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] hover:border-[var(--bd-text-muted)]"
+            ? "font-semibold text-[var(--bd-sidebar-active-text)] bg-[var(--bd-sidebar-active-bg)]"
+            : "font-normal text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)]"
         )}
       >
         <span className="truncate">{item.title}</span>

--- a/packages/theme-docs/src/components/Header.astro
+++ b/packages/theme-docs/src/components/Header.astro
@@ -54,14 +54,35 @@ function getPageTitle(page: string) {
     .join(" ");
 }
 
+function getLocalizedLabel(entry: { label: string; [key: string]: unknown }, locale: string, defaultLocale: string): string {
+  if (locale !== defaultLocale && entry[`label:${locale}`]) return entry[`label:${locale}`] as string;
+  return entry.label;
+}
+
+type PageEntry = string | { label: string; pages: string[]; [key: string]: unknown };
+function buildNavItems(pages: PageEntry[]): { title: string; href: string; isActive: boolean; children?: { title: string; href: string; isActive: boolean }[] }[] {
+  return pages.map((entry) => {
+    if (typeof entry === "string") {
+      return { title: getPageTitle(entry), href: getPageHref(entry), isActive: isActive(entry) };
+    }
+    const firstPage = entry.pages[0];
+    return {
+      title: getLocalizedLabel(entry, currentLocale, defaultLocale),
+      href: firstPage ? getPageHref(firstPage) : "#",
+      isActive: entry.pages.some((p: string) => isActive(p)),
+      children: entry.pages.map((p: string) => ({
+        title: getPageTitle(p),
+        href: getPageHref(p),
+        isActive: isActive(p),
+      })),
+    };
+  });
+}
+
 const mobileNavGroups = sectionNav.map((group: any) => ({
   title: getLocalizedNavGroup(group, currentLocale, defaultLocale),
   defaultOpen: true,
-  items: group.pages.map((page: string) => ({
-    title: getPageTitle(page),
-    href: getPageHref(page),
-    isActive: isActive(page),
-  })),
+  items: buildNavItems(group.pages),
 }));
 ---
 

--- a/packages/theme-docs/src/components/Sidebar.astro
+++ b/packages/theme-docs/src/components/Sidebar.astro
@@ -48,14 +48,35 @@ function getPageTitle(page: string): string {
     .join(' ');
 }
 
+function getLocalizedLabel(entry: { label: string; [key: string]: unknown }, locale: string, defaultLocale: string): string {
+  if (locale !== defaultLocale && entry[`label:${locale}`]) return entry[`label:${locale}`] as string;
+  return entry.label;
+}
+
+function buildItems(group: { group?: string; pages: (string | { label: string; pages: string[]; [key: string]: unknown })[] }) {
+  const pages = group.pages;
+  return pages.map((entry) => {
+    if (typeof entry === "string") {
+      return { title: getPageTitle(entry), href: getPageHref(entry), isActive: isActive(entry) };
+    }
+    const firstPage = entry.pages[0];
+    return {
+      title: getLocalizedLabel(entry, currentLocale, defaultLocale),
+      href: firstPage ? getPageHref(firstPage) : "#",
+      isActive: entry.pages.some((p: string) => isActive(p)),
+      children: entry.pages.map((page: string) => ({
+        title: getPageTitle(page),
+        href: getPageHref(page),
+        isActive: isActive(page),
+      })),
+    };
+  });
+}
+
 const groups = sectionNav.map((group: any) => ({
   title: getLocalizedNavGroup(group, currentLocale, defaultLocale),
   defaultOpen: true,
-  items: group.pages.map((page: string) => ({
-    title: getPageTitle(page),
-    href: getPageHref(page),
-    isActive: isActive(page),
-  })),
+  items: buildItems(group),
 }));
 ---
 

--- a/packages/theme-docs/src/layouts/DocsLayout.astro
+++ b/packages/theme-docs/src/layouts/DocsLayout.astro
@@ -52,19 +52,19 @@ const feedbackEndpoint = config.feedback?.endpoint;
   <Banner />
   <Header currentLocale={currentLocale} currentPath={currentPath} sectionSlug={sectionSlug} uiStrings={t} />
   
-  <!-- Centered container for docs layout -->
-  <div class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex justify-center overflow-x-clip" dir={dir}>
-    <div class="flex w-full max-w-[1280px] min-w-0">
-      <!-- Desktop Sidebar -->
-      <aside class="hidden lg:block w-[240px] shrink-0 border-r border-[var(--bd-border)]">
-        <div class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto overscroll-contain pt-2 pb-8 px-4 sidebar-scroll">
+  <!-- Full-width docs layout: sidebar + content + TOC use full viewport -->
+  <div class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex overflow-x-clip" dir={dir}>
+    <div class="flex w-full min-w-0">
+      <!-- Desktop Sidebar (Mintlify-style: no vertical line, indent + bold section, active = text only) -->
+      <aside class="hidden lg:block w-[280px] shrink-0 border-r border-[var(--bd-border)] bg-[var(--bd-bg)]">
+        <div class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto overscroll-contain py-6 px-5 pb-8 sidebar-scroll">
           <Sidebar currentPath={currentPath} currentLocale={currentLocale} sectionSlug={sectionSlug} />
         </div>
       </aside>
 
-      <!-- Main Content -->
-      <main class="flex-1 min-w-0 max-w-[768px]">
-        <div class="px-4 py-8 sm:px-6 sm:py-10 lg:px-10 lg:py-10">
+      <!-- Main Content: flex-1 uses full space between sidebar and TOC; inner wrapper caps width and centers -->
+      <main class="flex-1 min-w-0 flex justify-center">
+        <div class="w-full max-w-[768px] px-4 py-8 sm:px-6 sm:py-10 lg:px-10 lg:py-10">
           {breadcrumbs.length > 0 && <Breadcrumb items={breadcrumbs} sectionSlug={sectionSlug} />}
           {readingTime && (
             <div class="bd-reading-time mb-4">

--- a/packages/theme-docs/src/pages/section/[...slug].astro
+++ b/packages/theme-docs/src/pages/section/[...slug].astro
@@ -164,9 +164,19 @@ if (!isAsset) {
   readTime = readingTime(doc.body ?? "");
 }
 
+/** Flatten navigation entries to string slugs (handles nested { label, pages }). */
+function flatPages(pages: Array<string | { pages: string[] }>): string[] {
+  const out: string[] = [];
+  for (const entry of pages) {
+    if (typeof entry === "string") out.push(entry);
+    else out.push(...entry.pages);
+  }
+  return out;
+}
+
 function findCategory(slug: string): string | null {
   for (const group of sectionNav) {
-    if (group.pages.includes(slug)) {
+    if (flatPages(group.pages).includes(slug)) {
       return getLocalizedNavGroup(group, locale, defaultLocale);
     }
   }
@@ -177,7 +187,7 @@ function findCategory(slug: string): string | null {
 function getAllPages(): string[] {
   const pages: string[] = [];
   for (const group of sectionNav) {
-    pages.push(...group.pages);
+    pages.push(...flatPages(group.pages));
   }
   return pages;
 }

--- a/packages/theme-docs/src/styles/global.css
+++ b/packages/theme-docs/src/styles/global.css
@@ -70,7 +70,7 @@
     --bd-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.07), 0 2px 4px -2px rgb(0 0 0 / 0.05);
     --bd-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.04);
 
-    --bd-sidebar-active-bg:     var(--color-primary-50);
+    --bd-sidebar-active-bg:     var(--color-primary-100);
     --bd-sidebar-active-border: var(--color-primary-500);
     --bd-sidebar-active-text:   var(--color-primary-600);
 
@@ -108,7 +108,7 @@
     --bd-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.5), 0 2px 4px -2px rgb(0 0 0 / 0.4);
     --bd-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.5), 0 4px 6px -4px rgb(0 0 0 / 0.4);
 
-    --bd-sidebar-active-bg:     var(--color-primary-950);
+    --bd-sidebar-active-bg:     var(--color-primary-900);
     --bd-sidebar-active-border: var(--color-primary-400);
     --bd-sidebar-active-text:   var(--color-primary-400);
   }


### PR DESCRIPTION
## Summary
Adds support for nested/expandable sidebar items in `barodoc.config.json` (Mintlify-style).

## Config
`navigation[].pages` can now include objects:
```json
{ "label": "Setup", "pages": ["guides/installation", "guides/configuration"] }
```
Use `label:ko` etc. for localized labels.

## Changes
- **@barodoc/core**: Schema and types for `BarodocNavPageEntry` (string | { label, pages })
- **@barodoc/theme-docs**: Sidebar item-level collapse, full-width layout; prev/next and category use flattened slugs; Header.astro mobile nav supports nested items
- **barodoc**: `check` and `manifest` flatten `pages`
- **@barodoc/plugin-og-image**, **@barodoc/plugin-llms-txt**: Flatten `pages` when iterating
- Docs, README, AGENTS.md updated
- .gitignore: ignore `.barodoc/` (Quick mode temp dir)

Closes #128

Made with [Cursor](https://cursor.com)