### PR TITLE
Release 10.0.5: CLI, theme, plugin docs and asset full-width

### DIFF
--- a/.changeset/asset-fullwidth-layout.md
+++ b/.changeset/asset-fullwidth-layout.md
@@ -1,0 +1,8 @@
+---
+"@barodoc/theme-docs": patch
+barodoc: patch
+"@barodoc/plugin-openapi": patch
+"@barodoc/plugin-llms-txt": patch
+---
+
+feat: CLI production check, create --with-github-pages, theme readingTime/fullWidth, plugin READMEs and docs

--- a/docs/plans/2026-03-19-feedback-webhook-spec.md
+++ b/docs/plans/2026-03-19-feedback-webhook-spec.md
@@ -1,0 +1,62 @@
+# Feedback widget — webhook contract
+
+**Date:** 2026-03-19  
+**Status:** Spec only (theme-docs already has the UI; this doc defines the backend contract.)
+
+## Overview
+
+The docs layout can show a **"Was this helpful?"** block (Yes / No) in the page footer. When enabled, the client sends a POST request to a configurable endpoint. This document describes the request and optional response so you can implement a receiver (e.g. serverless function, webhook handler).
+
+## Config
+
+In `barodoc.config.json`:
+
+```json
+{
+  "feedback": {
+    "enabled": true,
+    "endpoint": "https://your-api.com/docs-feedback"
+  }
+}
+```
+
+- **enabled** — Show the feedback block.
+- **endpoint** — URL that will receive POST requests. If omitted, the buttons still appear but no request is sent.
+
+## Request
+
+- **Method:** `POST`
+- **Headers:** `Content-Type: application/json`
+- **Body:** JSON object
+
+| Field   | Type   | Description |
+|--------|--------|-------------|
+| `page` | string | Current pathname (e.g. `/docs/guides/configuration`) |
+| `value` | string | `"yes"` or `"no"` |
+
+Example:
+
+```json
+{
+  "page": "/docs/guides/configuration",
+  "value": "yes"
+}
+```
+
+The client does not send cookies or auth headers. If you need to identify users or avoid duplicates, implement that in your backend (e.g. require a token, or accept anonymous feedback and dedupe by IP/session in your own logic).
+
+## Response
+
+The client ignores the response body and status code (it does not retry on 4xx/5xx). Any 2xx is fine for success. Recommended: return `204 No Content` or `200 OK`.
+
+## Backend ideas
+
+- **Serverless:** e.g. Vercel/Netlify function that appends to a sheet, sends to Slack, or writes to a DB.
+- **Analytics:** Forward to your analytics (e.g. custom event with `page` and `value`).
+- **Storage:** Append to a CSV, Airtable, or Postgres table for later analysis.
+
+## Future (out of scope for this spec)
+
+- Optional comment field (would require theme change).
+- Rate limiting / abuse protection (backend responsibility).
+- Dedicated `@barodoc/plugin-feedback` that ships a default serverless handler (optional follow-up).

