### PR TITLE
feat(theme-docs): SaaS landing blocks and YAML landingPage

### DIFF
--- a/.changeset/feat-saas-landing-blocks.md
+++ b/.changeset/feat-saas-landing-blocks.md
@@ -1,0 +1,5 @@
+---
+"@barodoc/theme-docs": patch
+---
+
+feat(theme-docs): declarative SaaS landing — `LandingLayout`, `pageLayout` + `landingPage` YAML, and landing blocks (`LandingHero`, `LandingLogoStrip`, `LandingStats`, `LandingFeatures`, `LandingTestimonials`, `LandingPricing`, `LandingFaq`, `LandingCta`, `LandingFooter`). Export `@barodoc/theme-docs/landing` types. Standalone `[...page]` supports full-width marketing layout.

--- a/.cursor/skills/barodoc-components/SKILL.md
+++ b/.cursor/skills/barodoc-components/SKILL.md
@@ -362,6 +362,24 @@ import { ApiEndpoint, ApiParams, ApiParam, ApiResponse } from "@barodoc/theme-do
   </ApiResponse>
 </ApiEndpoint>
 
+## Landing (marketing / SaaS-style)
+
+Use for standalone pages with `pageLayout: landing` (full-width; not `layout` — reserved in Astro 5). Import from `@barodoc/theme-docs`:
+
+- `LandingHero` — badge, title + optional gradient `titleHighlight`, CTAs, optional `snippet` (use **`client:load`** for copy button)
+- `LandingLogoStrip` — “trusted by” name row
+- `LandingStats` — metric cells (`value` + `label`)
+- `LandingFeatures` — section title + `items` (icon, title, description)
+- `LandingTestimonials` — quote cards
+- `LandingPricing` — tier cards + `highlighted`
+- `LandingFaq` — `<details>` Q&A
+- `LandingCta` — closing headline + button
+- `LandingFooter` — tagline, optional logo, links
+
+YAML order under `landingPage:`: hero → logoStrip → stats → features → testimonials → pricing → faq → cta → footer.
+
+See `docs/src/content/docs/en/guides/landing.mdx` in the Barodoc repo.
+
 ## Quick Start
 
 <Steps>

--- a/docs/barodoc.config.json
+++ b/docs/barodoc.config.json
@@ -17,6 +17,7 @@
   },
   "tabs": [
     { "label": "Docs", "href": "/docs/introduction" },
+    { "label": "Landing demo", "label:ko": "랜딩 데모", "href": "/yaml-landing-demo" },
     { "label": "Help", "href": "/help/faq" },
     { "label": "Blog", "href": "/blog" },
     { "label": "API Reference", "href": "/docs/api/pet" },
@@ -49,6 +50,7 @@
         "guides/content-structure",
         "guides/sections",
         "guides/standalone-pages",
+        "guides/landing",
         "guides/cli",
         "guides/overrides",
         "guides/deployment",

--- a/docs/src/content/changelog/v10.0.6.mdx
+++ b/docs/src/content/changelog/v10.0.6.mdx
@@ -1,0 +1,18 @@
+---
+version: "10.0.6"
+date: 2026-03-19
+title: "SaaS-style landing blocks and YAML-driven pages"
+---
+
+### Theme (@barodoc/theme-docs)
+
+- **Landing layout** — `LandingLayout` full-width shell (header, banner, no sidebar). Standalone `pages` entries use `pageLayout: landing` (use `pageLayout`, not `layout` — reserved in Astro 5 Markdown collections).
+- **Declarative `landingPage` YAML** — Optional blocks rendered in order: `hero` → `logoStrip` → `stats` → `features` → `testimonials` → `pricing` → `faq` → `cta` → `footer`.
+- **React blocks** — `LandingHero`, `LandingLogoStrip`, `LandingStats`, `LandingFeatures`, `LandingTestimonials`, `LandingPricing`, `LandingFaq`, `LandingCta`, `LandingFooter` (also importable from `@barodoc/theme-docs` for MDX).
+- **Types** — `export "@barodoc/theme-docs/landing"` for `LandingFrontmatter` and related types.
+- **Home** — Default `index.astro` composes shared landing components.
+
+### Docs site
+
+- Guides: [Landing pages (SaaS-style)](/docs/guides/landing) (EN), KO summary; standalone pages guide links to landing.
+- Demo: `/yaml-landing-demo` — full SaaS-style sample from YAML; header tab **Landing demo**.

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -50,11 +50,132 @@ const helpCollection = defineCollection({
   }),
 });
 
+/** Declarative landing blocks (VuePress-style); use with `pageLayout: landing`. Key is `landingPage`. */
+const landingPageFrontmatterSchema = z
+  .object({
+    hero: z
+      .object({
+        badge: z.string().optional(),
+        title: z.string(),
+        titleHighlight: z.string().optional(),
+        subtitle: z.string(),
+        primaryCta: z.object({ label: z.string(), href: z.string() }),
+        secondaryCta: z.object({ label: z.string(), href: z.string() }).optional(),
+        snippet: z.string().optional(),
+        snippetAriaLabel: z.string().optional(),
+      })
+      .optional(),
+    logoStrip: z
+      .object({
+        title: z.string().optional(),
+        items: z.array(
+          z.object({
+            name: z.string(),
+            href: z.string().optional(),
+          }),
+        ),
+      })
+      .optional(),
+    stats: z
+      .object({
+        title: z.string().optional(),
+        subtitle: z.string().optional(),
+        items: z.array(
+          z.object({
+            value: z.string(),
+            label: z.string(),
+          }),
+        ),
+      })
+      .optional(),
+    features: z
+      .object({
+        title: z.string(),
+        subtitle: z.string().optional(),
+        items: z.array(
+          z.object({
+            icon: z.string(),
+            title: z.string(),
+            description: z.string(),
+          }),
+        ),
+      })
+      .optional(),
+    testimonials: z
+      .object({
+        title: z.string(),
+        subtitle: z.string().optional(),
+        items: z.array(
+          z.object({
+            quote: z.string(),
+            author: z.string(),
+            role: z.string(),
+            avatar: z.string().optional(),
+          }),
+        ),
+      })
+      .optional(),
+    pricing: z
+      .object({
+        title: z.string(),
+        subtitle: z.string().optional(),
+        plans: z.array(
+          z.object({
+            name: z.string(),
+            price: z.string(),
+            period: z.string().optional(),
+            description: z.string().optional(),
+            features: z.array(z.string()),
+            ctaLabel: z.string(),
+            ctaHref: z.string(),
+            highlighted: z.boolean().optional(),
+          }),
+        ),
+      })
+      .optional(),
+    faq: z
+      .object({
+        title: z.string().optional(),
+        subtitle: z.string().optional(),
+        items: z.array(
+          z.object({
+            q: z.string(),
+            a: z.string(),
+          }),
+        ),
+      })
+      .optional(),
+    cta: z
+      .object({
+        title: z.string(),
+        subtitle: z.string().optional(),
+        buttonLabel: z.string(),
+        buttonHref: z.string(),
+      })
+      .optional(),
+    footer: z
+      .object({
+        tagline: z.string().optional(),
+        showLogo: z.boolean().optional(),
+        links: z.array(z.object({ label: z.string(), href: z.string() })).optional(),
+      })
+      .optional(),
+  })
+  .optional();
+
 const pagesCollection = defineCollection({
   type: "content",
   schema: z.object({
     title: z.string(),
     description: z.string().optional(),
+    /**
+     * `landing` = full-width marketing layout. Use **`pageLayout`** — Astro 5 reserves `layout` for Markdown in content collections.
+     * @deprecated `layout` — ignored for `.md` in Astro 5; use `pageLayout` instead.
+     */
+    pageLayout: z.enum(["default", "landing"]).optional(),
+    layout: z.enum(["default", "landing"]).optional(),
+    /** With `pageLayout: landing`, optional YAML blocks (see Guides → Landing pages). */
+    landingPage: landingPageFrontmatterSchema,
   }),
 });
 

