### PR TITLE
docs: Changelog v10.0.0/v10.0.1, changeset guidelines (patch + docs changelog)

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,39 @@
+# Changesets
+
+## Version bump: prefer patch
+
+- **Use `patch`** for bug fixes, docs-only changes, and small improvements. Avoid unnecessary major/minor bumps.
+- Use **`minor`** only for new backward-compatible features that warrant a minor release.
+- Use **`major`** only for breaking changes.
+
+Example: when adding a changeset, set the affected packages to `patch`:
+
+```md
+---
+"@barodoc/theme-docs": patch
+---
+
+fix: description of the change
+```
+
+## Docs changelog (required when adding a changeset)
+
+When you add a changeset, **also add a changelog entry** so the [docs site Changelog](https://barodoc.barocss.com/changelog/) stays in sync:
+
+1. **File:** `docs/src/content/changelog/vX.Y.Z.mdx`
+2. **Version:** Use the **next** patch version (e.g. if linked packages are at `10.0.1`, the next release will be `10.0.2` → create `v10.0.2.mdx`). Check `packages/theme-docs/package.json` or `packages/core/package.json` for current version.
+3. **Frontmatter and body:**
+
+```md
+---
+version: "10.0.2"
+date: 2026-03-19
+title: "Short title for the release"
+---
+
+### Fixes
+
+- Description matching your changeset.
+```
+
+Commit the new `docs/src/content/changelog/vX.Y.Z.mdx` file **in the same PR** as the changeset. That way each release is both versioned and documented on the site.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -199,11 +199,19 @@ See `AGENTS.md` (Plugin System) and `.cursor/skills/barodoc-plugins/SKILL.md` fo
    pnpm -r exec tsc --noEmit
    ```
 
+### Adding a changeset (and releasing)
+
+1. **Prefer patch:** Use `patch` for the affected packages in the changeset (avoid unnecessary major/minor). Use `minor` only for new features, `major` only for breaking changes. See [.changeset/README.md](.changeset/README.md).
+2. Add a changeset file under `.changeset/` (e.g. `fix-something.md`) with the package(s) and summary.
+3. **Add a docs changelog entry:** Create `docs/src/content/changelog/vX.Y.Z.mdx` with the **next** patch version (e.g. if current is 10.0.1, use 10.0.2), `date`, `title`, and a body that matches the changeset. Commit it in the same PR as the changeset so the [site Changelog](https://barodoc.barocss.com/changelog/) stays in sync.
+4. Merge to `main`; the release workflow will create a "Version packages" PR. Merging that publishes to npm.
+
 ### Releasing a new plugin
 
 1. Add the package to the changeset **linked** array in `.changeset/config.json` if it should version with the rest of the stack.
-2. Add a changeset under `.changeset/` (e.g. `feat: add @barodoc/plugin-raw-md`).
-3. Merge to `main`; the release workflow will create a “Version packages” PR. Merging that publishes to npm.
+2. Add a changeset under `.changeset/` (e.g. `feat: add @barodoc/plugin-raw-md`). Prefer `patch` unless it's a new feature (`minor`).
+3. Add `docs/src/content/changelog/vX.Y.Z.mdx` for the release (see above).
+4. Merge to `main`; the release workflow will create a “Version packages” PR. Merging that publishes to npm.
 
 ---
 
@@ -217,7 +225,8 @@ See `AGENTS.md` (Plugin System) and `.cursor/skills/barodoc-plugins/SKILL.md` fo
 | Dev server (my-docs) | From my-docs: `node ../barodoc/packages/barodoc/dist/cli.js serve` |
 | Build my-docs | From my-docs: `node ../barodoc/packages/barodoc/dist/cli.js build . -o dist` |
 | Docs site deploy | Push to `main` → [.github/workflows/docs.yml](.github/workflows/docs.yml) builds `docs/dist` and deploys to GitHub Pages |
-| Changelog content | `docs/src/content/changelog/vX.Y.Z.mdx` (version, date, title + body); push to main to publish |
+| Changelog content | `docs/src/content/changelog/vX.Y.Z.mdx` (version, date, title + body); add when adding a changeset; push to main to publish |
+| Changeset | Prefer **patch**; add `.changeset/*.md` and **docs changelog** in same PR — see [.changeset/README.md](.changeset/README.md) |
 | Build all packages | `pnpm build:packages` |
 | Type-check | `pnpm --filter docs exec astro sync` then `pnpm -r exec tsc --noEmit` |
 | Plugin config (docs) | `docs/barodoc.config.json` → `plugins` |

--- a/docs/src/content/changelog/v10.0.0.mdx
+++ b/docs/src/content/changelog/v10.0.0.mdx
@@ -1,0 +1,23 @@
+---
+version: "10.0.0"
+date: 2026-03-19
+title: "Sidebar hierarchy and full-width docs layout"
+---
+
+### New Features
+
+- **Sidebar hierarchy** — `navigation[].pages` in `barodoc.config.json` now supports nested entries. Use `{ "label": "Setup", "pages": ["guides/installation", "guides/configuration"] }` for expandable sidebar groups. Use `label:ko` (or `label:ja`, etc.) for localized labels.
+- **Full-width docs layout** — Docs layout uses the full viewport: sidebar and main content area span edge-to-edge; article content remains centered with a readable max-width.
+
+### Improvements
+
+- **Sidebar UX** — Item-level collapse for entries with children (chevron on the right); group titles are always visible. Active item uses a rounded background highlight. Reduced indent for nested items.
+- **Header** — Header and nav bar span full width to match the new layout.
+- **Mobile nav** — Hamburger menu supports nested navigation items with the same hierarchy as the sidebar.
+- **Prev/next and category** — Correctly computed when using nested nav (flattened slug list).
+- **Plugins** — `@barodoc/plugin-og-image` and `@barodoc/plugin-llms-txt` now flatten nested `pages` when scanning. CLI `check` and `manifest` commands handle the new config shape.
+
+### Documentation
+
+- Configuration guide updated with flat list vs sidebar hierarchy examples (EN/KO).
+- README and AGENTS.md updated with `navigation.pages` type and hierarchy example.

--- a/docs/src/content/changelog/v10.0.1.mdx
+++ b/docs/src/content/changelog/v10.0.1.mdx
@@ -1,0 +1,16 @@
+---
+version: "10.0.1"
+date: 2026-03-19
+title: "Docs updates and Deploy Docs fix"
+---
+
+### Fixes
+
+- **MobileNav.astro** — Flatten nested nav entries when building mobile nav groups so `getPageTitle` never receives an object. Fixes Deploy Docs workflow failing with `page.split is not a function` when `navigation.pages` contains `{ label, pages }` objects.
+
+### Documentation
+
+- Changelog v9.1.0 and v10.0.0 added to the docs site; removed Mintlify-style wording from docs and code comments.
+- DESIGN-PLAN.md: layout/sidebar specs; DEVELOPMENT.md: docs site deployment (GitHub Pages, changelog content).
+- About, roadmap, quickstart, content-structure, introduction (en/ko) updated for sidebar hierarchy.
+- Changeset guidelines: prefer patch, add docs changelog when adding a changeset (`.changeset/README.md`, DEVELOPMENT.md).


### PR DESCRIPTION
## Summary
- **Docs changelog:** Add v10.0.0 (sidebar hierarchy, full-width layout), v10.0.1 (MobileNav fix, docs/changelog wording, changeset guidelines).
- **Changeset guidelines:** `.changeset/README.md` — prefer patch; require `docs/src/content/changelog/vX.Y.Z.mdx` when adding a changeset (same PR).
- **DEVELOPMENT.md:** "Adding a changeset (and releasing)" section; "Releasing a new plugin" updated with patch + changelog step; Quick reference row for Changeset.

Made with [Cursor](https://cursor.com)