--- a/docs/plans/2026-03-19-four-tier-implementation-plan.md
+++ b/docs/plans/2026-03-19-four-tier-implementation-plan.md
@@ -1,0 +1,221 @@
+# Barodoc 4단계 로드맵 — 실제 구현 계획
+
+**일자:** 2026-03-19  
+**근거:** [2026-03-19-four-tier-roadmap-design.md](./2026-03-19-four-tier-roadmap-design.md)
+
+순서: **1 → 2 → 3 → 4**. 각 단계 완료 후 다음 단계로 진행. 릴리즈는 단계마다 changeset + `docs/src/content/changelog/` 항목 ([barodoc-release 스킬](../../.cursor/skills/barodoc-release/SKILL.md) 참고).
+
+---
+
+## 공통
+
+| 항목 | 내용 |
+|------|------|
+| **검증** | `pnpm build:packages` → `pnpm dev` 또는 `pnpm build && pnpm preview` (theme-docs 아일랜드 검증 시 preview 권장, [DEVELOPMENT.md](../../DEVELOPMENT.md)) |
+| **타입체크** | `pnpm --filter docs exec astro sync` 후 `pnpm -r exec tsc --noEmit` |
+| **i18n** | 사용자 대면 문서는 `docs/src/content/docs/en/`와 `ko/` 둘 다 갱신(또는 한쪽만 먼저 + 이슈로 ko 백로그) |
+
+---
+
+## Phase 1 — 문서·설정 (코드 변경 최소)
+
+**목표:** 새 사용자가 문서만 보고 `base`, `editLink`, 테마, 검색, GitHub Pages(Quick), a11y/SEO를 따라 할 수 있게 한다.
+
+### Task 1.1 — `base` / GitHub Pages 프로젝트 사이트
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `docs/src/content/docs/en/guides/deployment.mdx`, `ko/guides/deployment.mdx` |
+| **작업** | `barodoc.config.json`의 `base` 설명 추가. `https://user.github.io/repo-name/` 형태의 **프로젝트 사이트**에서 `base`를 `/repo-name/`로 두는 예시. Quick 모드(`barodoc build`) 출력 경로와 `base` 관계 한 단락. |
+| **검증** | 배포 가이드만 읽고 프로젝트 사이트에서 자산 404 없이 로드되는지 수동 확인 절차 명시. |
+
+### Task 1.2 — `editLink` / `lastUpdated`
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `en/guides/configuration.mdx`, `ko/guides/configuration.mdx` (또는 전용 `guides/edit-and-meta.mdx` 신설 시 네비에 추가) |
+| **작업** | `editLink.baseUrl`, 파일 경로 템플릿(Barodoc이 실제로 쓰는 규칙과 일치하는지 `packages/theme-docs`에서 확인 후 문서화). `lastUpdated: true` 시 Git 기반 표시 여부·제한 사항. 푸터에서 어디에 보이는지 스크린샷 또는 설명 한 줄. |
+| **코드 확인** | `packages/core/src/config/schema.ts`의 `editLinkSchema`, theme-docs에서 `editUrl` 생성 로직. |
+
+### Task 1.3 — 테마·커스터마이징 가이드
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `en/guides/theming.mdx` 신설(또는 configuration 하위 섹션 확장), `ko` 대응, `docs/barodoc.config.json`의 `navigation`에 페이지 추가 |
+| **작업** | `theme.colors.primary`, 다크/라이트(`ThemeToggle` 동작), 코드 블록 하이라이트(테마가 쓰는 방식). Full Custom에서 `@barodoc/theme-docs` 오버라이드·`--bd-*` 변수(`global.css`) 링크. |
+
+### Task 1.4 — 검색 옵션 비교
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `en/guides/search-options.mdx` 신설, `ko` 대응, 네비에 추가 |
+| **작업** | 기본 Pagefind vs `@barodoc/plugin-search` vs `@barodoc/plugin-docsearch`(있다면) 비교표: 설정 난이도, 비용, 백엔드 필요 여부, 언제 무엇을 쓸지. `docs/barodoc.config.json`의 `plugins` 예시와 링크. |
+
+### Task 1.5 — GitHub Pages “Quick 모드” 경로
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `deployment.mdx`에 **Quick mode** 절 추가 |
+| **작업** | `barodoc`만 있는 저장소: `pnpm install` 없이 `npx barodoc build` 또는 CI에서 `pnpm add barodoc` 후 `barodoc build .` 예시. `base`와 `permissions`/Pages 설정 다시 강조. (Phase 2에서 워크플로 템플릿이 생기면 “자동 생성” 링크로 연결.) |
+
+### Task 1.6 — a11y·SEO 체크리스트
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `en/guides/accessibility-seo.mdx` 신설, `ko` 대응 |
+| **작업** | 제목 계층(H1 한 개), 키보드 포커스·skip link(테마에 있는지 확인 후 서술), i18n 시 `hreflang`/대체 URL, sitemap 플러그인, `@barodoc/plugin-og-image` 등 메타/OG. 선택: CI에 `pa11y` 등 한 줄 예시. |
+
+### Phase 1 완료 조건
+
+- 위 6개 영역이 docs에 반영됨.
+- `pnpm build`(docs 워크스페이스) 통과, 깨진 내부 링크 없음.
+
+---
+
+## Phase 2 — CLI·스캐폴딩
+
+**목표:** `barodoc check --production`, `barodoc create` 옵션으로 GitHub Pages 워크플로, 생성 템플릿에 권장 설정 주석/값.
+
+### Task 2.1 — `barodoc check --production`
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `packages/barodoc/src/commands/check.ts`, `packages/barodoc/src/cli.ts` |
+| **작업** | `--production` 플래그 추가. 검사 항목(설계안): `config.site` 설정 여부(프로덕션 URL), `public/favicon` 또는 config `favicon` 존재, **프로젝트 사이트로 배포할 때** `base` 미설정 경고(휴리스틱: `site`에 `github.io` 포함 시 등, 과하면 문서에 “수동 확인”만). 선택: sitemap 플러그인 권장 경고. |
+| **출력** | 실패/경고를 구분(`--strict`로 경고를 실패로 승격 가능 여부는 YAGNI 시 생략). |
+| **테스트** | `packages/barodoc`에 단위 테스트 또는 스냅샷(임시 디렉터리 + 최소 config). |
+
+### Task 2.2 — 배포 워크플로 템플릿 + `create` 옵션
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `packages/barodoc/src/commands/create.ts`, `cli.ts`, 템플릿 예: `packages/barodoc/templates/github-pages-deploy.yml` (또는 문자열 상수) |
+| **작업** | `barodoc create <name> --with-github-pages` (플래그명은 짧게 합의): `.github/workflows/deploy.yml` 생성. 내용: checkout, Node 20, **Quick 모드** 기준으로 `npm i -g pnpm` 또는 `pnpm add barodoc` + `barodoc build` 또는 문서에 맞는 한 가지 표준 경로. `permissions`/`deploy-pages`는 [DEVELOPMENT.md](../../DEVELOPMENT.md)의 docs 워크플로와 동일 패턴. **모노레포가 아닌** 단일 Barodoc 프로젝트 전제를 README 주석으로 명시. |
+| **검증** | 새로 만든 폴더에서 워크플로 YAML 문법 검증, 선택적으로 dry-run. |
+
+### Task 2.3 — `create` 기본 `barodoc.config.json` 보강
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `packages/barodoc/src/commands/create.ts` |
+| **작업** | 생성 JSON에 `editLink` / `lastUpdated` **주석은 JSON 불가** → 대신 생성 직후 `README.md` 또는 `docs/en/getting-started.md`에 “권장 설정” 단락 추가. 또는 `plugins` 배열에 `["@barodoc/plugin-sitemap"]` 등 **선택적** 기본값(의존성 없이 동작하는 것만). |
+| **주의** | Quick 모드에서 플러그인 패키지가 없으면 깨지지 않게: 주석 전용 문서 파일이 안전. |
+
+### Task 2.4 — 문서 상호 참조
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | Phase 1 `deployment.mdx` |
+| **작업** | `barodoc create --with-github-pages` 안내 추가. |
+
+### Phase 2 완료 조건
+
+- `barodoc check --production`이 설계된 규칙으로 동작.
+- `create --with-github-pages`로 워크플로 생성 가능.
+- Phase 1 배포 문서와 모순 없음.
+
+---
+
+## Phase 3 — 테마·콘텐츠
+
+**목표:** 읽기 시간·ToC·콜아웃·컴포넌트 갤러리·버저닝 문서. (코드는 “갭만 보강”.)
+
+### Task 3.1 — 읽기 시간
+
+| 필드 | 내용 |
+|------|------|
+| **현황** | `section/[...slug].astro`, `blog/[...slug].astro`에 `reading-time` 사용 중. |
+| **작업** | 문서 라우트 전수 조사: 읽기 시간이 없는 Docs 레이아웃 경로가 있으면 `DocsLayout`에 `readingTime` props 추가. 선택: frontmatter `readingTime: false`로 숨김. |
+| **문서** | `configuration` 또는 `theming`에 “읽기 시간 표시” 한 절. |
+
+### Task 3.2 — ToC 현재 섹션
+
+| 필드 | 내용 |
+|------|------|
+| **현황** | `TableOfContents.astro`에 IntersectionObserver 기반 `.active` 이미 존재. |
+| **작업** | 엣지 케이스(짧은 문서, 첫 헤딩) QA. 필요 시 `rootMargin`/`threshold` 조정. 문서에 “On this page 동작” 설명. |
+
+### Task 3.3 — 콜아웃 표준화
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `en/guides/callouts.mdx`(또는 components 문서 확장), `ko` |
+| **작업** | `Callout` / `DocCallout` 지원 타입(note, warning, tip, danger 등) 목록과 MDX 예제. 디자인 토큰과 일치하는 이름 사용. |
+
+### Task 3.4 — 콘텐츠 컴포넌트 갤러리
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `docs/src/content/docs/en/components-gallery.mdx`(또는 기존 `components-test.mdx` 정리·이름 변경) |
+| **작업** | Callout, Card, Steps, Tabs, Code/CodeGroup, API 블록 등 **한 페이지에** 예제 + 짧은 “언제 쓰나”. `barodoc.config.json` `navigation`에 추가. `ko` 번역 페이지. |
+
+### Task 3.5 — 버저닝 Quick 모드 문서
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `en/guides/versioning.mdx` 신설, `ko` |
+| **작업** | `config.versions` + `VersionSwitcher` 설정 예시, 폴더 구조(`docs/v1/`, `docs/v2/` 등 실제 코드와 일치하도록 core/theme-docs 확인). |
+
+### Phase 3 완료 조건
+
+- 읽기 시간·ToC·콜아웃·갤러리·버저닝이 문서 또는 코드로 요구사항 충족.
+- 공식 docs 사이트에서 갤러리 페이지 렌더 확인.
+
+---
+
+## Phase 4 — 플러그인·확장
+
+**목표:** 문서·가벼운 코드로 “정리됨” 상태. 큰 신규 플러그인은 범위를 쪼갠다.
+
+### Task 4.1 — OpenAPI / API 레퍼런스
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `packages/plugin-openapi/README.md`, `docs` 가이드 절(예: `guides/openapi.mdx`) |
+| **작업** | 옵션, `barodoc.config.json` 예시, 한계(버전 드롭다운, try-it 유무). 갭 목록을 README “Roadmap”에 bullet. |
+
+### Task 4.2 — 피드백 웹훅
+
+| 필드 | 내용 |
+|------|------|
+| **작업** | **최소:** 설계 이슈 또는 `docs/plans/`에 스펙만. **구현 시:** `packages/plugin-feedback`(신규) 또는 theme-docs 슬롯 + `fetch` POST. Phase 4에서 “문서 + 스켈레톤 플러그인”까지면 설계 충족으로 볼 수 있음. |
+
+### Task 4.3 — Suggest edit
+
+| 필드 | 내용 |
+|------|------|
+| **작업** | Task 1.2와 연계해 `editLink`가 곧 Suggest edit URL임을 명시. GitLab `/-/edit/` 패턴이 필요하면 schema/문서에 예시 추가. |
+
+### Task 4.4 — llms.txt / MCP
+
+| 필드 | 내용 |
+|------|------|
+| **파일** | `packages/plugin-llms-txt/README.md` 또는 docs 가이드 |
+| **작업** | 생성 경로, `robots.txt`와 관계, MCP 연동이 있다면 링크·한 줄 설명. |
+
+### Phase 4 완료 조건
+
+- OpenAPI·llms.txt는 README/가이드로 재현 가능.
+- 피드백은 문서화 또는 스켈레톤 패키지 + changeset 정책 합의.
+
+---
+
+## 권장 일정(병렬 가능 단위)
+
+| 주차(가이드) | 집중 |
+|--------------|------|
+| 1 | Phase 1 전부 (문서 위주, 병렬: en/ko) |
+| 2 | Phase 2.1–2.2 (CLI 핵심) + 2.3–2.4 |
+| 3 | Phase 3 (테마 갭 + 갤러리 + 가이드) |
+| 4 | Phase 4 (문서 우선, 피드백 플러그인은 범위에 따라 분리) |
+
+---
+
+## 한 줄 요약
+
+1. **문서 6축**으로 배포·설정·SEO·검색·테마를 채운 뒤,  
+2. **`check --production` + `create --with-github-pages`**로 CLI 가치를 올리고,  
+3. **테마·갤러리·버저닝 문서**로 읽기 경험을 설명하고,  
+4. **플러그인 README/가이드**로 확장 지점을 고정한다.
+
+*구현 중 설계와 충돌하면 본 문서와 `2026-03-19-four-tier-roadmap-design.md`를 먼저 갱신한 뒤 코드를 맞춘다.*