--- a/docs/src/content/docs/en/guides/landing.mdx
+++ b/docs/src/content/docs/en/guides/landing.mdx
@@ -1,0 +1,156 @@
+---
+title: Landing pages (SaaS-style)
+description: Build marketing-style landing pages with built-in Barodoc components and a full-width layout
+tags: [pages, landing, marketing, layout]
+related: [guides/standalone-pages, guides/content-structure]
+difficulty: beginner
+---
+
+import { Callout, Steps, Step } from "@barodoc/theme-docs";
+
+Barodoc ships **reusable landing blocks** in `@barodoc/theme-docs` so you can compose SaaS-style pages (hero, feature grid, CTA, footer) without copying HTML from the default home page.
+
+## Full-width layout
+
+Standalone pages normally use a **narrow** reading column (`max-width` ~720px). For marketing landings, set **`pageLayout: landing`** in frontmatter so the page uses the theme’s **full-width** shell (header + banner, no sidebar). Use **`pageLayout`** (not `layout`) — Astro 5 reserves `layout` for Markdown in content collections.
+
+```yaml
+---
+title: Pricing
+description: Plans and pricing
+pageLayout: landing
+---
+```
+
+You can either **declare sections in YAML** (VuePress-style, under **`landingPage:`**) or **compose React components** in MDX — or combine both (YAML blocks first, then optional Markdown body).
+
+## Declarative landing (frontmatter)
+
+With **`pageLayout: landing`**, add a **`landingPage:`** object. The theme renders built-in sections **in order** for each block you define: **hero → logoStrip → stats → features → testimonials → pricing → faq → cta → footer**. No imports required.
+
+For **YAML-heavy** pages, prefer **`.md`** so you avoid MDX parsing quirks (unquoted URLs like `/docs/guides/landing` can confuse the MDX compiler). For **MDX**, quote paths in YAML (`href: "/docs/..."`) and use **`pageLayout: "landing"`** if the compiler mis-parses bare `landing`.
+
+```yaml
+---
+title: Pricing
+pageLayout: landing
+landingPage:
+  hero:
+    badge: New
+    title: Simple
+    titleHighlight: pricing
+    subtitle: One plan for teams who ship docs.
+    primaryCta: { label: Start, href: /docs/introduction }
+    secondaryCta: { label: Contact, href: mailto:sales@example.com }
+    snippet: "npx create-barodoc my-docs"
+  stats:
+    title: At a glance
+    items:
+      - { value: "99%", label: "Uptime story" }
+      - { value: "24/7", label: "Static edge" }
+  features:
+    title: Why us
+    items:
+      - icon: "⚡"
+        title: Fast
+        description: Static output.
+  cta:
+    title: Ready?
+    buttonLabel: Read the docs
+    buttonHref: /docs/introduction
+  footer:
+    tagline: Built with Acme
+    showLogo: true
+    links:
+      - { label: Privacy, href: /privacy }
+---
+```
+
+- **`footer.links`** — omit to default to **GitHub** (from `topbar.github`) + **Documentation** (`/docs/introduction`). Set `links: []` for no links.
+- **`footer.showLogo`** — defaults to showing the site logo when `logo` is set in `barodoc.config.json`.
+
+Optional Markdown **below** the frontmatter is rendered in a prose column under the blocks (omit the body for YAML-only pages).
+
+Live demo: [`/yaml-landing-demo`](/yaml-landing-demo) (`.md` + `pageLayout` + `landingPage` YAML).
+
+## Components (MDX)
+
+Import from the same entry as other MDX components:
+
+```tsx
+import {
+  LandingHero,
+  LandingLogoStrip,
+  LandingStats,
+  LandingFeatures,
+  LandingTestimonials,
+  LandingPricing,
+  LandingFaq,
+  LandingCta,
+  LandingFooter,
+} from "@barodoc/theme-docs";
+```
+
+| Component | Role |
+|-----------|------|
+| `LandingHero` | Badge, headline + gradient highlight, subtitle, primary/secondary CTAs, optional install **snippet** with copy |
+| `LandingLogoStrip` | “Trusted by” **logo / name row** (optional `href` per item) |
+| `LandingStats` | Optional title + **metrics row** (value + label cells) |
+| `LandingFeatures` | Section title + responsive **feature cards** (emoji icon, title, description) |
+| `LandingTestimonials` | Quote cards (author, role, optional avatar label) |
+| `LandingPricing` | **3-column pricing** (features list, `highlighted` tier) |
+| `LandingFaq` | **`<details>`** FAQ list (accessible, no extra JS) |
+| `LandingCta` | Closing headline, optional subtitle, single button |
+| `LandingFooter` | Tagline, optional logo, link row |
+
+`LandingHero` uses a copy-to-clipboard control for the snippet — add **`client:load`** when you use it in MDX:
+
+```tsx
+<LandingHero
+  client:load
+  badge="New"
+  title="Ship docs"
+  titleHighlight="faster"
+  subtitle="One stack for docs and marketing."
+  primaryCta={{ label: "Get started", href: "/docs/introduction" }}
+  secondaryCta={{ label: "Pricing", href: "/pricing" }}
+  snippet="npx create-barodoc my-docs"
+/>
+```
+
+```tsx
+<LandingFeatures
+  title="Why us"
+  subtitle="Short value prop."
+  items={[
+    {
+      icon: "⚡",
+      title: "Fast",
+      description: "Static output, great DX.",
+    },
+  ]}
+/>
+```
+
+<Callout type="info">
+  The default site **home** (`/`) is implemented with these same components — see the theme’s `index.astro` for a full example.
+</Callout>
+
+## Quick checklist
+
+<Steps>
+  <Step title="Create an MDX page under pages">
+    e.g. `src/content/pages/pricing.mdx` (full custom) or `pages/pricing.mdx` (quick mode).
+  </Step>
+  <Step title="Set pageLayout: landing">
+    So content is not constrained to the prose column (use `pageLayout`, not `layout`).
+  </Step>
+  <Step title="Add content">
+    Either fill a **`landingPage:`** YAML block (declarative), or import `LandingHero`, `LandingFeatures`, `LandingCta`, and `LandingFooter` from `@barodoc/theme-docs` in MDX — or use YAML plus a short Markdown section below.
+  </Step>
+  <Step title="Link from tabs or docs">
+    Add the URL to `tabs` in `barodoc.config.json` if it should appear in the top bar.
+  </Step>
+</Steps>
+
+See also [Standalone pages](/docs/guides/standalone-pages) for routing, reserved slugs, and tabs.

--- a/docs/src/content/docs/en/guides/standalone-pages.mdx
+++ b/docs/src/content/docs/en/guides/standalone-pages.mdx
@@ -90,6 +90,8 @@ Standalone pages use a simple single-column layout:
 - **No sidebar** — no navigation groups
 - **No table of contents** — clean reading experience
 
+For **marketing / SaaS-style** full-width pages (hero, feature grids, CTAs), use frontmatter **`pageLayout: landing`** and the built-in `Landing*` components — see [Landing pages (SaaS-style)](/docs/guides/landing).
+
 ## Adding to navigation
 
 Add standalone pages to `tabs` to make them accessible from the header:

--- a/docs/src/content/docs/ko/guides/landing.mdx
+++ b/docs/src/content/docs/ko/guides/landing.mdx
@@ -1,0 +1,42 @@
+---
+title: 랜딩 페이지 (SaaS 스타일)
+description: Barodoc에 내장된 컴포넌트와 풀폭 레이아웃으로 마케팅형 랜딩을 만듭니다
+tags: [pages, landing, marketing, layout]
+related: [guides/content-structure]
+difficulty: beginner
+---
+
+import { Callout } from "@barodoc/theme-docs";
+
+`@barodoc/theme-docs`에 **랜딩용 블록**이 포함되어 있어, 홈과 같은 SaaS 느낌의 히어로·기능 그리드·CTA·푸터를 재사용할 수 있습니다.
+
+## 풀폭 레이아웃
+
+일반 standalone 페이지는 좁은 읽기 폭(~720px)을 씁니다. 마케팅 랜딩은 frontmatter에 **`pageLayout: landing`**을 넣어 **풀폭** 셸을 씁니다. Astro 5에서는 `layout` 키가 예약되어 있어 **`pageLayout`**을 씁니다.
+
+YAML로 섹션만 채우려면 **`landingPage:`** 블록을 쓰세요. 렌더 순서는 **히어로 → 로고 스트립 → 스탯 → 기능 → 후기 → 요금제 → FAQ → CTA → 푸터**입니다. 실제 SaaS 수준 예시는 **`/yaml-landing-demo`** 와 영문 가이드를 보세요.
+
+```yaml
+---
+title: 요금제
+description: 플랜 및 가격
+pageLayout: landing
+---
+```
+
+## 컴포넌트
+
+```tsx
+import {
+  LandingHero,
+  LandingFeatures,
+  LandingCta,
+  LandingFooter,
+} from "@barodoc/theme-docs";
+```
+
+`LandingHero`의 설치 명령 복사 버튼을 쓰려면 MDX에서 **`client:load`**를 붙이세요.
+
+<Callout type="info">
+  영어 가이드에는 예시와 체크리스트가 더 자세히 있습니다: [Landing pages (SaaS-style)](/docs/guides/landing) (영문 페이지).
+</Callout>

