### PR TITLE
fix: Changelog sort by version (newest first), move version utils to lib

### DIFF
--- a/.changeset/changelog-sort-and-lib-version.md
+++ b/.changeset/changelog-sort-and-lib-version.md
@@ -1,0 +1,8 @@
+---
+"@barodoc/theme-docs": patch
+---
+
+fix: Changelog page sort by version (newest first), move version utils to lib
+
+- Sort changelog entries by date desc, then by semver desc so same-date entries (e.g. 10.0.0 vs 10.0.1) show newest first.
+- Add lib/version.ts (parseVersion, compareVersion) and use from changelog index. Closes #138

--- a/docs/src/content/changelog/v10.0.3.mdx
+++ b/docs/src/content/changelog/v10.0.3.mdx
@@ -1,0 +1,13 @@
+---
+version: "10.0.3"
+date: 2026-03-19
+title: "Changelog sort and shared version utils"
+---
+
+### Fixes
+
+- **Changelog page** — Entries are now sorted by date (newest first), then by version when dates are equal, so the latest release (e.g. 10.0.2) always appears at the top.
+
+### Improvements
+
+- **Shared version helpers** — `parseVersion` and `compareVersion` moved to `lib/version.ts` for reuse; changelog page imports from there.

--- a/packages/theme-docs/src/lib/version.ts
+++ b/packages/theme-docs/src/lib/version.ts
@@ -1,0 +1,19 @@
+/**
+ * Parse "X.Y.Z" or "vX.Y.Z" and return [major, minor, patch] for comparison.
+ */
+export function parseVersion(v: string): [number, number, number] {
+  const parts = v.replace(/^v/, "").split(".").map(Number);
+  return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+}
+
+/**
+ * Compare two version strings. Returns a number for use with Array.sort:
+ * positive if b is newer than a, negative if a is newer, 0 if equal.
+ */
+export function compareVersion(a: string, b: string): number {
+  const [aMaj, aMin, aPatch] = parseVersion(a);
+  const [bMaj, bMin, bPatch] = parseVersion(b);
+  if (aMaj !== bMaj) return bMaj - aMaj;
+  if (aMin !== bMin) return bMin - aMin;
+  return bPatch - aPatch;
+}

--- a/packages/theme-docs/src/pages/changelog/index.astro
+++ b/packages/theme-docs/src/pages/changelog/index.astro
@@ -6,6 +6,7 @@ import Banner from "../../components/Banner.astro";
 import { defaultLocale, locales, uiStrings } from "virtual:barodoc/i18n";
 import { getLocaleFromPath } from "@barodoc/core";
 import config from "virtual:barodoc/config";
+import { compareVersion } from "../../lib/version.js";
 
 const currentPath = Astro.url.pathname;
 const i18nConfig = { defaultLocale, locales: locales ?? [defaultLocale] };
@@ -20,7 +21,10 @@ try {
 }
 
 const sorted = entries.sort((a, b) => {
-  return new Date(b.data.date).getTime() - new Date(a.data.date).getTime();
+  const dateA = new Date(a.data.date).getTime();
+  const dateB = new Date(b.data.date).getTime();
+  if (dateB !== dateA) return dateB - dateA; // newest date first
+  return compareVersion(b.data.version, a.data.version); // same date: newest version first
 });
 ---
 


### PR DESCRIPTION
## Summary
- Changelog page: sort by date desc, then by semver desc so same-date entries (e.g. 10.0.0 vs 10.0.1) show newest first.
- Add `lib/version.ts` (parseVersion, compareVersion); changelog index imports from there.
- Docs changelog v10.0.3.

Closes #138

Made with [Cursor](https://cursor.com)