### PR TITLE
fix: Changelog sort by version first (newest on top), correct compareVersion order

### DIFF
--- a/.changeset/changelog-sort-version-first.md
+++ b/.changeset/changelog-sort-version-first.md
@@ -1,0 +1,7 @@
+---
+"@barodoc/theme-docs": patch
+---
+
+fix: Changelog sort by version first (newest on top), correct compareVersion order
+
+- Use compareVersion(a, b) so newer version is placed first; sort by version desc then date desc. Closes #141

--- a/docs/src/content/changelog/v10.0.4.mdx
+++ b/docs/src/content/changelog/v10.0.4.mdx
@@ -1,0 +1,9 @@
+---
+version: "10.0.4"
+date: 2026-03-20
+title: "Changelog sort fix (newest version on top)"
+---
+
+### Fixes
+
+- **Changelog page** — Sort by version descending first (newest at top), then by date. Corrected `compareVersion` usage so newer versions (e.g. 10.0.3) no longer appear below older ones.

--- a/packages/theme-docs/src/pages/changelog/index.astro
+++ b/packages/theme-docs/src/pages/changelog/index.astro
@@ -20,11 +20,13 @@ try {
   // changelog collection may not exist
 }
 
+// Newest version first (primary), then newest date first (tiebreaker)
 const sorted = entries.sort((a, b) => {
+  const versionCompare = compareVersion(a.data.version, b.data.version);
+  if (versionCompare !== 0) return versionCompare; // positive when b is newer → b first
   const dateA = new Date(a.data.date).getTime();
   const dateB = new Date(b.data.date).getTime();
-  if (dateB !== dateA) return dateB - dateA; // newest date first
-  return compareVersion(b.data.version, a.data.version); // same date: newest version first
+  return dateB - dateA;
 });
 ---
 


### PR DESCRIPTION
## Summary
- Use `compareVersion(a, b)` so newer version is placed first (was `compareVersion(b, a)` which reversed order).
- Sort by **version descending** first, then date descending as tiebreaker.

Closes #141

Made with [Cursor](https://cursor.com)