--- a/docs/src/content/pages/yaml-landing-demo.md
+++ b/docs/src/content/pages/yaml-landing-demo.md
@@ -1,0 +1,151 @@
+---
+title: Barodoc Cloud
+description: Example SaaS-style landing — logos, metrics, features, testimonials, pricing, FAQ — all from YAML.
+pageLayout: landing
+landingPage:
+  hero:
+    badge: New · Declarative landing blocks
+    title: Ship docs your users
+    titleHighlight: actually open
+    subtitle: Barodoc turns Markdown and MDX into a fast documentation site with search, i18n, and a marketing surface — so product, design, and engineering tell one story without wiring a separate landing stack.
+    primaryCta:
+      label: Start for free
+      href: "/docs/introduction"
+    secondaryCta:
+      label: Talk to sales
+      href: "mailto:hello@example.com"
+    snippet: "npx create-barodoc my-product-docs"
+  logoStrip:
+    title: Trusted by teams who care about craft
+    items:
+      - name: Acme Platform
+      - name: Northwind Labs
+      - name: Contoso API
+      - name: Globex DX
+      - name: Umbrella Cloud
+      - name: Initech Docs
+  stats:
+    title: Proof in the numbers
+    subtitle: Illustrative metrics — swap for your own story, segment, or analyst quotes.
+    items:
+      - value: "4.9/5"
+        label: Average satisfaction from docs readers (survey)
+      - value: "62%"
+        label: Fewer repeated support tickets after launch (typical)
+      - value: "<250ms"
+        label: p95 time to interactive on static edge
+      - value: "40+"
+        label: Built-in MDX patterns and API reference helpers
+  features:
+    title: Platform teams run on Barodoc
+    subtitle: From first API guide to full product education — one codebase, one design system, one deploy.
+    items:
+      - icon: "🧭"
+        title: Opinionated IA
+        description: Sidebar, tabs, sections, and standalone pages so you can mirror how your product is sold — not how a wiki thinks.
+      - icon: "🧩"
+        title: MDX that scales
+        description: Callouts, steps, API tables, and embeds stay consistent across teams; extend with your own React islands when you need them.
+      - icon: "🌍"
+        title: i18n without a second CMS
+        description: Locale-aware navigation and labels so your landing and docs can ship together in every market you enter.
+      - icon: "🔎"
+        title: Search that feels instant
+        description: Static-friendly Pagefind output — great results on CDN hosting without running a search cluster.
+      - icon: "🔐"
+        title: SSO-ready story
+        description: Pair with your IdP at the edge or gate sensitive guides — the content layer stays portable Markdown.
+      - icon: "📈"
+        title: Instrument what matters
+        description: Drop in analytics plugins and measure which flows convert trials — same surface as your changelog and blog.
+  testimonials:
+    title: What teams say after launch
+    subtitle: Quotes are demo copy — replace with real customers when you ship.
+    items:
+      - quote: "We finally have a docs site that matches our product polish. Marketing owns the hero, eng owns the API reference — same repo."
+        author: Sarah Kim
+        role: VP Product, Acme Platform
+        avatar: "SK"
+      - quote: "Search and versioning cut our 'where is this documented?' pings by more than half in the first quarter."
+        author: Jordan Lee
+        role: Lead DevRel, Northwind Labs
+        avatar: "JL"
+      - quote: "The YAML landing blocks let us ship pricing and trust signals without asking frontend for a one-off page every sprint."
+        author: Morgan Patel
+        role: Director of DX, Contoso API
+        avatar: "MP"
+  pricing:
+    title: Plans that grow with your surface area
+    subtitle: Simple tiers for the demo — align names and limits with your packaging.
+    plans:
+      - name: Starter
+        price: "$0"
+        period: "/forever"
+        description: For open projects and early teams validating the stack.
+        features:
+          - Unlimited public docs pages
+          - Community support
+          - Static hosting anywhere
+          - MDX + core theme components
+        ctaLabel: Get started
+        ctaHref: "/docs/introduction"
+        highlighted: false
+      - name: Growth
+        price: "$49"
+        period: "/mo"
+        description: For product companies shipping weekly and iterating on docs-led growth.
+        features:
+          - Everything in Starter
+          - Private sections & SSO hooks
+          - Analytics plugins
+          - Priority email support
+          - Custom domain & SSL checklist
+        ctaLabel: Start trial
+        ctaHref: "/docs/guides/landing"
+        highlighted: true
+      - name: Enterprise
+        price: "Let’s talk"
+        period: ""
+        description: For regulated industries and multi-brand documentation programs.
+        features:
+          - SLA & onboarding workshop
+          - Audit-friendly export
+          - Custom theme review
+          - Success manager
+        ctaLabel: Contact sales
+        ctaHref: "mailto:hello@example.com"
+        highlighted: false
+  faq:
+    title: Questions teams ask before rollout
+    subtitle: Swap these with objections you hear in real sales calls.
+    items:
+      - q: Can we keep our existing Markdown and Git workflow?
+        a: Yes. Barodoc is built around content in Git — review in PRs, roll back like code, and publish static assets to any CDN you already use.
+      - q: How does this differ from a generic static site generator?
+        a: You get documentation primitives out of the box — nav models, search integration patterns, MDX components tuned for API and guide content — so you spend time on words, not plumbing.
+      - q: Do we need a separate marketing site?
+        a: No. Use the same theme for SaaS-style landing sections (hero, stats, pricing, FAQ) and deep docs — or split later without rewriting content.
+      - q: What about access control for internal guides?
+        a: Host behind your VPN or gate at the edge; the static output stays portable so you are not locked into a single vendor runtime.
+      - q: Can we customize the design?
+        a: Full custom mode gives you Astro-level control; quick mode keeps you in Markdown with optional barodoc.config.json for theme tokens and navigation.
+  cta:
+    title: Ready to make docs a growth lever?
+    subtitle: "Clone the demo, edit landingPage in YAML, and ship — or compose the same blocks in MDX for full control."
+    buttonLabel: Read the landing guide
+    buttonHref: "/docs/guides/landing"
+  footer:
+    tagline: Barodoc — documentation as a product surface
+    showLogo: true
+    links:
+      - label: Product docs
+        href: "/docs/introduction"
+      - label: Landing guide
+        href: "/docs/guides/landing"
+      - label: Changelog
+        href: "/changelog"
+      - label: GitHub
+        href: "https://github.com/barocss/barodoc"
+---
+
+Below the fold you can still add legal copy, data processing notes, or a compact comparison table — this block is **Markdown** under the generated sections.

--- a/packages/theme-docs/package.json
+++ b/packages/theme-docs/package.json
@@ -15,7 +15,8 @@
     "./layouts/*": "./src/layouts/*",
     "./pages/*": "./src/pages/*",
     "./styles/*": "./src/styles/*",