--- a/docs/plans/2026-03-19-four-tier-roadmap-design.md
+++ b/docs/plans/2026-03-19-four-tier-roadmap-design.md
@@ -1,0 +1,92 @@
+# Barodoc 4단계 로드맵 설계
+
+**일자:** 2026-03-19  
+**근거:** [2026-03-19-competitive-feature-research.md](./2026-03-19-competitive-feature-research.md) §3 우선순위 제안
+
+순서: **1 → 2 → 3 → 4** (순차).
+
+---
+
+## 1. 범위와 결과물
+
+| 단계 | 이름 | 범위(요지) | 완료 시 결과 |
+|------|------|------------|--------------|
+| **1** | 문서·설정 | base path, Edit/Last updated, 테마 가이드, 검색 옵션 비교, GitHub Pages 배포 경로, a11y·SEO 체크리스트 | 사용자가 설정·배포·접근성·SEO를 문서만 보고 따라 할 수 있음 |
+| **2** | CLI·스캐폴딩 | `barodoc check --production`, `barodoc deploy` 또는 워크플로 생성, `barodoc create`에 배포 워크플로·권장 설정 | 새 프로젝트 생성 시 배포 가능한 상태까지 한 번에; 배포 전 프로덕션 체크 가능 |
+| **3** | 테마·콘텐츠 | 읽기 시간, ToC 현재 섹션, 콜아웃 표준화, 콘텐츠 컴포넌트 갤러리, 버저닝 Quick 모드 문서 | 문서 사이트가 읽기·네비·컴포넌트·버전 전환까지 한 번에 이해 가능 |
+| **4** | 플러그인·확장 | OpenAPI → API 레퍼런스(정리/확장), 피드백 웹훅, Suggest edit, llms.txt/MCP 강화 | API 문서·피드백·편집 제안·AI 발견이 플러그인/가이드로 정리됨 |
+
+---
+
+## 2. 의존 관계와 순서
+
+- **1 → 2 → 3 → 4** 고정.
+- 2는 1 문서를 참조; 3·4는 2와 무관. 구현은 단계 완료 후 다음 단계 진행.
+
+---
+
+## 3. 1단계 — 문서·설정 (상세)
+
+| 항목 | 위치·형식 | 내용 요지 |
+|------|-----------|-----------|
+| base path | 배포 가이드 또는 Configuration | `base` 설정, GitHub Pages 프로젝트 사이트 예시, create 템플릿 주석 |
+| Edit / Last updated | Configuration 또는 Guides | `editLink`, `lastUpdated`, GitHub 브랜치/경로 템플릿, 테마 노출 위치 |
+| 테마·커스터마이징 | 새 가이드 또는 Configuration 하위 | 토큰, 다크/라이트, 코드 블록 테마, Full Custom 오버라이드 |
+| 검색 옵션 비교 | 가이드 한 페이지 | Pagefind vs DocSearch 등, 언제 어떤 걸 쓸지 |
+| GitHub Pages 배포 경로 | 배포 가이드 "GitHub Pages" 절 | 저장소 → create → 워크플로 → Pages; 2단계에서 워크플로 자동 추가 시 보강 |
+| a11y·SEO 체크리스트 | 가이드 한 페이지 또는 배포/체크리스트 | 제목 계층, 포커스·skip link, hreflang, sitemap, meta/OG, 선택적 CI a11y |
+
+**성공 기준:** 위 항목이 docs에 반영되어, 새 사용자가 문서만 보고 설정·배포·접근성·SEO를 따라 할 수 있음.
+
+---
+
+## 4. 2단계 — CLI·스캐폴딩 (상세)
+
+| 항목 | 내용 요지 |
+|------|-----------|
+| `barodoc check --production` | `site`, favicon, subpath 시 `base` 등 점검; 실패 시 경고/에러 안내 |
+| 배포 워크플로 스캐폴딩 | `barodoc create` 시 옵션으로 `.github/workflows/deploy.yml` 생성 (Node, build, deploy-pages) |
+| `barodoc deploy` | 1차는 워크플로만; 원커맨드 deploy는 설계에 "향후"로 명시 |
+| `barodoc create` 권장 설정 | editLink/lastUpdated·검색·sitemap 권장 주석 또는 기본값 |
+
+**성공 기준:** create로 (옵션) 배포 워크플로 포함, `check --production`으로 배포 전 점검 가능.
+
+---
+
+## 5. 3단계 — 테마·콘텐츠 (상세)
+
+| 항목 | 내용 요지 |
+|------|-----------|
+| 읽기 시간 | 단어 수 계산, "X min read" 노출 (frontmatter 또는 레이아웃) |
+| ToC 현재 섹션 | 스크롤에 따라 현재 H2/H3 하이라이트 (스크롤 스파이) |
+| 콜아웃 표준화 | note/warning/tip/danger 통일, 사용법 문서 |
+| 콘텐츠 컴포넌트 갤러리 | docs 전용 페이지: Callout, Card, Steps, Tabs, Code, API 블록 등 예제 |
+| 버저닝 Quick 모드 문서 | config 버전/VersionSwitcher, Quick 모드 폴더 구조 예시 |
+
+**성공 기준:** 읽기 시간·ToC 하이라이트·갤러리·버저닝 문서 반영.
+
+---
+
+## 6. 4단계 — 플러그인·확장 (상세)
+
+| 항목 | 내용 요지 |
+|------|-----------|
+| OpenAPI → API 레퍼런스 | plugin-openapi 현황·갭 정리, 필요 시 확장 |
+| 피드백 웹훅 | "Was this helpful?" → 웹훅/analytics (플러그인 또는 테마 슬롯) |
+| Suggest edit | Edit 링크를 GitHub/GitLab 편집 URL로, 설정 문서화 |
+| llms.txt / MCP | plugin-llms-txt·MCP 가이드 강화 |
+
+**성공 기준:** API 문서·피드백·편집 제안·AI 발견이 플러그인/가이드로 정리됨.
+
+---
+
+## 7. 단계별 성공 기준 요약
+
+| 단계 | 완료 조건 |
+|------|-----------|
+| 1 | 6개 문서·설정 항목이 docs에 반영됨 |
+| 2 | check --production 동작, create 시 (옵션) 배포 워크플로 생성 가능 |
+| 3 | 읽기 시간·ToC 하이라이트·갤러리·버저닝 문서 반영됨 |
+| 4 | OpenAPI·피드백·Suggest edit·llms.txt 설계 범위 문서/플러그인 정리됨 |
+
+릴리즈는 1→2→3→4 순서로, 단계마다 patch/minor로 진행.

--- a/docs/src/content/changelog/v10.0.5.mdx
+++ b/docs/src/content/changelog/v10.0.5.mdx
@@ -1,0 +1,24 @@
+---
+version: "10.0.5"
+date: 2026-03-19
+title: "CLI, theme, and plugin docs update"
+---
+
+### CLI (barodoc)
+
+- **`barodoc check --production`** — New flag to check production readiness: warns when `site` is missing, when deploying to GitHub Pages project site without `base`, and when favicon is missing.
+- **`barodoc create --with-github-pages`** — Creates `.github/workflows/deploy.yml` for Quick mode (Node 20, `pnpm add barodoc`, `barodoc build . -o dist`, deploy-pages). New projects also get a README with recommended config (site, base, editLink, lastUpdated, plugins).
+
+### Theme (@barodoc/theme-docs)
+
+- **Reading time** — Frontmatter `readingTime: false` hides the reading time block on that page.
+- **Full-width asset layout** — PDF, CSV, HTML, pptx, ipynb, rst, epub, and other asset viewers now use the full content area next to the sidebar instead of the 768px column. `DocsLayout` accepts an optional `fullWidth` prop.
+
+### Plugins
+
+- **@barodoc/plugin-openapi** — README added. Docs: Limitations (version dropdown, playground CORS) and Roadmap.
+- **@barodoc/plugin-llms-txt** — README added. Docs: output path (site root), robots.txt, MCP/AI tools usage.
+
+### Docs site
+
+- New guides: callouts, versioning, component gallery; configuration: Reading time, On this page (ToC), editLink = Suggest edit; deployment: `create --with-github-pages`; OpenAPI/llms-txt limitations and roadmap; feedback webhook spec in `docs/plans/`.

--- a/docs/src/content/docs/en/components/gallery.mdx
+++ b/docs/src/content/docs/en/components/gallery.mdx
@@ -1,0 +1,99 @@
+---
+title: Component gallery
+description: Overview of Barodoc content components with when to use each
+tags: [components, callout, card, steps, tabs, code, api]
+related: [components/callout, components/card, components/steps, components/tabs, components/code-group, components/api-reference]
+difficulty: beginner
+---
+import { Callout, Card, CardGroup, Steps, Step, Tabs } from "@barodoc/theme-docs";
+import CodeGroup from "@barodoc/theme-docs/components/mdx/CodeGroup.astro";
+import CodeItem from "@barodoc/theme-docs/components/mdx/CodeItem.astro";
+import { ApiEndpoint, ApiParams, ApiParam, ApiResponse } from "@barodoc/theme-docs";
+
+This page shows the main content components in one place. Use it to choose the right component and then open the linked page for full props and examples.
+
+## Callout
+
+**When to use:** Notes, tips, warnings, and danger blocks in prose.
+
+<Callout type="tip" title="Tip">
+  Prefer a single accent color and use callouts to draw attention where needed.
+</Callout>
+
+→ [Callout](/docs/components/callout)
+
+## Card & CardGroup
+
+**When to use:** Feature highlights, next-step links, or a grid of related pages.
+
+<CardGroup cols={2}>
+  <Card title="Installation" icon="📦" href="/docs/guides/installation">
+    Set up Barodoc in your project.
+  </Card>
+  <Card title="Configuration" icon="⚙️" href="/docs/guides/configuration">
+    Configure name, theme, and navigation.
+  </Card>
+</CardGroup>
+
+→ [Card](/docs/components/card)
+
+## Steps
+
+**When to use:** Numbered how-to guides (install, configure, run).
+
+<Steps client:load>
+  <Step title="First step">Do this first.</Step>
+  <Step title="Second step">Then do this.</Step>
+  <Step title="Third step">Finally, verify.</Step>
+</Steps>
+
+→ [Steps](/docs/components/steps)
+
+## Tabs
+
+**When to use:** Switching between package managers, languages, or code variants.
+
+<Tabs client:load items={[
+  { label: "npm", value: "npm", children: "npm install barodoc" },
+  { label: "pnpm", value: "pnpm", children: "pnpm add barodoc" },
+  { label: "yarn", value: "yarn", children: "yarn add barodoc" }
+]} />
+
+→ [Tabs](/docs/components/tabs)
+
+## Code group
+
+**When to use:** Multiple code samples (e.g. same example in JS, Python, Go).
+
+<CodeGroup>
+  <CodeItem title="JavaScript">
+
+```javascript
+console.log("Hello");
+```
+
+  </CodeItem>
+  <CodeItem title="Python">
+
+```python
+print("Hello")
+```
+
+  </CodeItem>
+</CodeGroup>
+
+→ [Code Group](/docs/components/code-group)
+
+## API reference
+
+**When to use:** Documenting REST endpoints (method, path, params, responses).
+
+<ApiEndpoint method="GET" path="/api/health" description="Health check.">
+  <ApiResponse status={200} description="OK">
+    <ApiParams title="Body">
+      <ApiParam name="status" type="string" description="ok" />
+    </ApiParams>
+  </ApiResponse>
+</ApiEndpoint>
+
+→ [API Reference](/docs/components/api-reference)