-    "./lib/*": "./src/lib/*"
+    "./lib/*": "./src/lib/*",
+    "./landing": "./src/landing/types.ts"
   },
   "files": [
     "src",

--- a/packages/theme-docs/src/components/index.ts
+++ b/packages/theme-docs/src/components/index.ts
@@ -37,6 +37,49 @@ export { ApiResponse } from "./mdx/ApiResponse.tsx";
 
 export { VersionSwitcher } from "./VersionSwitcher.tsx";
 
+// SaaS-style landing blocks (MDX / Astro)
+export {
+  LandingHero,
+  LandingLogoStrip,
+  LandingStats,
+  LandingFeatures,
+  LandingTestimonials,
+  LandingPricing,
+  LandingFaq,
+  LandingCta,
+  LandingFooter,
+} from "./landing/index.ts";
+export type {
+  LandingHeroProps,
+  LandingLogoStripProps,
+  LandingLogoStripItem,
+  LandingStatsProps,
+  LandingStatItem,
+  LandingFeaturesProps,
+  LandingFeatureItem,
+  LandingTestimonialsProps,
+  LandingTestimonialItem,
+  LandingPricingProps,
+  LandingPricingPlan,
+  LandingFaqProps,
+  LandingFaqItem,
+  LandingCtaProps,
+  LandingFooterProps,
+  LandingFooterLink,
+} from "./landing/index.ts";
+export type {
+  LandingFrontmatter,
+  LandingHeroFm,
+  LandingLogoStripFm,
+  LandingStatsFm,
+  LandingFeaturesFm,
+  LandingTestimonialsFm,
+  LandingPricingFm,
+  LandingFaqFm,
+  LandingCtaFm,
+  LandingFooterFm,
+} from "../landing/types.ts";
+
 // Legacy exports for backwards compatibility
 export { Tabs, Tab } from "./mdx/Tabs.tsx";
 export { Accordion, AccordionGroup } from "./mdx/Accordion.tsx";

--- a/packages/theme-docs/src/components/landing/LandingBlocks.astro
+++ b/packages/theme-docs/src/components/landing/LandingBlocks.astro
@@ -1,0 +1,115 @@
+---
+/**
+ * Renders built-in landing sections from frontmatter (`landingPage:` in content schema).
+ * Order: Hero → Logo strip → Stats → Features → Testimonials → Pricing → FAQ → CTA → Footer
+ */
+import config from "virtual:barodoc/config";
+import type { LandingFrontmatter } from "../../landing/types.ts";
+import { LandingHero } from "./LandingHero.tsx";
+import { LandingLogoStrip } from "./LandingLogoStrip.tsx";
+import { LandingStats } from "./LandingStats.tsx";
+import { LandingFeatures } from "./LandingFeatures.tsx";
+import { LandingTestimonials } from "./LandingTestimonials.tsx";
+import { LandingPricing } from "./LandingPricing.tsx";
+import { LandingFaq } from "./LandingFaq.tsx";
+import { LandingCta } from "./LandingCta.tsx";
+import { LandingFooter } from "./LandingFooter.tsx";
+
+interface Props {
+  landing: LandingFrontmatter;
+}
+
+const { landing } = Astro.props;
+
+const siteName = (config as { name?: string }).name ?? "";
+const logo = (config as { logo?: string }).logo;
+const github = (config as { topbar?: { github?: string } }).topbar?.github;
+
+const footerShowLogo = landing.footer?.showLogo !== false;
+---
+
+<div class="bd-landing-blocks">
+  {landing.hero && (
+    <LandingHero
+      client:load
+      badge={landing.hero.badge}
+      title={landing.hero.title}
+      titleHighlight={landing.hero.titleHighlight}
+      subtitle={landing.hero.subtitle}
+      primaryCta={landing.hero.primaryCta}
+      secondaryCta={landing.hero.secondaryCta}
+      snippet={landing.hero.snippet}
+      snippetAriaLabel={landing.hero.snippetAriaLabel}
+    />
+  )}
+
+  {landing.logoStrip && landing.logoStrip.items?.length > 0 && (
+    <LandingLogoStrip title={landing.logoStrip.title} items={landing.logoStrip.items} />
+  )}
+
+  {landing.stats && landing.stats.items?.length > 0 && (
+    <LandingStats
+      title={landing.stats.title}
+      subtitle={landing.stats.subtitle}
+      items={landing.stats.items}
+    />
+  )}
+
+  {landing.features && (
+    <LandingFeatures
+      title={landing.features.title}
+      subtitle={landing.features.subtitle}
+      items={landing.features.items}
+    />
+  )}
+
+  {landing.testimonials && landing.testimonials.items?.length > 0 && (
+    <LandingTestimonials
+      title={landing.testimonials.title}
+      subtitle={landing.testimonials.subtitle}
+      items={landing.testimonials.items}
+    />
+  )}
+
+  {landing.pricing && landing.pricing.plans?.length > 0 && (
+    <LandingPricing
+      title={landing.pricing.title}
+      subtitle={landing.pricing.subtitle}
+      plans={landing.pricing.plans}
+    />
+  )}
+
+  {landing.faq && landing.faq.items?.length > 0 && (
+    <LandingFaq
+      title={landing.faq.title}
+      subtitle={landing.faq.subtitle}
+      items={landing.faq.items}
+    />
+  )}
+
+  {landing.cta && (
+    <LandingCta
+      title={landing.cta.title}
+      subtitle={landing.cta.subtitle}
+      buttonLabel={landing.cta.buttonLabel}
+      buttonHref={landing.cta.buttonHref}
+    />
+  )}
+
+  {landing.footer && (
+    <LandingFooter
+      tagline={landing.footer.tagline ?? `Built with ${siteName || "Barodoc"}`}
+      logoSrc={footerShowLogo && logo ? logo : undefined}
+      logoAlt={siteName}
+      links={
+        landing.footer.links ??
+        (github
+          ? [
+              { label: "GitHub", href: github },
+              { label: "Documentation", href: "/docs/introduction" },
+            ]
+          : [{ label: "Documentation", href: "/docs/introduction" }])
+      }
+    />
+  )}
+</div>

--- a/packages/theme-docs/src/components/landing/LandingCta.tsx
+++ b/packages/theme-docs/src/components/landing/LandingCta.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+export interface LandingCtaProps {
+  title: string;
+  subtitle?: string;
+  buttonLabel: string;
+  buttonHref: string;
+}
+
+export function LandingCta({ title, subtitle, buttonLabel, buttonHref }: LandingCtaProps) {
+  return (
+    <div className="relative py-20 sm:py-24 overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-br from-primary-600/[0.08] via-transparent to-violet-600/[0.06] dark:from-primary-500/[0.06] dark:to-violet-500/[0.05] pointer-events-none" />
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[min(90vw,56rem)] h-64 rounded-full bg-primary-500/10 blur-3xl pointer-events-none" />
+
+      <div className="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="rounded-3xl p-8 sm:p-10 md:p-12 text-center border border-[var(--bd-border)] bg-[var(--bd-bg)]/70 backdrop-blur-xl shadow-2xl shadow-primary-500/10 ring-1 ring-primary-500/10 dark:ring-primary-400/10">
+          <h2 className="text-2xl sm:text-3xl md:text-4xl font-extrabold text-[var(--bd-text)] mb-4 tracking-tight">
+            {title}
+          </h2>
+          {subtitle && (
+            <p className="text-base sm:text-lg text-[var(--bd-text-secondary)] mb-8 max-w-xl mx-auto leading-relaxed">
+              {subtitle}
+            </p>
+          )}
+          <a
+            href={buttonHref}
+            className="inline-flex items-center justify-center gap-2 px-8 py-3.5 rounded-xl font-semibold text-white bg-gradient-to-r from-primary-600 via-primary-500 to-cyan-600 hover:from-primary-500 hover:via-primary-400 hover:to-cyan-500 shadow-lg shadow-primary-500/35 hover:shadow-xl hover:shadow-primary-500/45 hover:-translate-y-0.5 transition-all duration-200 ring-1 ring-white/15"
+          >
+            {buttonLabel}
+            <svg className="w-4 h-4 opacity-90" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/theme-docs/src/components/landing/LandingFaq.tsx
+++ b/packages/theme-docs/src/components/landing/LandingFaq.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+
+export interface LandingFaqItem {
+  q: string;
+  a: string;
+}
+
+export interface LandingFaqProps {
+  title?: string;
+  subtitle?: string;
+  items: LandingFaqItem[];
+}
+
+export function LandingFaq({ title = "Frequently asked questions", subtitle, items }: LandingFaqProps) {
+  if (!items.length) return null;
+
+  return (
+    <div className="relative py-20 sm:py-24 bg-[var(--bd-bg)]">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl sm:text-4xl font-extrabold text-[var(--bd-text)] tracking-tight mb-4">{title}</h2>
+          {subtitle && <p className="text-lg text-[var(--bd-text-secondary)]">{subtitle}</p>}
+        </div>
+        <div className="space-y-3">
+          {items.map((item, i) => (
+            <details
+              key={String(i)}
+              className="group rounded-xl border border-[var(--bd-border)] bg-[var(--bd-bg-subtle)]/50 hover:bg-[var(--bd-bg-subtle)] transition-colors open:bg-[var(--bd-bg)] open:shadow-md"
+            >
+              <summary className="cursor-pointer list-none flex items-center justify-between gap-4 px-5 py-4 font-semibold text-[var(--bd-text)] text-left [&::-webkit-details-marker]:hidden">
+                <span>{item.q}</span>
+                <span className="shrink-0 text-primary-500 opacity-70 group-open:rotate-180 transition-transform text-xs" aria-hidden>
+                  ▼
+                </span>
+              </summary>
+              <div className="px-5 pb-4 text-sm sm:text-base text-[var(--bd-text-secondary)] leading-relaxed">
+                {item.a}
+              </div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/theme-docs/src/components/landing/LandingFeatures.tsx
+++ b/packages/theme-docs/src/components/landing/LandingFeatures.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+
+export interface LandingFeatureItem {
+  icon: string;
+  title: string;
+  description: string;
+}
+
+export interface LandingFeaturesProps {
+  title: string;
+  subtitle?: string;
+  items: LandingFeatureItem[];
+}
+
+export function LandingFeatures({ title, subtitle, items }: LandingFeaturesProps) {
+  return (
+    <div className="relative py-20 sm:py-24 bg-[var(--bd-bg-subtle)] border-y border-[var(--bd-border)] overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-primary-500/[0.03] to-transparent dark:via-primary-400/[0.04] pointer-events-none" />
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 w-3/4 max-w-2xl h-px bg-gradient-to-r from-transparent via-primary-400/40 to-transparent" />
+
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-14 sm:mb-16">
+          <h2 className="text-3xl sm:text-4xl font-extrabold text-[var(--bd-text)] mb-4 tracking-tight">{title}</h2>
+          {subtitle && (
+            <p className="text-lg text-[var(--bd-text-secondary)] max-w-2xl mx-auto leading-relaxed">{subtitle}</p>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 sm:gap-6">
+          {items.map((feature, i) => (
+            <div
+              key={feature.title + String(i)}
+              className="group relative p-6 sm:p-7 rounded-2xl bg-[var(--bd-bg)] border border-[var(--bd-border)] shadow-sm hover:shadow-2xl hover:shadow-primary-500/10 dark:hover:shadow-primary-400/5 hover:border-primary-300/60 dark:hover:border-primary-600/50 transition-all duration-300 hover:-translate-y-1 overflow-hidden"
+            >
+              <div className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-500 bg-gradient-to-br from-primary-500/[0.04] via-transparent to-cyan-500/[0.06] pointer-events-none" />
+              <div className="relative">
+                <div className="flex items-center justify-center w-14 h-14 rounded-2xl bg-gradient-to-br from-primary-100 to-cyan-50 dark:from-primary-950/80 dark:to-cyan-950/40 border border-primary-200/50 dark:border-primary-800/50 mb-5 group-hover:scale-105 transition-transform duration-300 shadow-inner">
+                  <span className="text-2xl sm:text-[1.75rem]" aria-hidden>
+                    {feature.icon}
+                  </span>
+                </div>
+                <h3 className="text-lg font-bold text-[var(--bd-text)] mb-2">{feature.title}</h3>
+                <p className="text-sm text-[var(--bd-text-secondary)] leading-relaxed">{feature.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/theme-docs/src/components/landing/LandingFooter.tsx
+++ b/packages/theme-docs/src/components/landing/LandingFooter.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+export interface LandingFooterLink {
+  label: string;
+  href: string;
+}
+
+export interface LandingFooterProps {
+  /** e.g. "Built with Barodoc" */
+  tagline?: string;
+  logoSrc?: string;
+  logoAlt?: string;
+  links?: LandingFooterLink[];
+}
+
+export function LandingFooter({ tagline = "Built with Barodoc", logoSrc, logoAlt = "", links = [] }: LandingFooterProps) {
+  return (
+    <footer className="relative border-t border-[var(--bd-border)] bg-gradient-to-b from-[var(--bd-bg-subtle)] to-[var(--bd-bg)] mt-auto overflow-hidden">
+      <div className="absolute top-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-primary-500/25 to-transparent" />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+          <div className="flex items-center gap-2 text-[var(--bd-text-secondary)]">
+            {logoSrc && <img src={logoSrc} alt={logoAlt} className="h-5 w-5 opacity-60" />}
+            <span className="text-sm">{tagline}</span>
+          </div>
+          {links.length > 0 && (
+            <div className="flex flex-wrap items-center justify-center gap-6">
+              {links.map((link) => (
+                <a
+                  key={link.href + link.label}
+                  href={link.href}
+                  className="text-sm text-[var(--bd-text-secondary)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+                >
+                  {link.label}
+                </a>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/packages/theme-docs/src/components/landing/LandingHero.tsx
+++ b/packages/theme-docs/src/components/landing/LandingHero.tsx
@@ -1,0 +1,123 @@
+import * as React from "react";
+
+export interface LandingHeroProps {
+  /** Small pill above the headline (e.g. "New", "Powered by …") */
+  badge?: string;
+  /** Main headline (plain text) */
+  title: string;
+  /** Gradient-accent segment after `title` (optional) */
+  titleHighlight?: string;
+  subtitle: string;
+  primaryCta: { label: string; href: string };
+  secondaryCta?: { label: string; href: string };
+  /** e.g. install command — shows copy button */
+  snippet?: string;
+  snippetAriaLabel?: string;
+}
+
+export function LandingHero({
+  badge,
+  title,
+  titleHighlight,
+  subtitle,
+  primaryCta,
+  secondaryCta,
+  snippet,
+  snippetAriaLabel = "Copy command",
+}: LandingHeroProps) {
+  const [copied, setCopied] = React.useState(false);
+
+  const copySnippet = () => {
+    if (!snippet) return;
+    void navigator.clipboard.writeText(snippet).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="relative overflow-hidden">
+      {/* Base washes */}
+      <div className="absolute inset-0 bg-gradient-to-b from-primary-50/70 via-transparent to-transparent dark:from-primary-950/30 dark:via-transparent pointer-events-none" />
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_90%_60%_at_50%_-15%,rgba(59,130,246,0.18),transparent)] dark:bg-[radial-gradient(ellipse_90%_60%_at_50%_-15%,rgba(59,130,246,0.12),transparent)] pointer-events-none" />
+      <div className="absolute -top-24 -right-24 h-72 w-72 rounded-full bg-gradient-to-br from-primary-400/25 to-cyan-400/10 blur-3xl dark:from-primary-500/15 dark:to-cyan-500/10 pointer-events-none" />
+      <div className="absolute -bottom-32 -left-20 h-80 w-80 rounded-full bg-gradient-to-tr from-violet-500/15 to-primary-500/10 blur-3xl dark:from-violet-500/10 pointer-events-none" />
+
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 pb-20 sm:pt-24 sm:pb-32">
+        <div className="text-center max-w-4xl mx-auto">
+          {badge && (
+            <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-gradient-to-r from-primary-50 to-cyan-50/80 dark:from-primary-950/60 dark:to-cyan-950/30 border border-primary-200/80 dark:border-primary-800/80 shadow-sm mb-8">
+              <span className="relative flex h-2 w-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-primary-500" />
+              </span>
+              <span className="text-sm font-semibold bg-gradient-to-r from-primary-700 to-cyan-700 dark:from-primary-300 dark:to-cyan-300 bg-clip-text text-transparent">
+                {badge}
+              </span>
+            </div>
+          )}
+
+          <h1 className="text-4xl sm:text-5xl lg:text-[3.25rem] font-extrabold tracking-tight text-[var(--bd-text)] mb-6 leading-[1.08]">
+            {title}
+            {titleHighlight && (
+              <>
+                {" "}
+                <span className="text-transparent bg-clip-text bg-gradient-to-r from-primary-600 via-primary-500 to-cyan-500 dark:from-primary-400 dark:via-primary-300 dark:to-cyan-400">
+                  {titleHighlight}
+                </span>
+              </>
+            )}
+          </h1>
+
+          <p className="text-lg sm:text-xl text-[var(--bd-text-secondary)] mb-10 max-w-2xl mx-auto leading-relaxed">
+            {subtitle}
+          </p>
+
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <a
+              href={primaryCta.href}
+              className="w-full sm:w-auto px-8 py-3.5 rounded-xl font-semibold text-center text-white bg-gradient-to-r from-primary-600 to-primary-500 hover:from-primary-500 hover:to-primary-400 shadow-lg shadow-primary-500/30 hover:shadow-xl hover:shadow-primary-500/40 hover:-translate-y-0.5 transition-all duration-200 ring-1 ring-white/20"
+            >
+              {primaryCta.label}
+            </a>
+            {secondaryCta && (
+              <a
+                href={secondaryCta.href}
+                className="w-full sm:w-auto px-8 py-3.5 border border-[var(--bd-border)] text-[var(--bd-text)] rounded-xl font-medium hover:bg-[var(--bd-bg-subtle)] hover:border-primary-300/60 dark:hover:border-primary-600/50 backdrop-blur-sm transition-all duration-200 text-center"
+              >
+                {secondaryCta.label}
+              </a>
+            )}
+          </div>
+
+          {snippet && (
+            <div className="mt-12 flex justify-center px-2">
+              <div className="inline-flex max-w-full items-center gap-3 px-5 py-3 rounded-xl bg-[var(--bd-bg-subtle)]/90 backdrop-blur-md border border-[var(--bd-border)] shadow-lg ring-1 ring-primary-500/15 dark:ring-primary-400/10">
+                <code className="text-sm text-[var(--bd-text-secondary)] font-mono truncate">{snippet}</code>
+                <button
+                  type="button"
+                  className="p-1.5 shrink-0 rounded-lg hover:bg-[var(--bd-bg-muted)] text-[var(--bd-text-muted)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+                  onClick={copySnippet}
+                  aria-label={snippetAriaLabel}
+                >
+                  {copied ? (
+                    <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">Copied</span>
+                  ) : (
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                      />
+                    </svg>
+                  )}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/theme-docs/src/components/landing/LandingLogoStrip.tsx
+++ b/packages/theme-docs/src/components/landing/LandingLogoStrip.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+
+export interface LandingLogoStripItem {
+  name: string;
+  href?: string;
+}
+
+export interface LandingLogoStripProps {
+  title?: string;
+  items: LandingLogoStripItem[];
+}
+
+export function LandingLogoStrip({ title = "Trusted by teams who ship", items }: LandingLogoStripProps) {
+  if (!items.length) return null;
+
+  return (
+    <div className="relative border-b border-[var(--bd-border)] bg-[var(--bd-bg)] py-10 sm:py-12">
+      <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary-500/20 to-transparent" />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <p className="text-xs sm:text-sm font-semibold uppercase tracking-[0.2em] text-[var(--bd-text-muted)] mb-8">
+          {title}
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-x-10 gap-y-6 sm:gap-x-14 opacity-90">
+          {items.map((item) => {
+            const inner = (
+              <span className="text-base sm:text-lg font-semibold text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] transition-colors whitespace-nowrap">
+                {item.name}
+              </span>
+            );
+            return item.href ? (
+              <a key={item.name} href={item.href} className="grayscale hover:grayscale-0 transition-all">
+                {inner}
+              </a>
+            ) : (
+              <span key={item.name} className="grayscale">
+                {inner}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/theme-docs/src/components/landing/LandingPricing.tsx
+++ b/packages/theme-docs/src/components/landing/LandingPricing.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+
+export interface LandingPricingPlan {
+  name: string;
+  price: string;
+  /** e.g. "/month" or "forever" */
+  period?: string;
+  description?: string;
+  features: string[];
+  ctaLabel: string;
+  ctaHref: string;
+  highlighted?: boolean;
+}
+
+export interface LandingPricingProps {
+  title: string;
+  subtitle?: string;
+  plans: LandingPricingPlan[];
+}
+
+export function LandingPricing({ title, subtitle, plans }: LandingPricingProps) {
+  if (!plans.length) return null;
+
+  return (
+    <div className="relative py-20 sm:py-24 bg-[var(--bd-bg-subtle)] border-y border-[var(--bd-border)]">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center max-w-2xl mx-auto mb-14">
+          <h2 className="text-3xl sm:text-4xl font-extrabold text-[var(--bd-text)] tracking-tight mb-4">{title}</h2>
+          {subtitle && <p className="text-lg text-[var(--bd-text-secondary)] leading-relaxed">{subtitle}</p>}
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8 items-stretch">
+          {plans.map((plan) => {
+            const hi = plan.highlighted;
+            return (
+              <div
+                key={plan.name}
+                className={`relative flex flex-col rounded-2xl border p-6 sm:p-8 transition-all duration-300 ${
+                  hi
+                    ? "border-primary-500/60 bg-[var(--bd-bg)] shadow-2xl shadow-primary-500/15 ring-2 ring-primary-500/20 scale-[1.02] z-10"
+                    : "border-[var(--bd-border)] bg-[var(--bd-bg)]/90 hover:border-primary-300/50 dark:hover:border-primary-600/40 hover:shadow-lg"
+                }`}
+              >
+                {hi && (
+                  <span className="absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-0.5 rounded-full text-xs font-semibold bg-gradient-to-r from-primary-600 to-cyan-600 text-white shadow">
+                    Most popular
+                  </span>
+                )}
+                <div className="mb-6">
+                  <h3 className="text-lg font-bold text-[var(--bd-text)]">{plan.name}</h3>
+                  {plan.description && (
+                    <p className="text-sm text-[var(--bd-text-secondary)] mt-2">{plan.description}</p>
+                  )}
+                  <div className="mt-4 flex items-baseline gap-1">
+                    <span className="text-4xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-[var(--bd-text)] to-primary-600 dark:to-primary-400">
+                      {plan.price}
+                    </span>
+                    {plan.period && (
+                      <span className="text-sm text-[var(--bd-text-secondary)]">{plan.period}</span>
+                    )}
+                  </div>
+                </div>
+                <ul className="space-y-3 mb-8 flex-1">
+                  {plan.features.map((f) => (
+                    <li key={f} className="flex gap-2 text-sm text-[var(--bd-text-secondary)]">
+                      <span className="text-emerald-500 dark:text-emerald-400 shrink-0 mt-0.5" aria-hidden>
+                        ✓
+                      </span>
+                      <span>{f}</span>
+                    </li>
+                  ))}
+                </ul>
+                <a
+                  href={plan.ctaHref}
+                  className={`inline-flex justify-center items-center w-full py-3 px-4 rounded-xl font-semibold text-center transition-all ${
+                    hi
+                      ? "text-white bg-gradient-to-r from-primary-600 to-primary-500 hover:from-primary-500 hover:to-primary-400 shadow-lg shadow-primary-500/30"
+                      : "border border-[var(--bd-border)] text-[var(--bd-text)] hover:bg-[var(--bd-bg-subtle)] hover:border-primary-300/60"
+                  }`}
+                >
+                  {plan.ctaLabel}
+                </a>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/theme-docs/src/components/landing/LandingStats.tsx
+++ b/packages/theme-docs/src/components/landing/LandingStats.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+
+export interface LandingStatItem {
+  value: string;
+  label: string;
+}
+
+export interface LandingStatsProps {
+  title?: string;
+  subtitle?: string;
+  items: LandingStatItem[];
+}
+
+export function LandingStats({ title, subtitle, items }: LandingStatsProps) {
+  if (!items.length) return null;
+
+  return (
+    <div className="relative border-y border-[var(--bd-border)] overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-r from-primary-600/[0.06] via-transparent to-primary-400/[0.08] dark:from-primary-400/[0.05] dark:to-primary-600/[0.06] pointer-events-none" />
+      <div
+        className="absolute inset-0 opacity-[0.35] dark:opacity-25 pointer-events-none"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%230070f3' fill-opacity='0.08'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E")`,
+        }}
+      />
+
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-14 sm:py-16">
+        {(title || subtitle) && (
+          <div className="text-center mb-10 sm:mb-12 max-w-2xl mx-auto">
+            {title && (
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primary-600 dark:text-primary-400 mb-2">
+                {title}
+              </p>
+            )}
+            {subtitle && (
+              <p className="text-base sm:text-lg text-[var(--bd-text-secondary)] leading-relaxed">{subtitle}</p>
+            )}
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-6 sm:gap-8">
+          {items.map((s) => (
+            <div
+              key={s.label}
+              className="group text-center p-5 sm:p-6 rounded-2xl bg-[var(--bd-bg)]/80 backdrop-blur-sm border border-[var(--bd-border)] shadow-sm hover:shadow-xl hover:border-primary-300/50 dark:hover:border-primary-600/40 transition-all duration-300 hover:-translate-y-1"
+            >
+              <div className="text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-transparent bg-clip-text bg-gradient-to-br from-primary-600 via-primary-500 to-primary-400 dark:from-primary-400 dark:via-primary-300 dark:to-primary-500 mb-2 tabular-nums">
+                {s.value}
+              </div>
+              <div className="text-xs sm:text-sm text-[var(--bd-text-secondary)] font-medium leading-snug">{s.label}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/theme-docs/src/components/landing/LandingTestimonials.tsx
+++ b/packages/theme-docs/src/components/landing/LandingTestimonials.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+
+export interface LandingTestimonialItem {
+  quote: string;
+  author: string;
+  role: string;
+  /** Emoji or short avatar label */
+  avatar?: string;
+}
+
+export interface LandingTestimonialsProps {
+  title: string;
+  subtitle?: string;
+  items: LandingTestimonialItem[];
+}
+
+export function LandingTestimonials({ title, subtitle, items }: LandingTestimonialsProps) {
+  if (!items.length) return null;
+
+  return (
+    <div className="relative py-20 sm:py-24 bg-[var(--bd-bg)] overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-primary-500/[0.03] to-transparent pointer-events-none" />
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center max-w-2xl mx-auto mb-14">
+          <h2 className="text-3xl sm:text-4xl font-extrabold text-[var(--bd-text)] tracking-tight mb-4">{title}</h2>
+          {subtitle && (
+            <p className="text-lg text-[var(--bd-text-secondary)] leading-relaxed">{subtitle}</p>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8">
+          {items.map((t, i) => (
+            <blockquote
+              key={t.author + String(i)}
+              className="relative flex flex-col p-6 sm:p-8 rounded-2xl border border-[var(--bd-border)] bg-[var(--bd-bg-subtle)]/80 backdrop-blur-sm shadow-lg hover:shadow-xl hover:border-primary-300/40 dark:hover:border-primary-600/30 transition-all duration-300"
+            >
+              <div className="text-4xl leading-none text-primary-500/40 dark:text-primary-400/30 mb-4 font-serif">"</div>
+              <p className="text-[var(--bd-text)] leading-relaxed flex-1 mb-6 text-sm sm:text-base">{t.quote}</p>
+              <footer className="flex items-center gap-3 mt-auto pt-4 border-t border-[var(--bd-border)]">
+                <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-gradient-to-br from-primary-100 to-cyan-100 dark:from-primary-900/60 dark:to-cyan-900/40 text-xs font-bold tracking-tight text-primary-800 dark:text-primary-200 border border-primary-200/50 dark:border-primary-800/50">
+                  {t.avatar ?? "•"}
+                </div>
+                <div>
+                  <cite className="not-italic font-semibold text-[var(--bd-text)] text-sm">{t.author}</cite>
+                  <div className="text-xs text-[var(--bd-text-secondary)]">{t.role}</div>
+                </div>
+              </footer>
+            </blockquote>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/theme-docs/src/components/landing/index.ts
+++ b/packages/theme-docs/src/components/landing/index.ts
@@ -1,0 +1,9 @@
+export { LandingHero, type LandingHeroProps } from "./LandingHero.tsx";
+export { LandingLogoStrip, type LandingLogoStripProps, type LandingLogoStripItem } from "./LandingLogoStrip.tsx";
+export { LandingStats, type LandingStatsProps, type LandingStatItem } from "./LandingStats.tsx";
+export { LandingFeatures, type LandingFeaturesProps, type LandingFeatureItem } from "./LandingFeatures.tsx";
+export { LandingTestimonials, type LandingTestimonialsProps, type LandingTestimonialItem } from "./LandingTestimonials.tsx";
+export { LandingPricing, type LandingPricingProps, type LandingPricingPlan } from "./LandingPricing.tsx";
+export { LandingFaq, type LandingFaqProps, type LandingFaqItem } from "./LandingFaq.tsx";
+export { LandingCta, type LandingCtaProps } from "./LandingCta.tsx";
+export { LandingFooter, type LandingFooterProps, type LandingFooterLink } from "./LandingFooter.tsx";

--- a/packages/theme-docs/src/landing/types.ts
+++ b/packages/theme-docs/src/landing/types.ts
@@ -1,0 +1,97 @@
+/**
+ * Frontmatter-driven landing page (VuePress-style declarative home).
+ * Used with `pageLayout: landing` on `pages` collection entries.
+ */
+export interface LandingHeroFm {
+  badge?: string;
+  title: string;
+  titleHighlight?: string;
+  subtitle: string;
+  primaryCta: { label: string; href: string };
+  secondaryCta?: { label: string; href: string };
+  snippet?: string;
+  snippetAriaLabel?: string;
+}
+
+export interface LandingLogoStripFm {
+  title?: string;
+  items: Array<{ name: string; href?: string }>;
+}
+
+export interface LandingStatsFm {
+  title?: string;
+  subtitle?: string;
+  items: Array<{
+    value: string;
+    label: string;
+  }>;
+}
+
+export interface LandingFeaturesFm {
+  title: string;
+  subtitle?: string;
+  items: Array<{
+    icon: string;
+    title: string;
+    description: string;
+  }>;
+}
+
+export interface LandingTestimonialsFm {
+  title: string;
+  subtitle?: string;
+  items: Array<{
+    quote: string;
+    author: string;
+    role: string;
+    avatar?: string;
+  }>;
+}
+
+export interface LandingPricingFm {
+  title: string;
+  subtitle?: string;
+  plans: Array<{
+    name: string;
+    price: string;
+    period?: string;
+    description?: string;
+    features: string[];
+    ctaLabel: string;
+    ctaHref: string;
+    highlighted?: boolean;
+  }>;
+}
+
+export interface LandingFaqFm {
+  title?: string;
+  subtitle?: string;
+  items: Array<{ q: string; a: string }>;
+}
+
+export interface LandingCtaFm {
+  title: string;
+  subtitle?: string;
+  buttonLabel: string;
+  buttonHref: string;
+}
+
+export interface LandingFooterFm {
+  tagline?: string;
+  /** When true, uses site `logo` from barodoc config (if set). Default true when footer is present. */
+  showLogo?: boolean;
+  links?: Array<{ label: string; href: string }>;
+}
+
+/** YAML `landingPage:` block (see pages collection schema). */
+export interface LandingFrontmatter {
+  hero?: LandingHeroFm;
+  logoStrip?: LandingLogoStripFm;
+  stats?: LandingStatsFm;
+  features?: LandingFeaturesFm;
+  testimonials?: LandingTestimonialsFm;
+  pricing?: LandingPricingFm;
+  faq?: LandingFaqFm;
+  cta?: LandingCtaFm;
+  footer?: LandingFooterFm;
+}

--- a/packages/theme-docs/src/layouts/LandingLayout.astro
+++ b/packages/theme-docs/src/layouts/LandingLayout.astro
@@ -1,0 +1,34 @@
+---
+/**
+ * Full-width marketing-style layout for standalone `pages` content (no sidebar, no narrow prose column).
+ * Use with frontmatter `pageLayout: landing` in `src/content/pages/*.{md,mdx}`.
+ */
+import BaseLayout from "./BaseLayout.astro";
+import Header from "../components/Header.astro";
+import Banner from "../components/Banner.astro";
+import CodeCopy from "../components/CodeCopy.astro";
+import { defaultLocale } from "virtual:barodoc/i18n";
+import { getLocaleFromPath } from "@barodoc/core";
+
+interface Props {
+  title: string;
+  description?: string;
+}
+
+const { title, description } = Astro.props;
+const currentPath = Astro.url.pathname;
+const i18nConfig = { defaultLocale, locales: [defaultLocale] };
+const currentLocale = getLocaleFromPath(currentPath, i18nConfig);
+---
+
+<BaseLayout title={title} description={description}>
+  <Banner />
+  <Header currentLocale={currentLocale} currentPath={currentPath} />
+
+  <div class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex flex-col">
+    <main class="w-full flex-1">
+      <slot />
+    </main>
+    <CodeCopy />
+  </div>
+</BaseLayout>

--- a/packages/theme-docs/src/pages/[...page].astro
+++ b/packages/theme-docs/src/pages/[...page].astro
@@ -1,7 +1,10 @@
 ---
 import { getCollection, render } from "astro:content";
 import PageLayout from "../layouts/PageLayout.astro";
+import LandingLayout from "../layouts/LandingLayout.astro";
+import LandingBlocks from "../components/landing/LandingBlocks.astro";
 import config from "virtual:barodoc/config";
+import type { LandingFrontmatter } from "../landing/types.ts";
 
 export async function getStaticPaths() {
   const reserved = new Set(["blog", "changelog", "docs", "rss.xml"]);
@@ -38,8 +41,25 @@ interface Props {
 
 const { page } = Astro.props;
 const { Content } = await render(page);
+const data = page.data as { pageLayout?: string; layout?: string; landingPage?: LandingFrontmatter };
+/** Prefer `pageLayout` — Astro 5 reserves `layout` for Markdown in content collections. */
+const pageLayout = data.pageLayout ?? data.layout ?? "default";
+const landingPage = data.landingPage;
 ---
 
-<PageLayout title={page.data.title} description={page.data.description}>
-  <Content />
-</PageLayout>
+{pageLayout === "landing" ? (
+  <LandingLayout title={page.data.title} description={page.data.description}>
+    {landingPage && <LandingBlocks landing={landingPage} />}
+    {landingPage ? (
+      <div class="bd-landing-mdx max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10 prose prose-gray dark:prose-invert max-w-none">
+        <Content />
+      </div>
+    ) : (
+      <Content />
+    )}
+  </LandingLayout>
+) : (
+  <PageLayout title={page.data.title} description={page.data.description}>
+    <Content />
+  </PageLayout>
+)}

--- a/packages/theme-docs/src/pages/index.astro
+++ b/packages/theme-docs/src/pages/index.astro
@@ -2,38 +2,49 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { ThemeToggle } from "../components/ThemeToggle";
 import config from "virtual:barodoc/config";
+import { LandingHero } from "../components/landing/LandingHero.tsx";
+import { LandingFeatures } from "../components/landing/LandingFeatures.tsx";
+import { LandingCta } from "../components/landing/LandingCta.tsx";
+import { LandingFooter } from "../components/landing/LandingFooter.tsx";
 
 const features = [
   {
     icon: "📝",
     title: "MDX Support",
-    description: "Write documentation in MDX with full React component support."
+    description: "Write documentation in MDX with full React component support.",
   },
   {
     icon: "🌙",
     title: "Dark Mode",
-    description: "Built-in dark mode with system preference detection."
+    description: "Built-in dark mode with system preference detection.",
   },
   {
     icon: "🔍",
     title: "Full-text Search",
-    description: "Client-side search powered by Pagefind for fast results."
+    description: "Client-side search powered by Pagefind for fast results.",
   },
   {
     icon: "🌐",
     title: "Internationalization",
-    description: "Multi-language support out of the box with Astro i18n."
+    description: "Multi-language support out of the box with Astro i18n.",
   },
   {
     icon: "⚡",
     title: "Lightning Fast",
-    description: "Static site generation for optimal performance."
+    description: "Static site generation for optimal performance.",
   },
   {
     icon: "🎨",
     title: "Customizable",
-    description: "Easily customize colors, fonts, and components."
-  }
+    description: "Easily customize colors, fonts, and components.",
+  },
+];
+
+const footerLinks = [
+  ...(config.topbar?.github
+    ? [{ label: "GitHub", href: config.topbar.github as string }]
+    : []),
+  { label: "Documentation", href: "/docs/introduction" },
 ];
 ---
 
@@ -71,7 +82,11 @@ const features = [
                 aria-label="GitHub"
               >
                 <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                  <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"></path>
+                  <path
+                    fill-rule="evenodd"
+                    d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                    clip-rule="evenodd"
+                  />
                 </svg>
               </a>
             )}
@@ -87,145 +102,37 @@ const features = [
       </div>
     </header>
 
-    <!-- Hero Section -->
     <main class="flex-1">
-      <div class="relative overflow-hidden">
-        <!-- Background gradient -->
-        <div class="absolute inset-0 bg-gradient-to-b from-primary-50/50 to-transparent dark:from-primary-950/20 dark:to-transparent pointer-events-none"></div>
-        <div class="absolute inset-0 bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.15),rgba(255,255,255,0))] dark:bg-[radial-gradient(ellipse_80%_80%_at_50%_-20%,rgba(120,119,198,0.1),rgba(0,0,0,0))] pointer-events-none"></div>
-        
-        <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-24 sm:pt-28 sm:pb-32">
-          <div class="text-center max-w-4xl mx-auto">
-            <!-- Badge -->
-            <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary-50 dark:bg-primary-950/50 border border-primary-200 dark:border-primary-800 mb-8">
-              <span class="relative flex h-2 w-2">
-                <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary-400 opacity-75"></span>
-                <span class="relative inline-flex rounded-full h-2 w-2 bg-primary-500"></span>
-              </span>
-              <span class="text-sm font-medium text-primary-700 dark:text-primary-300">Powered by Astro</span>
-            </div>
-            
-            <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-[var(--bd-text)] mb-6 leading-tight">
-              Build beautiful
-              <span class="text-transparent bg-clip-text bg-gradient-to-r from-primary-600 to-primary-400"> documentation</span>
-            </h1>
-            
-            <p class="text-lg sm:text-xl text-[var(--bd-text-secondary)] mb-10 max-w-2xl mx-auto leading-relaxed">
-              Create stunning documentation sites with MDX, Astro, and Tailwind CSS. 
-              Deploy anywhere with static site generation.
-            </p>
-            
-            <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-              <a
-                href="/docs/introduction"
-                class="w-full sm:w-auto px-8 py-3.5 bg-primary-600 text-white rounded-xl hover:bg-primary-700 transition-all font-medium shadow-lg shadow-primary-500/25 hover:shadow-xl hover:shadow-primary-500/30 hover:-translate-y-0.5"
-              >
-                Get Started
-              </a>
-              <a
-                href="/docs/quickstart"
-                class="w-full sm:w-auto px-8 py-3.5 border border-[var(--bd-border)] text-[var(--bd-text)] rounded-xl hover:bg-[var(--bd-bg-subtle)] hover:border-[var(--bd-text-muted)] transition-all font-medium"
-              >
-                Quick Start
-              </a>
-            </div>
-            
-            <!-- Install command -->
-            <div class="mt-12 inline-flex items-center gap-3 px-5 py-3 bg-[var(--bd-bg-subtle)] border border-[var(--bd-border)] rounded-xl">
-              <code class="text-sm text-[var(--bd-text-secondary)] font-mono">
-                npx create-barodoc my-docs
-              </code>
-              <button 
-                class="p-1.5 rounded-lg hover:bg-[var(--bd-bg-muted)] text-[var(--bd-text-muted)] hover:text-[var(--bd-text)] transition-colors"
-                onclick="navigator.clipboard.writeText('npx create-barodoc my-docs')"
-                aria-label="Copy command"
-              >
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
-                </svg>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
+      <LandingHero
+        client:load
+        badge="Powered by Astro"
+        title="Build beautiful"
+        titleHighlight="documentation"
+        subtitle="Create stunning documentation sites with MDX, Astro, and Tailwind CSS. Deploy anywhere with static site generation."
+        primaryCta={{ label: "Get Started", href: "/docs/introduction" }}
+        secondaryCta={{ label: "Quick Start", href: "/docs/quickstart" }}
+        snippet="npx create-barodoc my-docs"
+      />
 
-      <!-- Features Section -->
-      <div class="py-20 bg-[var(--bd-bg-subtle)] border-y border-[var(--bd-border)]">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div class="text-center mb-16">
-            <h2 class="text-3xl font-bold text-[var(--bd-text)] mb-4">
-              Everything you need
-            </h2>
-            <p class="text-lg text-[var(--bd-text-secondary)] max-w-2xl mx-auto">
-              Barodoc comes with all the features you need to create beautiful documentation.
-            </p>
-          </div>
-          
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {features.map((feature) => (
-              <div class="group p-6 bg-[var(--bd-bg)] rounded-2xl border border-[var(--bd-border)] hover:border-primary-300 dark:hover:border-primary-700 hover:shadow-lg transition-all duration-200">
-                <div class="flex items-center justify-center w-12 h-12 rounded-xl bg-primary-50 dark:bg-primary-950/50 mb-4 group-hover:scale-110 transition-transform">
-                  <span class="text-2xl">{feature.icon}</span>
-                </div>
-                <h3 class="text-lg font-semibold text-[var(--bd-text)] mb-2">
-                  {feature.title}
-                </h3>
-                <p class="text-sm text-[var(--bd-text-secondary)] leading-relaxed">
-                  {feature.description}
-                </p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
+      <LandingFeatures
+        title="Everything you need"
+        subtitle="Barodoc comes with all the features you need to create beautiful documentation."
+        items={features}
+      />
 
-      <!-- CTA Section -->
-      <div class="py-20">
-        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 class="text-3xl font-bold text-[var(--bd-text)] mb-4">
-            Ready to get started?
-          </h2>
-          <p class="text-lg text-[var(--bd-text-secondary)] mb-8">
-            Create your documentation site in minutes.
-          </p>
-          <a
-            href="/docs/introduction"
-            class="inline-flex px-8 py-3.5 bg-primary-600 text-white rounded-xl hover:bg-primary-700 transition-all font-medium shadow-lg shadow-primary-500/25 hover:shadow-xl hover:shadow-primary-500/30 hover:-translate-y-0.5"
-          >
-            Read the docs
-          </a>
-        </div>
-      </div>
+      <LandingCta
+        title="Ready to get started?"
+        subtitle="Create your documentation site in minutes."
+        buttonLabel="Read the docs"
+        buttonHref="/docs/introduction"
+      />
     </main>
 
-    <!-- Footer -->
-    <footer class="border-t border-[var(--bd-border)] bg-[var(--bd-bg-subtle)]">
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
-          <div class="flex items-center gap-2 text-[var(--bd-text-secondary)]">
-            {config.logo && <img src={config.logo} alt={config.name} class="h-5 w-5 opacity-60" />}
-            <span class="text-sm">Built with Barodoc</span>
-          </div>
-          <div class="flex items-center gap-6">
-            {config.topbar?.github && (
-              <a
-                href={config.topbar.github}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-sm text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] transition-colors"
-              >
-                GitHub
-              </a>
-            )}
-            <a
-              href="/docs/introduction"
-              class="text-sm text-[var(--bd-text-secondary)] hover:text-[var(--bd-text)] transition-colors"
-            >
-              Documentation
-            </a>
-          </div>
-        </div>
-      </div>
-    </footer>
+    <LandingFooter
+      tagline="Built with Barodoc"
+      logoSrc={config.logo}
+      logoAlt={config.name}
+      links={footerLinks}
+    />
   </div>
 </BaseLayout>


### PR DESCRIPTION
## Closes
Closes #147

## What
- **`pageLayout: landing`** + **`landingPage`** YAML (hero → logoStrip → stats → features → testimonials → pricing → faq → cta → footer)
- **Components**: `LandingHero`, `LandingLogoStrip`, `LandingStats`, `LandingFeatures`, `LandingTestimonials`, `LandingPricing`, `LandingFaq`, `LandingCta`, `LandingFooter`; `LandingBlocks.astro` for frontmatter
- **Exports**: `@barodoc/theme-docs/landing` types; barrel re-exports from `@barodoc/theme-docs`
- **Docs**: EN/KO landing guides, `/yaml-landing-demo`, tab **Landing demo**
- **Changeset**: patch `@barodoc/theme-docs`
- **Site changelog**: `v10.0.6.mdx`

Made with [Cursor](https://cursor.com)