--- a/docs/src/content/docs/en/guides/accessibility-seo.mdx
+++ b/docs/src/content/docs/en/guides/accessibility-seo.mdx
@@ -1,0 +1,66 @@
+---
+title: Accessibility and SEO
+description: Checklist for accessible and search-engine-friendly Barodoc sites
+tags: [accessibility, a11y, seo]
+related: [guides/configuration, guides/deployment]
+difficulty: intermediate
+---
+
+A few checks help keep your Barodoc site accessible and easy to find in search results.
+
+## Accessibility (a11y)
+
+### Heading hierarchy
+
+- Use **one H1 per page** (usually the page title). The theme uses the first heading or frontmatter `title` as the document title.
+- Use H2 → H3 in order; don’t skip levels (e.g. H2 then H4).
+
+### Focus and keyboard
+
+- Interactive elements (links, buttons, search, theme toggle) are focusable. The theme uses visible focus styles where applicable.
+- If you add custom interactive components, ensure they are keyboard accessible and not trap focus.
+
+### Skip link
+
+- The theme may include a “Skip to content” or similar link for keyboard users; if not, consider adding one in a custom layout for long pages.
+
+### Color contrast
+
+- The default palette meets contrast guidelines for body text and links. If you override `theme.colors`, test contrast (e.g. with browser DevTools or a contrast checker).
+
+### Screen readers
+
+- Landmarks (header, main, nav, footer) and heading structure make the page navigable. Images should have `alt` text in Markdown or MDX.
+
+## SEO
+
+### site and base
+
+- Set **`site`** in `barodoc.config.json` to your production URL (e.g. `https://docs.example.com`). Used for canonical URLs and OG tags.
+- For **project sites** (e.g. `username.github.io/repo-name/`), set **`base`** to `/repo-name/` so assets and routes resolve correctly. See [Deployment — Base path](/docs/guides/deployment#base-path-project-sites).
+
+### Meta and Open Graph
+
+- Each page uses `title` and `description` (from frontmatter or first heading/paragraph). For rich previews (social, search), use **@barodoc/plugin-og-image** or ensure your layout outputs `<meta property="og:title">`, `og:description`, and `og:image` where needed.
+- The theme can emit basic meta tags; check the layout or plugin docs.
+
+### Sitemap
+
+- Use **@barodoc/plugin-sitemap** so search engines can discover all pages. Add it to `plugins` in config.
+
+### i18n and hreflang
+
+- If you use multiple locales, the theme may output `hreflang` links for alternate language versions. Verify in the built HTML that each locale has the correct `hreflang` and canonical URL.
+
+### Content
+
+- Clear **title** and **description** per page improve snippets in search results. Avoid empty or duplicate descriptions.
+
+## Optional: CI checks
+
+You can add a lightweight a11y check in CI (e.g. on the built `dist/`):
+
+- **pa11y** or **axe-core** (e.g. `npx pa11y-ci dist/index.html`) to catch obvious violations.
+- Run only on a few key URLs to keep CI fast.
+
+This is optional; the checklist above already improves accessibility and SEO for most sites.

--- a/docs/src/content/docs/en/guides/callouts.mdx
+++ b/docs/src/content/docs/en/guides/callouts.mdx
@@ -1,0 +1,59 @@
+---
+title: Callouts
+description: Use callouts to highlight notes, tips, warnings, and danger in your docs
+tags: [components, callout, mdx]
+related: [components/callout, guides/theming]
+difficulty: beginner
+---
+import { Callout } from "@barodoc/theme-docs";
+
+Callouts draw attention to important information. The theme provides five types that match common documentation patterns.
+
+## Supported types
+
+| Type     | Use for |
+|----------|--------|
+| `info`   | General information, neutral notes |
+| `note`   | Supplementary or reference information (gray) |
+| `tip`    | Helpful tips, best practices |
+| `warning`| Important notices, caveats |
+| `danger` | Critical warnings, breaking changes |
+
+## Examples
+
+<Callout type="info">
+  **Info** — Use for general information that isn’t a tip or warning.
+</Callout>
+
+<Callout type="note">
+  **Note** — Use for extra context or references (e.g. “See also …”).
+</Callout>
+
+<Callout type="tip">
+  **Tip** — Use for shortcuts, recommendations, or “pro” advice.
+</Callout>
+
+<Callout type="warning">
+  **Warning** — Use for deprecations, limitations, or things that can go wrong.
+</Callout>
+
+<Callout type="danger">
+  **Danger** — Use for security, data loss, or breaking changes.
+</Callout>
+
+## In MDX
+
+Import from `@barodoc/theme-docs` (full custom) or use the component name your setup exposes:
+
+```mdx
+import { Callout } from "@barodoc/theme-docs";
+
+<Callout type="tip" title="Quick tip">
+  Prefer `base` and `site` in config when deploying to a subpath.
+</Callout>
+```
+
+- **type** — `info` | `note` | `warning` | `tip` | `danger` (default: `info`).
+- **title** — Optional; overrides the default label (e.g. "Info", "Warning").
+
+For more examples and API details, see [Callout](/docs/components/callout).

--- a/docs/src/content/docs/en/guides/search-options.mdx
+++ b/docs/src/content/docs/en/guides/search-options.mdx
@@ -1,0 +1,51 @@
+---
+title: Search options
+description: Compare Pagefind, DocSearch, and when to use each
+tags: [search, pagefind, docsearch]
+related: [guides/configuration, guides/plugins/search, guides/plugins/docsearch]
+difficulty: beginner
+---
+
+Barodoc supports two main search options: **Pagefind** (built-in, client-side) and **Algolia DocSearch** (hosted, optional). Choose based on site size, hosting, and whether you want a backend.
+
+## Comparison
+
+| | **@barodoc/plugin-search** (Pagefind) | **@barodoc/plugin-docsearch** (Algolia) |
+|--|--------------------------------------|----------------------------------------|
+| **Backend** | None. Index is built at build time and served as static files. | Algolia hosts the index; search requests go to Algolia. |
+| **Setup** | Add plugin to `plugins`; index runs after build (`pagefind --site dist`). | Requires Algolia DocSearch application (free for public docs); add plugin with app id and API key. |
+| **Cost** | Free. | Free for public, open-source docs via [DocSearch program](https://docsearch.algolia.com/); paid for private or high volume. |
+| **Best for** | Small–medium docs, static-only hosting, no API keys. | Large docs, instant typo-tolerant search, need for analytics or hosted index. |
+| **Index** | Generated into `dist/pagefind/` (or configured path). | Crawled by Algolia; no local index. |
+
+## Pagefind (default)
+
+When you use `@barodoc/plugin-search` (or the theme’s default search), Barodoc uses [Pagefind](https://pagefind.app/). The index is created during `barodoc build` and loaded in the browser; no server or API key is needed. Good for:
+
+- Quick mode and full custom projects.
+- GitHub Pages, Vercel, Netlify, or any static host.
+- Sites that stay under roughly a few hundred pages (Pagefind scales well but very large sites may prefer Algolia for speed).
+
+Add to `barodoc.config.json`:
+
+```json
+{
+  "plugins": ["@barodoc/plugin-search"]
+}
+```
+
+Search is enabled by default when the theme is used; the plugin ensures the index is built and the search UI is wired. See [Search plugin](/docs/guides/plugins/search) for options.
+
+## Algolia DocSearch
+
+Use **@barodoc/plugin-docsearch** when you want Algolia’s hosted search (faster typo tolerance, analytics, or crawling-based indexing). You need an Algolia DocSearch application; for open-source docs you can apply for the free program. See [DocSearch plugin](/docs/guides/plugins/docsearch) for setup (app id, API key, index name).
+
+- **When to choose:** Large doc sets, need for DocSearch branding/analytics, or preference for a hosted index.
+- **When to skip:** Prefer zero backend, no API keys, or minimal setup; then use Pagefind.
+
+## Summary
+
+- **Default / no backend:** Use `@barodoc/plugin-search` (Pagefind). No keys, no server.
+- **Hosted search / Algolia:** Use `@barodoc/plugin-docsearch` and configure Algolia.
+
+You can only use one search provider at a time; do not enable both plugins together.

--- a/docs/src/content/docs/en/guides/theming.mdx
+++ b/docs/src/content/docs/en/guides/theming.mdx
@@ -1,0 +1,123 @@
+---
+title: Theming and customization
+description: Customize colors, fonts, dark mode, and code blocks in Barodoc
+tags: [theme, customization, colors, dark-mode]
+related: [guides/configuration]
+difficulty: beginner
+---
+
+The default theme uses a primary (accent) palette and a neutral gray scale. You can override both via `barodoc.config.json` and, in full custom mode, with CSS variables.
+
+## Colors
+
+### Accent (primary)
+
+Set a single hex color; the theme generates a full OKLCH palette (50–950) for links, buttons, and active states:
+
+```json
+{
+  "theme": {
+    "colors": {
+      "accent": "#2563eb"
+    }
+  }
+}
+```
+
+In the docs config you may also see `primary`; it is an alias for `accent`.
+
+### Gray scale
+
+Use a preset or a custom hex for backgrounds, text, and borders:
+
+```json
+{
+  "theme": {
+    "colors": {
+      "gray": "zinc"
+    }
+  }
+}
+```
+
+**Presets:** `zinc`, `slate`, `neutral`, `stone`, `gray`. Default is `zinc`.
+
+### Light and dark
+
+The theme supports a light/dark toggle (user preference or system). You can set a different accent for dark mode:
+
+```json
+{
+  "theme": {
+    "colors": {
+      "accent": "#2563eb",
+      "dark": {
+        "accent": "#60a5fa"
+      }
+    }
+  }
+}
+```
+
+## Fonts
+
+Override heading, body, and code fonts:
+
+```json
+{
+  "theme": {
+    "fonts": {
+      "heading": "Inter, sans-serif",
+      "body": "Inter, sans-serif",
+      "code": "JetBrains Mono, monospace"
+    }
+  }
+}
+```
+
+Load the fonts in your layout or `public/` (e.g. link tag or `@font-face`).
+
+## Border radius
+
+Affects buttons, cards, and inputs:
+
+```json
+{
+  "theme": {
+    "radius": "0.5rem"
+  }
+}
+```
+
+Use any valid CSS value (e.g. `"8px"`, `"0.25rem"`).
+
+## Dark mode
+
+The header includes a theme toggle. The theme uses the `dark` class on the root; colors switch via semantic tokens (`--bd-bg`, `--bd-text`, etc.) that map to the gray scale and accent in both modes. No extra config is required beyond `theme.colors.dark` if you want a different accent in dark mode.
+
+## Code blocks
+
+Syntax highlighting uses the theme’s background and text tokens. Line numbers are controlled by the top-level `lineNumbers` option in `barodoc.config.json`. The code block style (e.g. border, padding) is defined in the theme’s global CSS; in full custom mode you can override it with `customCss` or by replacing the theme’s code block styles.
+
+## Full custom (Astro) overrides
+
+When you use Barodoc in full custom mode (your own Astro project with `@barodoc/theme-docs`), you can override the design tokens directly. The theme defines CSS variables in `global.css` (in `@barodoc/theme-docs`):
+
+- **Accent:** `--color-primary-50` … `--color-primary-950` (generated from `theme.colors.accent`).
+- **Gray:** `--bd-gray-50` … `--bd-gray-950`.
+- **Semantic:** `--bd-bg`, `--bd-text`, `--bd-border`, `--bd-sidebar-active-*`, etc.
+
+Add a custom CSS file via `customCss` in config, or import your own styles in the Astro layout, and override these variables. Example:
+
+```css
+:root {
+  --bd-bg: #fafafa;
+  --bd-text: #1a1a1a;
+}
+.dark {
+  --bd-bg: #0a0a0a;
+  --bd-text: #e5e5e5;
+}
+```
+
+This gives you full control over the look while keeping the same structure (sidebar, content, TOC).

--- a/docs/src/content/docs/en/guides/versioning.mdx
+++ b/docs/src/content/docs/en/guides/versioning.mdx
@@ -1,0 +1,74 @@
+---
+title: Doc versioning
+description: Serve multiple doc versions with the version switcher
+tags: [versioning, versions, configuration]
+related: [guides/configuration, guides/content-structure]
+difficulty: intermediate
+---
+
+When you maintain several doc versions (e.g. v1 and v2), you can show a **version switcher** in the sidebar and structure content so each version has its own URL segment.
+
+## Config
+
+In `barodoc.config.json` add `versions`: an array of `{ label, path }`. The switcher is hidden when there is only one version.
+
+```json
+{
+  "versions": [
+    { "label": "v2", "path": "v2" },
+    { "label": "v1", "path": "v1" }
+  ]
+}
+```
+
+- **label** — Text shown in the dropdown (e.g. `"v2"`, `"Current"`).
+- **path** — URL segment used for that version. Docs for this version are served under `/docs/{path}/...` (e.g. `/docs/v2/en/introduction`).
+
+## Folder structure
+
+Content must be organized so the first segment after the section (e.g. `docs`) is the version path.
+
+**Full custom (Astro)** — under your docs content collection (e.g. `src/content/docs/`):
+
+- `v1/en/introduction.md` → URL `/docs/v1/en/introduction` (or `/docs/v1/introduction` if default locale is omitted)
+- `v2/en/introduction.md` → URL `/docs/v2/en/introduction`
+
+So you get:
+
+```
+src/content/docs/
+├── v1/
+│   ├── en/
+│   │   ├── introduction.md
+│   │   └── guides/
+│   └── ko/
+└── v2/
+    ├── en/
+    └── ko/
+```
+
+**Quick mode** — under `docs/`:
+
+- `docs/v1/en/introduction.md`, `docs/v2/en/introduction.md`, etc.
+
+Navigation in `barodoc.config.json` uses slugs relative to each version. So for `v2` you still reference `introduction`, `guides/setup`; the theme and build resolve them under the versioned path. Ensure each version’s navigation points to slugs that exist under that version’s folder.
+
+## VersionSwitcher behavior
+
+The theme’s **VersionSwitcher** component (used in the sidebar when `config.versions` has more than one entry):
+
+1. Reads the current URL and finds which `versions[].path` matches (e.g. `/docs/v2/en/...` → `v2`).
+2. Renders a dropdown with all labels; the current version is highlighted.
+3. On select, navigates to the same relative path under the chosen version (e.g. from `/docs/v2/en/guides/setup` to `/docs/v1/en/guides/setup`).
+
+If the current path does not contain any version segment, the first item in `versions` is treated as current.
+
+## Summary
+
+| Step | Action |
+|------|--------|
+| 1 | Add `versions: [{ label, path }, ...]` to `barodoc.config.json`. |
+| 2 | Organize content so each version lives under `docs/{path}/...` (e.g. `v1/en/`, `v2/en/`). |
+| 3 | Keep navigation slugs consistent across versions so the switcher can map paths correctly. |
+
+For a single-version site, omit `versions`; the switcher will not appear.

--- a/docs/src/content/docs/ko/components/gallery.mdx
+++ b/docs/src/content/docs/ko/components/gallery.mdx
@@ -1,0 +1,100 @@
+---
+title: 컴포넌트 갤러리
+description: Barodoc 콘텐츠 컴포넌트 개요와 사용 시점
+tags: [components, callout, card, steps, tabs, code, api]
+related: [components/callout, components/card, components/steps, components/tabs, components/code-group, components/api-reference]
+difficulty: beginner
+---
+import { Callout, Card, CardGroup, Steps, Step } from "@barodoc/theme-docs";
+import CodeGroup from "@barodoc/theme-docs/components/mdx/CodeGroup.astro";
+import CodeItem from "@barodoc/theme-docs/components/mdx/CodeItem.astro";
+import { ApiEndpoint, ApiParams, ApiParam, ApiResponse } from "@barodoc/theme-docs";
+import { Tabs } from "@barodoc/theme-docs";
+
+한 페이지에서 주요 콘텐츠 컴포넌트를 모아 둡니다. 여기서 적절한 컴포넌트를 고른 뒤, 링크된 페이지에서 전체 props와 예제를 확인하세요.
+
+## Callout
+
+**사용 시점:** 본문 안의 참고, 팁, 경고, 위험 블록.
+
+<Callout type="tip" title="팁">
+  액센트 색은 하나로 통일하고, 필요한 곳만 콜아웃으로 강조하세요.
+</Callout>
+
+→ [Callout](/docs/components/callout)
+
+## Card & CardGroup
+
+**사용 시점:** 기능 하이라이트, 다음 단계 링크, 관련 페이지 그리드.
+
+<CardGroup cols={2}>
+  <Card title="설치" icon="📦" href="/docs/guides/installation">
+    프로젝트에 Barodoc 설치하기.
+  </Card>
+  <Card title="설정" icon="⚙️" href="/docs/guides/configuration">
+    이름, 테마, 네비게이션 설정.
+  </Card>
+</CardGroup>
+
+→ [Card](/docs/components/card)
+
+## Steps
+
+**사용 시점:** 번호가 붙은 how-to 가이드(설치 → 설정 → 실행).
+
+<Steps client:load>
+  <Step title="첫 단계">먼저 이것부터 하세요.</Step>
+  <Step title="두 번째 단계">그다음 이것을 하세요.</Step>
+  <Step title="세 번째 단계">마지막으로 확인하세요.</Step>
+</Steps>
+
+→ [Steps](/docs/components/steps)
+
+## Tabs
+
+**사용 시점:** 패키지 매니저, 언어, 코드 변형 전환.
+
+<Tabs client:load items={[
+  { label: "npm", value: "npm", children: "npm install barodoc" },
+  { label: "pnpm", value: "pnpm", children: "pnpm add barodoc" },
+  { label: "yarn", value: "yarn", children: "yarn add barodoc" }
+]} />
+
+→ [Tabs](/docs/components/tabs)
+
+## Code group
+
+**사용 시점:** 여러 코드 예제(같은 예제를 JS, Python, Go 등으로).
+
+<CodeGroup>
+  <CodeItem title="JavaScript">
+
+```javascript
+console.log("Hello");
+```
+
+  </CodeItem>
+  <CodeItem title="Python">
+
+```python
+print("Hello")
+```
+
+  </CodeItem>
+</CodeGroup>
+
+→ [Code Group](/docs/components/code-group)
+
+## API reference
+
+**사용 시점:** REST 엔드포인트 문서화(메서드, 경로, 파라미터, 응답).
+
+<ApiEndpoint method="GET" path="/api/health" description="헬스 체크.">
+  <ApiResponse status={200} description="OK">
+    <ApiParams title="Body">
+      <ApiParam name="status" type="string" description="ok" />
+    </ApiParams>
+  </ApiResponse>
+</ApiEndpoint>
+
+→ [API Reference](/docs/components/api-reference)

--- a/docs/src/content/docs/ko/guides/accessibility-seo.mdx
+++ b/docs/src/content/docs/ko/guides/accessibility-seo.mdx
@@ -1,0 +1,66 @@
+---
+title: 접근성과 SEO
+description: 접근 가능하고 검색에 유리한 Barodoc 사이트를 위한 체크리스트
+tags: [accessibility, a11y, seo]
+related: [guides/configuration, guides/deployment]
+difficulty: intermediate
+---
+
+몇 가지를 점검하면 Barodoc 사이트를 접근 가능하게 유지하고 검색 결과에 잘 노출할 수 있습니다.
+
+## 접근성 (a11y)
+
+### 제목 계층
+
+- 페이지당 **H1은 하나** (보통 페이지 제목). 테마는 첫 제목 또는 frontmatter `title`을 문서 제목으로 사용합니다.
+- H2 → H3 순서를 지키고, 단계를 건너뛰지 마세요 (예: H2 다음 H4).
+
+### 포커스와 키보드
+
+- 링크, 버튼, 검색, 테마 토글 등은 포커스 가능합니다. 테마는 해당 요소에 포커스 스타일을 둡니다.
+- 커스텀 인터랙티브 컴포넌트를 추가할 때는 키보드로 조작 가능하고 포커스가 갇히지 않도록 하세요.
+
+### 스킵 링크
+
+- 테마에 “본문으로 건너뛰기” 등 링크가 있을 수 있습니다. 없으면 긴 페이지용으로 커스텀 레이아웃에 추가를 고려하세요.
+
+### 색 대비
+
+- 기본 팔레트는 본문·링크에 대해 대비 가이드라인을 충족합니다. `theme.colors`를 덮어쓸 때는 대비를 확인하세요 (브라우저 DevTools 또는 대비 검사 도구).
+
+### 스크린 리더
+
+- 랜드마크(header, main, nav, footer)와 제목 구조로 페이지 탐색이 가능합니다. 이미지는 Markdown/MDX에서 `alt` 텍스트를 넣으세요.
+
+## SEO
+
+### site와 base
+
+- **`site`**를 `barodoc.config.json`에 프로덕션 URL(예: `https://docs.example.com`)로 설정하세요. canonical·OG 태그에 사용됩니다.
+- **프로젝트 사이트**(예: `username.github.io/repo-name/`)면 **`base`**를 `/repo-name/`로 두어 자산·라우트가 올바르게 해석되게 하세요. [배포 — Base path](/docs/guides/deployment#base-path-프로젝트-사이트) 참고.
+
+### 메타와 Open Graph
+
+- 각 페이지는 frontmatter 또는 첫 제목/단락의 `title`, `description`을 사용합니다. 소셜·검색 미리보기를 위해 **@barodoc/plugin-og-image**를 쓰거나, 레이아웃에서 `<meta property="og:title">`, `og:description`, `og:image`를 출력하세요.
+- 테마가 기본 메타 태그를 내보낼 수 있음; 레이아웃·플러그인 문서를 확인하세요.
+
+### Sitemap
+
+- **@barodoc/plugin-sitemap**을 사용해 검색 엔진이 모든 페이지를 발견할 수 있게 하세요. 설정의 `plugins`에 추가합니다.
+
+### i18n과 hreflang
+
+- 여러 로케일을 쓰면 테마가 대체 언어용 `hreflang` 링크를 출력할 수 있습니다. 빌드된 HTML에서 각 로케일의 `hreflang`와 canonical URL이 맞는지 확인하세요.
+
+### 콘텐츠
+
+- 페이지별 명확한 **title**과 **description**이 검색 스니펫에 유리합니다. 비어 있거나 중복된 설명은 피하세요.
+
+## 선택: CI 검사
+
+빌드 결과 `dist/`에 대해 CI에서 간단한 a11y 검사를 넣을 수 있습니다:
+
+- **pa11y** 또는 **axe-core** (예: `npx pa11y-ci dist/index.html`)로 눈에 띄는 위반을 찾습니다.
+- 주요 URL 몇 개만 검사해 CI 시간을 줄이세요.
+
+선택 사항이며, 위 체크리스트만으로도 대부분의 사이트에서 접근성과 SEO가 개선됩니다.

--- a/docs/src/content/docs/ko/guides/callouts.mdx
+++ b/docs/src/content/docs/ko/guides/callouts.mdx
@@ -1,0 +1,59 @@
+---
+title: 콜아웃
+description: 문서에서 참고, 팁, 경고, 위험을 강조하는 콜아웃 사용하기
+tags: [components, callout, mdx]
+related: [components/callout, guides/theming]
+difficulty: beginner
+---
+import { Callout } from "@barodoc/theme-docs";
+
+콜아웃은 중요한 내용을 강조할 때 씁니다. 테마에서 제공하는 다섯 가지 타입은 문서에서 자주 쓰는 패턴과 맞춰져 있습니다.
+
+## 지원 타입
+
+| 타입     | 용도 |
+|----------|------|
+| `info`   | 일반 정보, 중립적인 안내 |
+| `note`   | 보조·참고 정보(회색) |
+| `tip`    | 유용한 팁, 권장 사항 |
+| `warning`| 주의 사항, 제한 사항 |
+| `danger` | 중요 경고, 호환 깨짐 등 |
+
+## 예시
+
+<Callout type="info">
+  **Info** — 팁이나 경고가 아닌 일반 정보에 사용합니다.
+</Callout>
+
+<Callout type="note">
+  **Note** — 추가 맥락이나 참고(예: "참고: …")에 사용합니다.
+</Callout>
+
+<Callout type="tip">
+  **Tip** — 요령, 권장 사항, "프로" 팁에 사용합니다.
+</Callout>
+
+<Callout type="warning">
+  **Warning** — deprecated, 제한, 문제가 생길 수 있는 경우에 사용합니다.
+</Callout>
+
+<Callout type="danger">
+  **Danger** — 보안, 데이터 손실, 호환 깨짐 등에 사용합니다.
+</Callout>
+
+## MDX에서
+
+Full custom에서는 `@barodoc/theme-docs`에서 import하고, 사용 중인 설정에서 노출된 컴포넌트 이름을 사용하세요:
+
+```mdx
+import { Callout } from "@barodoc/theme-docs";
+
+<Callout type="tip" title="요약">
+  서브경로에 배포할 때는 config에 `base`와 `site`를 두는 것이 좋습니다.
+</Callout>
+```
+
+- **type** — `info` | `note` | `warning` | `tip` | `danger` (기본: `info`).
+- **title** — 선택; 기본 라벨(예: "Info", "Warning")을 덮어씁니다.
+
+더 많은 예시와 API는 [Callout](/docs/components/callout)을 참고하세요.

--- a/docs/src/content/docs/ko/guides/search-options.mdx
+++ b/docs/src/content/docs/ko/guides/search-options.mdx
@@ -1,0 +1,51 @@
+---
+title: 검색 옵션
+description: Pagefind와 DocSearch 비교 및 선택 가이드
+tags: [search, pagefind, docsearch]
+related: [guides/configuration, guides/plugins/search, guides/plugins/docsearch]
+difficulty: beginner
+---
+
+Barodoc은 **Pagefind**(내장, 클라이언트)와 **Algolia DocSearch**(호스팅, 선택) 두 가지 검색 방식을 지원합니다. 사이트 규모, 호스팅, 백엔드 필요 여부에 따라 선택하세요.
+
+## 비교
+
+| | **@barodoc/plugin-search** (Pagefind) | **@barodoc/plugin-docsearch** (Algolia) |
+|--|--------------------------------------|----------------------------------------|
+| **백엔드** | 없음. 빌드 시 인덱스 생성 후 정적 파일로 제공. | Algolia가 인덱스 호스팅; 검색 요청이 Algolia로 전달됨. |
+| **설정** | `plugins`에 플러그인 추가; 빌드 후 인덱스 생성(`pagefind --site dist`). | Algolia DocSearch 신청(공개 문서는 무료); 플러그인에 app id, API key 설정. |
+| **비용** | 무료. | 공개·오픈소스 문서는 [DocSearch 프로그램](https://docsearch.algolia.com/)으로 무료; 비공개·대량은 유료. |
+| **적합** | 소·중규모 문서, 정적 전용 호스팅, API 키 없음. | 대규모 문서, 즉시 오타 허용 검색, 분석·호스팅 인덱스 필요 시. |
+| **인덱스** | `dist/pagefind/`(또는 설정 경로)에 생성. | Algolia가 크롤링; 로컬 인덱스 없음. |
+
+## Pagefind (기본)
+
+`@barodoc/plugin-search`(또는 테마 기본 검색)를 쓰면 Barodoc은 [Pagefind](https://pagefind.app/)를 사용합니다. 인덱스는 `barodoc build` 시 생성되고 브라우저에서 로드되며, 서버나 API 키가 필요 없습니다. 다음에 적합합니다:
+
+- Quick 모드 및 Full custom 프로젝트.
+- GitHub Pages, Vercel, Netlify 등 정적 호스팅.
+- 수백 페이지 이하 규모(Pagefind도 확장 가능하나, 매우 큰 사이트는 Algolia가 더 빠를 수 있음).
+
+`barodoc.config.json`에 추가:
+
+```json
+{
+  "plugins": ["@barodoc/plugin-search"]
+}
+```
+
+테마를 쓰면 검색은 기본 활성화되며, 플러그인은 인덱스 빌드와 검색 UI 연결을 담당합니다. 옵션은 [Search 플러그인](/docs/guides/plugins/search)을 참고하세요.
+
+## Algolia DocSearch
+
+**@barodoc/plugin-docsearch**는 Algolia 호스팅 검색(오타 허용, 분석, 크롤링 기반 인덱스)이 필요할 때 사용합니다. Algolia DocSearch 애플리케이션이 필요하며, 오픈소스 문서는 무료 프로그램에 신청할 수 있습니다. 설정(app id, API key, index name)은 [DocSearch 플러그인](/docs/guides/plugins/docsearch)을 참고하세요.
+
+- **선택 시기:** 대규모 문서, DocSearch 브랜딩/분석, 호스팅 인덱스 선호.
+- **생략 시기:** 백엔드·API 키 없이 최소 설정을 원할 때는 Pagefind 사용.
+
+## 요약
+
+- **기본 / 백엔드 없음:** `@barodoc/plugin-search` (Pagefind). 키·서버 불필요.
+- **호스팅 검색 / Algolia:** `@barodoc/plugin-docsearch` 사용 후 Algolia 설정.
+
+검색 제공자는 하나만 사용할 수 있으며, 두 플러그인을 동시에 켜지 마세요.

--- a/docs/src/content/docs/ko/guides/theming.mdx
+++ b/docs/src/content/docs/ko/guides/theming.mdx
@@ -1,0 +1,123 @@
+---
+title: 테마와 커스터마이징
+description: Barodoc에서 색상, 폰트, 다크 모드, 코드 블록 커스터마이징하기
+tags: [theme, customization, colors, dark-mode]
+related: [guides/configuration]
+difficulty: beginner
+---
+
+기본 테마는 primary(강조) 팔레트와 중립 그레이 스케일을 사용합니다. `barodoc.config.json`으로 둘 다 덮어쓸 수 있고, Full custom 모드에서는 CSS 변수로도 조정할 수 있습니다.
+
+## 색상
+
+### Accent (primary)
+
+hex 색상 하나를 지정하면 테마가 링크, 버튼, 활성 상태용 OKLCH 팔레트(50–950)를 생성합니다:
+
+```json
+{
+  "theme": {
+    "colors": {
+      "accent": "#2563eb"
+    }
+  }
+}
+```
+
+문서 설정에서는 `primary`로 적혀 있을 수 있으며, `accent`와 동일합니다.
+
+### 그레이 스케일
+
+배경, 텍스트, 테두리용으로 프리셋 이름 또는 커스텀 hex를 씁니다:
+
+```json
+{
+  "theme": {
+    "colors": {
+      "gray": "zinc"
+    }
+  }
+}
+```
+
+**프리셋:** `zinc`, `slate`, `neutral`, `stone`, `gray`. 기본값은 `zinc`입니다.
+
+### 라이트 / 다크
+
+테마는 라이트/다크 토글이 있으며(사용자 설정 또는 시스템 설정). 다크 모드에서 다른 accent를 줄 수 있습니다:
+
+```json
+{
+  "theme": {
+    "colors": {
+      "accent": "#2563eb",
+      "dark": {
+        "accent": "#60a5fa"
+      }
+    }
+  }
+}
+```
+
+## 폰트
+
+제목, 본문, 코드 폰트를 덮어씁니다:
+
+```json
+{
+  "theme": {
+    "fonts": {
+      "heading": "Inter, sans-serif",
+      "body": "Inter, sans-serif",
+      "code": "JetBrains Mono, monospace"
+    }
+  }
+}
+```
+
+폰트는 레이아웃 또는 `public/`에서 로드(link 태그 또는 `@font-face`)하세요.
+
+## 테두리 반경
+
+버튼, 카드, 입력 필드에 적용됩니다:
+
+```json
+{
+  "theme": {
+    "radius": "0.5rem"
+  }
+}
+```
+
+유효한 CSS 값(예: `"8px"`, `"0.25rem"`)을 사용하세요.
+
+## 다크 모드
+
+헤더에 테마 토글이 있습니다. 테마는 루트에 `dark` 클래스를 두고, 시맨틱 토큰(`--bd-bg`, `--bd-text` 등)으로 색을 바꿉니다. 다크 모드에서 다른 accent만 쓰려면 `theme.colors.dark`만 설정하면 됩니다.
+
+## 코드 블록
+
+문법 강조는 테마의 배경·텍스트 토큰을 사용합니다. 줄 번호는 `barodoc.config.json` 최상위 `lineNumbers` 옵션으로 켜거나 끕니다. Full custom 모드에서는 `customCss` 또는 테마 코드 블록 스타일을 덮어써서 스타일을 바꿀 수 있습니다.
+
+## Full custom (Astro) 오버라이드
+
+Barodoc을 Full custom 모드(자체 Astro 프로젝트 + `@barodoc/theme-docs`)로 쓸 때는 디자인 토큰을 직접 덮어쓸 수 있습니다. 테마는 `@barodoc/theme-docs`의 `global.css`에 CSS 변수를 정의합니다:
+
+- **Accent:** `--color-primary-50` … `--color-primary-950` (`theme.colors.accent`에서 생성).
+- **Gray:** `--bd-gray-50` … `--bd-gray-950`.
+- **시맨틱:** `--bd-bg`, `--bd-text`, `--bd-border`, `--bd-sidebar-active-*` 등.
+
+설정의 `customCss`에 커스텀 CSS 파일을 추가하거나, Astro 레이아웃에서 자체 스타일을 import한 뒤 이 변수들을 오버라이드하세요. 예:
+
+```css
+:root {
+  --bd-bg: #fafafa;
+  --bd-text: #1a1a1a;
+}
+.dark {
+  --bd-bg: #0a0a0a;
+  --bd-text: #e5e5e5;
+}
+```
+
+구조(사이드바, 본문, TOC)는 그대로 두고 시각만 완전히 제어할 수 있습니다.

--- a/docs/src/content/docs/ko/guides/versioning.mdx
+++ b/docs/src/content/docs/ko/guides/versioning.mdx
@@ -1,0 +1,74 @@
+---
+title: 문서 버저닝
+description: 버전 스위처로 여러 문서 버전 제공하기
+tags: [versioning, versions, configuration]
+related: [guides/configuration, guides/content-structure]
+difficulty: intermediate
+---
+
+문서를 여러 버전(예: v1, v2)으로 유지할 때, 사이드바에 **버전 스위처**를 표시하고 콘텐츠를 버전별 URL 세그먼트로 구성할 수 있습니다.
+
+## 설정
+
+`barodoc.config.json`에 `versions`를 추가합니다. `{ label, path }` 배열이며, 버전이 하나뿐이면 스위처는 숨겨집니다.
+
+```json
+{
+  "versions": [
+    { "label": "v2", "path": "v2" },
+    { "label": "v1", "path": "v1" }
+  ]
+}
+```
+
+- **label** — 드롭다운에 표시되는 텍스트(예: `"v2"`, `"현재"`).
+- **path** — 해당 버전의 URL 세그먼트. 이 버전의 문서는 `/docs/{path}/...` 아래에 제공됩니다(예: `/docs/v2/en/introduction`).
+
+## 폴더 구조
+
+콘텐츠는 섹션(예: `docs`) 다음 첫 번째 세그먼트가 버전 경로가 되도록 구성합니다.
+
+**Full custom (Astro)** — docs 콘텐츠 컬렉션(예: `src/content/docs/`) 아래:
+
+- `v1/en/introduction.md` → URL `/docs/v1/en/introduction` (기본 로케일 생략 시 `/docs/v1/introduction`)
+- `v2/en/introduction.md` → URL `/docs/v2/en/introduction`
+
+구조 예:
+
+```
+src/content/docs/
+├── v1/
+│   ├── en/
+│   │   ├── introduction.md
+│   │   └── guides/
+│   └── ko/
+└── v2/
+    ├── en/
+    └── ko/
+```
+
+**Quick 모드** — `docs/` 아래:
+
+- `docs/v1/en/introduction.md`, `docs/v2/en/introduction.md` 등.
+
+`barodoc.config.json`의 navigation은 각 버전 기준 슬러그를 사용합니다. v2에서도 `introduction`, `guides/setup`처럼 참조하며, 테마와 빌드가 버전 경로 아래에서 해석합니다. 각 버전의 navigation이 해당 버전 폴더에 있는 슬러그를 가리키는지 확인하세요.
+
+## VersionSwitcher 동작
+
+테마의 **VersionSwitcher** 컴포넌트는 `config.versions`가 2개 이상일 때 사이드바에 사용됩니다.
+
+1. 현재 URL을 읽어 일치하는 `versions[].path`를 찾습니다(예: `/docs/v2/en/...` → `v2`).
+2. 모든 label로 드롭다운을 렌더링하고, 현재 버전을 강조합니다.
+3. 선택 시 같은 상대 경로로 해당 버전으로 이동합니다(예: `/docs/v2/en/guides/setup` → `/docs/v1/en/guides/setup`).
+
+현재 경로에 버전 세그먼트가 없으면 `versions`의 첫 항목이 현재로 간주됩니다.
+
+## 요약
+
+| 단계 | 작업 |
+|------|------|
+| 1 | `barodoc.config.json`에 `versions: [{ label, path }, ...]` 추가. |
+| 2 | 콘텐츠를 `docs/{path}/...`(예: `v1/en/`, `v2/en/`) 아래에 버전별로 구성. |
+| 3 | 스위처가 경로를 올바르게 매핑할 수 있도록 버전 간 navigation 슬러그를 맞춤. |
+
+단일 버전 사이트에서는 `versions`를 두지 않으면 스위처가 표시되지 않습니다.

--- a/packages/plugin-llms-txt/README.md
+++ b/packages/plugin-llms-txt/README.md
@@ -1,0 +1,42 @@
+# @barodoc/plugin-llms-txt
+
+Generate [llms.txt](https://llmstxt.org) and optional `llms-full.txt` at build time so AI assistants and LLMs can consume your documentation as plain text.
+
+## Install
+
+```bash
+pnpm add @barodoc/plugin-llms-txt
+```
+
+## Config
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-llms-txt", {
+      "description": "Documentation for My Project",
+      "full": true,
+      "links": [
+        { "title": "GitHub", "url": "https://github.com/user/repo" }
+      ]
+    }]
+  ]
+}
+```
+
+- **description** — Site description in the llms.txt header (default: config name).
+- **full** — Generate `llms-full.txt` with full page content (default: `true`).
+- **links** — Extra links to include (e.g. repo, API).
+
+## Output
+
+Files are written to the **build output root** (e.g. `dist/`), so after deploy you get:
+
+- `https://your-docs.com/llms.txt` — Summary (titles, descriptions, links).
+- `https://your-docs.com/llms-full.txt` — Full content (when `full: true`).
+
+The plugin does not change `robots.txt`. AI tools and MCP servers can fetch these URLs by convention.
+
+## Docs
+
+Full guide: [LLMs.txt Plugin](https://barodoc.dev/guides/plugins/llms-txt).

--- a/packages/plugin-openapi/README.md
+++ b/packages/plugin-openapi/README.md
@@ -1,0 +1,50 @@
+# @barodoc/plugin-openapi
+
+Generate API documentation pages from OpenAPI (Swagger) 3.x specs. Each endpoint gets parameter tables, response examples, cURL snippets, and an optional interactive playground.
+
+## Install
+
+```bash
+pnpm add @barodoc/plugin-openapi
+```
+
+## Config
+
+Add to `barodoc.config.json`:
+
+```json
+{
+  "plugins": [
+    ["@barodoc/plugin-openapi", {
+      "specFile": "openapi.yaml",
+      "basePath": "api",
+      "groupBy": "tags",
+      "baseUrl": "https://api.example.com",
+      "playground": true
+    }]
+  ]
+}
+```
+
+- **specFile** — Path to spec (YAML/JSON), or an array of `{ file, basePath?, baseUrl?, groupBy? }` for multiple APIs.
+- **basePath** — Output directory under docs (e.g. `api` → `/docs/api/...`).
+- **groupBy** — `"tags"` (one page per tag) or `"paths"` (all on one page).
+- **baseUrl** — Base URL for playground and cURL examples.
+- **playground** — Set to `false` for docs-only (no try-it UI).
+
+Add the generated slugs to `navigation` (e.g. `["api/users", "api/auth"]`).
+
+## Docs
+
+Full guide: [OpenAPI Plugin](https://barodoc.dev/guides/plugins/openapi) — multi-spec setup, options reference, and playground auth.
+
+## Limitations
+
+- No built-in **version dropdown** for multiple API versions (e.g. v1 vs v2); use separate specs and nav groups or doc versioning.
+- **Playground** is optional; when enabled it runs in the browser (CORS and auth are your responsibility).
+
+## Roadmap
+
+- Optional version switcher for multiple spec versions.
+- More auth schemes in the playground (OAuth2).
+- Export OpenAPI spec from playground requests for debugging.

--- a/packages/theme-docs/src/pages/section/[...slug].astro
+++ b/packages/theme-docs/src/pages/section/[...slug].astro
@@ -161,7 +161,10 @@ if (!isAsset) {
   const rendered = await render(doc);
   Content = rendered.Content;
   headings = rendered.headings;
-  readTime = readingTime(doc.body ?? "");
+  const frontmatter = doc.data as Record<string, unknown>;
+  if (frontmatter.readingTime !== false) {
+    readTime = readingTime(doc.body ?? "");
+  }
 }
 
 /** Flatten navigation entries to string slugs (handles nested { label, pages }). */
@@ -254,9 +257,10 @@ const assetUrl = isAsset
   editUrl={editUrl}
   lastUpdated={lastUpdated}
   breadcrumbs={breadcrumbs}
-  readingTime={readTime.text}
+  readingTime={readTime.text || undefined}
   filePath={isAsset ? undefined : `src/content/${sectionSlug}/${doc.id}`}
   sectionSlug={sectionSlug}
+  fullWidth={isAsset}
 >
   {isAsset ? (
     <div class="asset-viewer-wrapper">


### PR DESCRIPTION
Closes #144

## Summary
- **CLI:** `check --production`, `create --with-github-pages`, create template README
- **Theme:** `readingTime: false`, full-width layout for asset viewers (PDF, CSV, HTML, etc.)
- **Plugins:** OpenAPI / llms-txt README and docs (limitations, roadmap, output path, MCP)
- **Docs:** callouts, versioning, component gallery, a11y/SEO, search options, theming; configuration (Reading time, On this page, Suggest edit); deployment `create --with-github-pages`; feedback webhook spec

Includes changeset and `docs/src/content/changelog/v10.0.5.mdx`.

Made with [Cursor](https://cursor.com)