### PR TITLE
feat(theme-docs): reader UX — skip link, TOC, trust badges, changelog & feedback

### DIFF
--- a/.changeset/reader-docs-toc-a11y-meta.md
+++ b/.changeset/reader-docs-toc-a11y-meta.md
@@ -1,0 +1,11 @@
+---
+"@barodoc/core": patch
+"@barodoc/theme-docs": patch
+"barodoc": patch
+---
+
+feat(theme-docs): reader UX — skip link, TOC h4 + scroll spy, doc badges, changelog & feedback links
+
+- Skip-to-main, `main-content` targets; TOC includes h2–h4 with scroll-based active state.
+- Frontmatter: `since`, `deprecated`, `experimental`, `changelogUrl`; config `changelogUrl` and `feedback.issueUrl`.
+- Section link copy on headings; i18n for new UI strings; docs site dogfoods `changelogUrl`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,16 @@ interface BarodocConfig {
   plugins?: Array<string | [string, object]>;
   
   topbar?: { github?: string };
+
+  /** Doc footer link to changelog (path or URL). */
+  changelogUrl?: string;
+
+  feedback?: {
+    enabled: boolean;
+    endpoint?: string;
+    /** "Report an issue" (e.g. GitHub issues/new); page title sent as query when possible. */
+    issueUrl?: string;
+  };
 }
 ```
 
@@ -128,6 +138,13 @@ description: This becomes the description.
 ### Wikilinks (Obsidian-style)
 
 In `@barodoc/theme-docs`, `[[...]]` in `.md`/`.mdx` is resolved at **MDX compile time** (remark), so **dev and production** use the same rules. Targets are resolved within the same content section (`docs`, `help`, etc.); see `packages/theme-docs/src/lib/wikiIndex.ts` for resolution order and tests.
+
+### Reader-oriented frontmatter (optional)
+
+- **`since`** — text badge (e.g. product version).
+- **`deprecated`** — `true` or a short string (shown next to the badge).
+- **`experimental`** — boolean badge.
+- **`changelogUrl`** — overrides site `changelogUrl` for the doc footer link.
 
 ### Link graph
 

--- a/docs/barodoc.config.json
+++ b/docs/barodoc.config.json
@@ -1,6 +1,7 @@
 {
   "name": "Barodoc",
   "site": "https://barodoc.dev",
+  "changelogUrl": "/changelog",
   "logo": "/logo.svg",
   "favicon": "/favicon.ico",
   "theme": {

--- a/docs/src/content/changelog/v10.0.8.mdx
+++ b/docs/src/content/changelog/v10.0.8.mdx
@@ -1,0 +1,27 @@
+---
+version: "10.0.8"
+date: 2026-03-24
+title: "Reader-focused docs: accessibility, TOC, trust badges, and feedback"
+---
+
+### Core (@barodoc/core)
+
+- **Config** — Optional `changelogUrl` for doc footers; `feedback.issueUrl` for “Report an issue” (prefills title when supported).
+- **Content schema** — Frontmatter: `since`, `deprecated`, `experimental`, `changelogUrl` (Quick mode `content.config` template updated).
+- **i18n** — New UI strings: skip to content, since/deprecated/experimental, changelog, copy section link, feedback thanks, report issue.
+
+### CLI (barodoc)
+
+- Generated **content collection schema** includes the new doc frontmatter fields.
+
+### Theme (@barodoc/theme-docs)
+
+- **Accessibility** — Skip link to `#main-content`; main/content wrappers use `id="main-content"` on docs, pages, blog, landing.
+- **On this page** — Headings `h2`–`h4`; scroll-based TOC highlight; duplicate scroll listeners avoided with `AbortController`.
+- **Trust** — Badges from frontmatter; footer **Changelog** link from site or page `changelogUrl`.
+- **Feedback** — Localized thanks text; optional **Report an issue** when `feedback.issueUrl` is set.
+- **Headings** — `#` anchor plus **copy section URL** control next to h2–h4.
+
+### Docs site
+
+- **`changelogUrl`** in `barodoc.config.json` pointing at `/changelog`.

--- a/docs/src/content/config.ts
+++ b/docs/src/content/config.ts
@@ -11,6 +11,10 @@ const docsCollection = defineCollection({
     api_reference: z.boolean().optional(),
     difficulty: z.enum(["beginner", "intermediate", "advanced"]).optional(),
     lastUpdated: z.date().optional(),
+    since: z.string().optional(),
+    deprecated: z.union([z.boolean(), z.string()]).optional(),
+    experimental: z.boolean().optional(),
+    changelogUrl: z.string().optional(),
   }),
 });
 
@@ -47,6 +51,10 @@ const helpCollection = defineCollection({
     tags: z.array(z.string()).optional(),
     related: z.array(z.string()).optional(),
     difficulty: z.enum(["beginner", "intermediate", "advanced"]).optional(),
+    since: z.string().optional(),
+    deprecated: z.union([z.boolean(), z.string()]).optional(),
+    experimental: z.boolean().optional(),
+    changelogUrl: z.string().optional(),
   }),
 });
 

--- a/packages/barodoc/src/runtime/project.ts
+++ b/packages/barodoc/src/runtime/project.ts
@@ -264,6 +264,10 @@ const contentSchema = `z.object({
     api_reference: z.boolean().optional(),
     difficulty: z.enum(["beginner", "intermediate", "advanced"]).optional(),
     lastUpdated: z.date().optional(),
+    since: z.string().optional(),
+    deprecated: z.union([z.boolean(), z.string()]).optional(),
+    experimental: z.boolean().optional(),
+    changelogUrl: z.string().optional(),
   })`;
 
 function generateContentConfig(config: BarodocConfig): string {

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -79,6 +79,7 @@ export const announcementSchema = z.object({
 export const feedbackSchema = z.object({
   enabled: z.boolean(),
   endpoint: z.string().optional(),
+  issueUrl: z.string().optional(),
 }).optional();
 
 /** Frontmatter schema for MDX/MD content files. Reusable across custom and quick mode. */
@@ -91,6 +92,14 @@ export const docsFrontmatterSchema = z.object({
   api_reference: z.boolean().optional(),
   difficulty: z.enum(["beginner", "intermediate", "advanced"]).optional(),
   lastUpdated: z.date().optional(),
+  /** Shown as a "Since …" badge (e.g. product or doc version). */
+  since: z.string().optional(),
+  /** Mark page as deprecated; use `true` or a short reason string. */
+  deprecated: z.union([z.boolean(), z.string()]).optional(),
+  /** Experimental / preview badge. */
+  experimental: z.boolean().optional(),
+  /** Override site `changelogUrl` for this page only. */
+  changelogUrl: z.string().optional(),
 });
 
 export type DocsFrontmatter = z.infer<typeof docsFrontmatterSchema>;
@@ -138,6 +147,7 @@ export const barodocConfigSchema = z.object({
   lineNumbers: lineNumbersSchema,
   editLink: editLinkSchema,
   lastUpdated: z.boolean().optional(),
+  changelogUrl: z.string().optional(),
   announcement: announcementSchema,
   feedback: feedbackSchema,
   blog: blogConfigSchema,

--- a/packages/core/src/i18n/defaultStrings.ts
+++ b/packages/core/src/i18n/defaultStrings.ts
@@ -34,6 +34,14 @@ export const DEFAULT_UI_STRINGS: Record<string, string> = {
   linksOut: "Links to",
   linksIn: "Linked from",
   brokenLinks: "Unresolved internal links",
+  skipToContent: "Skip to main content",
+  sinceVersion: "Since",
+  deprecated: "Deprecated",
+  experimental: "Experimental",
+  viewChangelog: "Changelog",
+  copySectionLink: "Copy link to section",
+  feedbackThanks: "Thanks for your feedback!",
+  reportIssue: "Report an issue",
 };
 
 /** Optional default strings for other locales (partial overrides). */
@@ -70,6 +78,14 @@ export const DEFAULT_UI_STRINGS_KO: Record<string, string> = {
   linksOut: "이 문서에서 링크",
   linksIn: "이 문서를 가리키는 페이지",
   brokenLinks: "풀리지 않은 내부 링크",
+  skipToContent: "본문으로 건너뛰기",
+  sinceVersion: "도입",
+  deprecated: "사용 중단",
+  experimental: "실험적",
+  viewChangelog: "변경 사항",
+  copySectionLink: "섹션 링크 복사",
+  feedbackThanks: "피드백 감사합니다!",
+  reportIssue: "이슈 등록",
 };
 
 export function getDefaultUIStringsForLocale(locale: string): Record<string, string> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -96,6 +96,9 @@ export interface BarodocConfig {
   /** When true, shows git-based last updated timestamp on each page. */
   lastUpdated?: boolean;
 
+  /** Site-wide link to changelog (shown on doc pages when set). Path or absolute URL. */
+  changelogUrl?: string;
+
   /** Top-of-page announcement banner. */
   announcement?: {
     text: string;
@@ -107,6 +110,8 @@ export interface BarodocConfig {
   feedback?: {
     enabled: boolean;
     endpoint?: string;
+    /** Base URL for "Report an issue" (e.g. GitHub issues/new). Page path is appended as title query param when possible. */
+    issueUrl?: string;
   };
   
   blog?: {

--- a/packages/theme-docs/src/components/TableOfContents.astro
+++ b/packages/theme-docs/src/components/TableOfContents.astro
@@ -12,8 +12,7 @@ interface Props {
 
 const { headings, onThisPageLabel = "On this page" } = Astro.props;
 
-// Filter to only show h2 and h3
-const filteredHeadings = headings.filter(h => h.depth >= 2 && h.depth <= 3);
+const filteredHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 4);
 ---
 
 {filteredHeadings.length > 0 && (
@@ -21,7 +20,7 @@ const filteredHeadings = headings.filter(h => h.depth >= 2 && h.depth <= 3);
     <h4 class="text-[11px] font-semibold uppercase tracking-widest text-[var(--bd-text-muted)] mb-3">
       {onThisPageLabel}
     </h4>
-    <nav class="relative">
+    <nav class="relative" aria-label={onThisPageLabel}>
       <div class="absolute left-0 top-0 bottom-0 w-px bg-[var(--bd-border)]"></div>
       <ul class="space-y-0.5">
         {filteredHeadings.map((heading) => (
@@ -30,7 +29,7 @@ const filteredHeadings = headings.filter(h => h.depth >= 2 && h.depth <= 3);
               href={`#${heading.slug}`}
               class:list={[
                 "toc-link block text-[var(--bd-text-muted)] hover:text-[var(--bd-text)] transition-all duration-150",
-                heading.depth === 2 ? "py-1 pl-3.5 text-[13px]" : "py-0.5 pl-6 text-xs"
+                heading.depth === 2 ? "py-1 pl-3.5 text-[13px]" : heading.depth === 3 ? "py-0.5 pl-6 text-xs" : "py-0.5 pl-8 text-[11px]",
               ]}
               data-heading={heading.slug}
             >
@@ -48,9 +47,9 @@ const filteredHeadings = headings.filter(h => h.depth >= 2 && h.depth <= 3);
     color: var(--color-primary-600);
     font-weight: 500;
   }
-  
+
   .toc-link.active::before {
-    content: '';
+    content: "";
     position: absolute;
     left: 0;
     top: 50%;
@@ -60,40 +59,62 @@ const filteredHeadings = headings.filter(h => h.depth >= 2 && h.depth <= 3);
     background: var(--color-primary-500);
     border-radius: 1px;
   }
-  
+
   :global(.dark) .toc-link.active {
     color: var(--color-primary-400);
   }
 </style>
 
-<script>
-  function initTOCHighlight() {
-    const headings = document.querySelectorAll('article h2, article h3');
-    const tocLinks = document.querySelectorAll('.toc-link');
-    
-    if (headings.length === 0 || tocLinks.length === 0) return;
+<script is:inline>
+  (function () {
+    let tocAbort = null;
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            const id = entry.target.id;
-            tocLinks.forEach((link) => {
-              const isActive = link.getAttribute('data-heading') === id;
-              link.classList.toggle('active', isActive);
-            });
-          }
+    function getHeadingElements() {
+      return Array.prototype.slice.call(
+        document.querySelectorAll("article h2[id], article h3[id], article h4[id]"),
+      );
+    }
+
+    function initTOCHighlight() {
+      if (tocAbort) tocAbort.abort();
+      tocAbort = new AbortController();
+      const signal = tocAbort.signal;
+
+      const headings = getHeadingElements();
+      const tocLinks = document.querySelectorAll(".toc-link");
+      if (headings.length === 0 || tocLinks.length === 0) return;
+
+      const offset = 96;
+      let raf = 0;
+
+      function updateActive() {
+        let activeId = headings[0].id;
+        for (let i = 0; i < headings.length; i++) {
+          const h = headings[i];
+          const top = h.getBoundingClientRect().top;
+          if (top <= offset) activeId = h.id;
+          else break;
+        }
+
+        tocLinks.forEach(function (link) {
+          link.classList.toggle("active", link.getAttribute("data-heading") === activeId);
         });
-      },
-      {
-        rootMargin: '-80px 0px -80% 0px',
-        threshold: 0
       }
-    );
 
-    headings.forEach((heading) => observer.observe(heading));
-  }
+      function onScrollOrResize() {
+        if (raf) cancelAnimationFrame(raf);
+        raf = requestAnimationFrame(function () {
+          updateActive();
+          raf = 0;
+        });
+      }
 
-  initTOCHighlight();
-  document.addEventListener('astro:page-load', initTOCHighlight);
+      updateActive();
+      window.addEventListener("scroll", onScrollOrResize, { passive: true, signal: signal });
+      window.addEventListener("resize", onScrollOrResize, { passive: true, signal: signal });
+    }
+
+    initTOCHighlight();
+    document.addEventListener("astro:page-load", initTOCHighlight);
+  })();
 </script>

--- a/packages/theme-docs/src/layouts/BaseLayout.astro
+++ b/packages/theme-docs/src/layouts/BaseLayout.astro
@@ -25,6 +25,7 @@ const ogImageUrl = ogImage
   : undefined;
 
 const themeCSS = config.theme?.colors ? generateThemeCSS(config.theme.colors) : "";
+const skipLabel = uiStrings?.skipToContent ?? "Skip to main content";
 ---
 
 <!doctype html>
@@ -58,6 +59,12 @@ const themeCSS = config.theme?.colors ? generateThemeCSS(config.theme.colors) : 
     {themeCSS && <style set:html={themeCSS} />}
   </head>
   <body class="min-h-screen bg-[var(--bd-bg)] text-[var(--bd-text)] antialiased">
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[200] focus:rounded-md focus:bg-primary-600 focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-white focus:outline-none focus:ring-2 focus:ring-primary-400 focus:ring-offset-2 dark:focus:ring-offset-[var(--bd-bg)]"
+    >
+      {skipLabel}
+    </a>
     <slot />
     <SearchDialog client:load searchPlaceholder={uiStrings?.searchPlaceholder} noResults={uiStrings?.noResults} searchIndexNotAvailable={uiStrings?.searchIndexNotAvailable} />
   </body>

--- a/packages/theme-docs/src/layouts/BlogLayout.astro
+++ b/packages/theme-docs/src/layouts/BlogLayout.astro
@@ -28,7 +28,11 @@ const t = uiStrings?.[currentLocale] ?? uiStrings?.[defaultLocale] ?? {};
   <Banner />
   <Header currentLocale={currentLocale} currentPath={currentPath} uiStrings={t} />
   
-  <div class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex justify-center">
+  <div
+    id="main-content"
+    tabindex="-1"
+    class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex justify-center outline-none"
+  >
     <article class="w-full max-w-[720px] px-4 py-10 sm:px-6 lg:px-8">
       <!-- Blog post header -->
       <header class="mb-10">

--- a/packages/theme-docs/src/layouts/DocsLayout.astro
+++ b/packages/theme-docs/src/layouts/DocsLayout.astro
@@ -40,9 +40,34 @@ interface Props {
   connectedIncoming?: PageLink[];
   /** Internal links that did not resolve (see graph.json) */
   brokenLinks?: { kind: string; raw: string }[];
+  /** Reader-trust badges from frontmatter (`since`, `deprecated`, `experimental`). */
+  docMeta?: {
+    since?: string;
+    deprecated?: boolean | string;
+    experimental?: boolean;
+  };
+  /** Resolved changelog link (site or page `changelogUrl`). */
+  changelogHref?: string | null;
 }
 
-const { title, description, headings = [], prevPage, nextPage, editUrl, lastUpdated, breadcrumbs = [], readingTime, filePath, sectionSlug, connectedOutgoing = [], connectedIncoming = [], brokenLinks = [] } = Astro.props;
+const {
+  title,
+  description,
+  headings = [],
+  prevPage,
+  nextPage,
+  editUrl,
+  lastUpdated,
+  breadcrumbs = [],
+  readingTime,
+  filePath,
+  sectionSlug,
+  connectedOutgoing = [],
+  connectedIncoming = [],
+  brokenLinks = [],
+  docMeta,
+  changelogHref = null,
+} = Astro.props;
 const currentPath = Astro.url.pathname;
 
 const i18nConfig = { defaultLocale, locales };
@@ -52,6 +77,30 @@ const dir = dirByLocale[currentLocale] ?? dirByLocale[defaultLocale] ?? "ltr";
 
 const hasFeedback = config.feedback?.enabled === true;
 const feedbackEndpoint = config.feedback?.endpoint;
+const feedbackIssueUrl = config.feedback?.issueUrl;
+
+const hasDocMetaRow =
+  docMeta &&
+  (docMeta.since ||
+    docMeta.experimental === true ||
+    (docMeta.deprecated !== undefined && docMeta.deprecated !== false));
+
+function buildIssueUrl(base: string, pageTitle: string): string {
+  try {
+    const u = new URL(base);
+    if (!u.searchParams.has("title")) {
+      u.searchParams.set("title", `[docs] ${pageTitle}`);
+    }
+    return u.toString();
+  } catch {
+    return base;
+  }
+}
+
+const feedbackIssueHref =
+  feedbackIssueUrl && hasFeedback ? buildIssueUrl(feedbackIssueUrl, title) : null;
+
+const tocHeadings = headings.filter((h) => h.depth >= 2 && h.depth <= 4);
 ---
 
 <BaseLayout title={title} description={description} dir={dir} lang={currentLocale} uiStrings={t}>
@@ -69,7 +118,7 @@ const feedbackEndpoint = config.feedback?.endpoint;
       </aside>
 
       <!-- Main Content: flex-1 uses full space between sidebar and TOC; inner wrapper caps width and centers -->
-      <main class="flex-1 min-w-0 flex justify-center">
+      <main id="main-content" tabindex="-1" class="flex-1 min-w-0 flex justify-center outline-none">
         <div class="w-full max-w-[768px] px-4 py-8 sm:px-6 sm:py-10 lg:px-10 lg:py-10">
           {breadcrumbs.length > 0 && <Breadcrumb items={breadcrumbs} sectionSlug={sectionSlug} />}
           {readingTime && (
@@ -80,7 +129,32 @@ const feedbackEndpoint = config.feedback?.endpoint;
               <span>{readingTime}</span>
             </div>
           )}
-          <article class="prose prose-gray dark:prose-invert max-w-none min-w-0 overflow-x-auto">
+          {hasDocMetaRow && (
+            <div class="not-prose flex flex-wrap items-center gap-2 mb-4" aria-label="page status">
+              {docMeta!.since && (
+                <span class="inline-flex items-center rounded-md border border-primary-200 bg-primary-50 px-2 py-0.5 text-xs font-medium text-primary-800 dark:border-primary-800/40 dark:bg-primary-950/40 dark:text-primary-200">
+                  {t.sinceVersion ?? "Since"} {docMeta!.since}
+                </span>
+              )}
+              {docMeta!.experimental === true && (
+                <span class="inline-flex items-center rounded-md border border-violet-200 bg-violet-50 px-2 py-0.5 text-xs font-medium text-violet-900 dark:border-violet-800/40 dark:bg-violet-950/40 dark:text-violet-200">
+                  {t.experimental ?? "Experimental"}
+                </span>
+              )}
+              {docMeta!.deprecated !== undefined && docMeta!.deprecated !== false && (
+                <span class="inline-flex items-center rounded-md border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-950 dark:border-amber-800/50 dark:bg-amber-950/30 dark:text-amber-100">
+                  {t.deprecated ?? "Deprecated"}
+                  {typeof docMeta!.deprecated === "string"
+                    ? `: ${docMeta!.deprecated}`
+                    : ""}
+                </span>
+              )}
+            </div>
+          )}
+          <article
+            class="prose prose-gray dark:prose-invert max-w-none min-w-0 overflow-x-auto"
+            data-copy-section-label={t.copySectionLink ?? "Copy link to section"}
+          >
             <slot />
           </article>
 
@@ -178,13 +252,23 @@ const feedbackEndpoint = config.feedback?.endpoint;
           <footer class="mt-8 pt-6 border-t border-[var(--bd-border-subtle)] flex flex-col gap-3">
             {filePath && <Contributors filePath={filePath} />}
             <div class="flex flex-wrap items-center justify-between gap-2 text-[13px] text-[var(--bd-text-muted)]">
-              {lastUpdated && (
-                <span>
-                  {t.lastUpdated ?? "Last updated"}: <time datetime={lastUpdated.toISOString()}>
-                    {lastUpdated.toLocaleDateString(currentLocale, { year: "numeric", month: "short", day: "numeric" })}
-                  </time>
-                </span>
-              )}
+              <div class="flex flex-wrap items-center gap-x-4 gap-y-1">
+                {lastUpdated && (
+                  <span>
+                    {t.lastUpdated ?? "Last updated"}: <time datetime={lastUpdated.toISOString()}>
+                      {lastUpdated.toLocaleDateString(currentLocale, { year: "numeric", month: "short", day: "numeric" })}
+                    </time>
+                  </span>
+                )}
+                {changelogHref && (
+                  <a
+                    href={changelogHref}
+                    class="inline-flex items-center gap-1.5 text-[var(--bd-text-secondary)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+                  >
+                    {t.viewChangelog ?? "Changelog"}
+                  </a>
+                )}
+              </div>
               {editUrl && (
                 <a
                   href={editUrl}
@@ -200,7 +284,11 @@ const feedbackEndpoint = config.feedback?.endpoint;
               )}
             </div>
             {hasFeedback && (
-              <div class="doc-feedback flex items-center gap-3 text-sm text-[var(--bd-text-muted)]" data-endpoint={feedbackEndpoint}>
+              <div
+                class="doc-feedback flex flex-wrap items-center gap-3 text-sm text-[var(--bd-text-muted)]"
+                data-endpoint={feedbackEndpoint}
+                data-thanks={t.feedbackThanks ?? "Thanks!"}
+              >
                 <span>{t.wasThisHelpful ?? "Was this helpful?"}</span>
                 <button type="button" class="feedback-btn inline-flex items-center gap-1 px-2 py-1 rounded border border-[var(--bd-border)] hover:bg-[var(--bd-bg-subtle)] transition-colors" data-value="yes" aria-label={t.yes ?? "Yes"}>
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 9V5a3 3 0 00-3-3l-4 9v11h11.28a2 2 0 002-1.7l1.38-9a2 2 0 00-2-2.3H14z" /></svg>
@@ -208,7 +296,17 @@ const feedbackEndpoint = config.feedback?.endpoint;
                 <button type="button" class="feedback-btn inline-flex items-center gap-1 px-2 py-1 rounded border border-[var(--bd-border)] hover:bg-[var(--bd-bg-subtle)] transition-colors" data-value="no" aria-label={t.no ?? "No"}>
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 15v3.586a1 1 0 01-.293.707l-2 2A1 1 0 016 20.586V15m4 0h5.17a2 2 0 001.98-1.742l1.08-7.56A1 1 0 0017.242 4.5H10m0 10.5V4.5m0 0H7.5A2.5 2.5 0 005 7v3" /></svg>
                 </button>
-                <span class="feedback-thanks hidden text-green-600 dark:text-green-400">Thanks for your feedback!</span>
+                {feedbackIssueHref && (
+                  <a
+                    href={feedbackIssueHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="feedback-issue inline-flex items-center gap-1 text-[var(--bd-text-secondary)] hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+                  >
+                    {t.reportIssue ?? "Report an issue"}
+                  </a>
+                )}
+                <span class="feedback-thanks hidden text-green-600 dark:text-green-400" />
               </div>
             )}
           </footer>
@@ -216,7 +314,7 @@ const feedbackEndpoint = config.feedback?.endpoint;
       </main>
 
       <!-- Table of Contents -->
-      {headings.length > 0 && (
+      {tocHeadings.length > 0 && (
         <aside class="hidden xl:block w-[220px] shrink-0">
           <div class="sticky top-14 h-[calc(100vh-3.5rem)] overflow-y-auto py-10 pl-8">
             <TableOfContents headings={headings} onThisPageLabel={t.onThisPage ?? "On this page"} />
@@ -248,17 +346,39 @@ const feedbackEndpoint = config.feedback?.endpoint;
     document.addEventListener('astro:page-load', initImageZoom);
   </script>
 
-  <!-- Heading anchor links -->
+  <!-- Heading anchor + copy link to section -->
   <script>
     function initHeadingAnchors() {
+      const article = document.querySelector('article.prose[data-copy-section-label]');
+      const copyLabel = article?.getAttribute('data-copy-section-label') ?? 'Copy link to section';
       document.querySelectorAll('.prose h2[id], .prose h3[id], .prose h4[id]').forEach((heading) => {
-        if (heading.querySelector('.heading-anchor')) return;
+        if (heading.querySelector('.heading-anchor-wrap')) return;
+        const wrap = document.createElement('span');
+        wrap.className = 'heading-anchor-wrap';
         const anchor = document.createElement('a');
         anchor.className = 'heading-anchor';
         anchor.href = `#${heading.id}`;
         anchor.textContent = '#';
-        anchor.setAttribute('aria-label', `Link to ${heading.textContent}`);
-        heading.appendChild(anchor);
+        const ht = heading.textContent?.replace(/\s*#\s*$/, '').trim() ?? '';
+        anchor.setAttribute('aria-label', `Link to ${ht}`);
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'heading-copy-link';
+        btn.setAttribute('aria-label', copyLabel);
+        btn.title = copyLabel;
+        btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>';
+        btn.addEventListener('click', async (e) => {
+          e.preventDefault();
+          const url = `${window.location.origin}${window.location.pathname}#${heading.id}`;
+          try {
+            await navigator.clipboard.writeText(url);
+            btn.classList.add('heading-copy-done');
+            setTimeout(() => btn.classList.remove('heading-copy-done'), 1500);
+          } catch { /* ignore */ }
+        });
+        wrap.appendChild(anchor);
+        wrap.appendChild(btn);
+        heading.appendChild(wrap);
       });
     }
     initHeadingAnchors();
@@ -278,7 +398,11 @@ const feedbackEndpoint = config.feedback?.endpoint;
               const value = btn.getAttribute('data-value');
               const page = window.location.pathname;
               el.querySelectorAll('.feedback-btn').forEach((b: any) => b.disabled = true);
-              if (thanks) thanks.classList.remove('hidden');
+              if (thanks) {
+                const msg = el.getAttribute('data-thanks');
+                if (msg) thanks.textContent = msg;
+                thanks.classList.remove('hidden');
+              }
               if (endpoint) {
                 try { await fetch(endpoint, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ page, value }) }); } catch {}
               }

--- a/packages/theme-docs/src/layouts/LandingLayout.astro
+++ b/packages/theme-docs/src/layouts/LandingLayout.astro
@@ -7,7 +7,7 @@ import BaseLayout from "./BaseLayout.astro";
 import Header from "../components/Header.astro";
 import Banner from "../components/Banner.astro";
 import CodeCopy from "../components/CodeCopy.astro";
-import { defaultLocale } from "virtual:barodoc/i18n";
+import { defaultLocale, locales, uiStrings } from "virtual:barodoc/i18n";
 import { getLocaleFromPath } from "@barodoc/core";
 
 interface Props {
@@ -17,16 +17,17 @@ interface Props {
 
 const { title, description } = Astro.props;
 const currentPath = Astro.url.pathname;
-const i18nConfig = { defaultLocale, locales: [defaultLocale] };
+const i18nConfig = { defaultLocale, locales: locales ?? [defaultLocale] };
 const currentLocale = getLocaleFromPath(currentPath, i18nConfig);
+const t = uiStrings[currentLocale] ?? uiStrings[defaultLocale] ?? {};
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout title={title} description={description} uiStrings={t}>
   <Banner />
   <Header currentLocale={currentLocale} currentPath={currentPath} />
 
   <div class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex flex-col">
-    <main class="w-full flex-1">
+    <main id="main-content" tabindex="-1" class="w-full flex-1 outline-none">
       <slot />
     </main>
     <CodeCopy />

--- a/packages/theme-docs/src/layouts/PageLayout.astro
+++ b/packages/theme-docs/src/layouts/PageLayout.astro
@@ -3,7 +3,7 @@ import BaseLayout from "./BaseLayout.astro";
 import Header from "../components/Header.astro";
 import Banner from "../components/Banner.astro";
 import CodeCopy from "../components/CodeCopy.astro";
-import { defaultLocale } from "virtual:barodoc/i18n";
+import { defaultLocale, locales, uiStrings } from "virtual:barodoc/i18n";
 import { getLocaleFromPath } from "@barodoc/core";
 
 interface Props {
@@ -13,15 +13,20 @@ interface Props {
 
 const { title, description } = Astro.props;
 const currentPath = Astro.url.pathname;
-const i18nConfig = { defaultLocale, locales: [defaultLocale] };
+const i18nConfig = { defaultLocale, locales: locales ?? [defaultLocale] };
 const currentLocale = getLocaleFromPath(currentPath, i18nConfig);
+const t = uiStrings[currentLocale] ?? uiStrings[defaultLocale] ?? {};
 ---
 
-<BaseLayout title={title} description={description}>
+<BaseLayout title={title} description={description} uiStrings={t}>
   <Banner />
   <Header currentLocale={currentLocale} currentPath={currentPath} />
 
-  <div class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex justify-center">
+  <div
+    id="main-content"
+    tabindex="-1"
+    class="w-full min-w-0 min-h-[calc(100vh-3.5rem)] flex justify-center outline-none"
+  >
     <article class="w-full max-w-[720px] px-4 py-10 sm:px-6 lg:px-8">
       <header class="mb-8">
         <h1 class="text-3xl sm:text-4xl font-bold tracking-tight text-[var(--bd-text-heading)] leading-tight">

--- a/packages/theme-docs/src/pages/section/[...slug].astro
+++ b/packages/theme-docs/src/pages/section/[...slug].astro
@@ -291,6 +291,37 @@ breadcrumbs.push({ label: pageTitle });
 const assetUrl = isAsset
   ? `/_content/${sectionSlug}/${assetEntry!.relPath}`
   : "";
+
+function resolveChangelogHref(
+  pageOverride: string | undefined,
+  siteChangelog: string | undefined,
+  site: string | undefined,
+): string | null {
+  const raw = pageOverride ?? siteChangelog;
+  if (!raw) return null;
+  if (/^https?:\/\//i.test(raw)) return raw;
+  if (site) {
+    const base = site.replace(/\/$/, "");
+    return `${base}${raw.startsWith("/") ? raw : `/${raw}`}`;
+  }
+  return raw.startsWith("/") ? raw : `/${raw}`;
+}
+
+const fm = !isAsset ? (doc.data as Record<string, unknown>) : null;
+const docMeta = fm
+  ? {
+      since: fm.since as string | undefined,
+      deprecated: fm.deprecated as boolean | string | undefined,
+      experimental: fm.experimental as boolean | undefined,
+    }
+  : undefined;
+const changelogHref = fm
+  ? resolveChangelogHref(
+      fm.changelogUrl as string | undefined,
+      config.changelogUrl,
+      config.site,
+    )
+  : null;
 ---
 
 <DocsLayout
@@ -305,10 +336,11 @@ const assetUrl = isAsset
   readingTime={readTime.text || undefined}
   filePath={isAsset ? undefined : `src/content/${sectionSlug}/${doc.id}`}
   sectionSlug={sectionSlug}
-  fullWidth={isAsset}
   connectedOutgoing={isAsset ? [] : connectedOutgoing}
   connectedIncoming={isAsset ? [] : connectedIncoming}
   brokenLinks={isAsset ? [] : brokenOnPage}
+  docMeta={docMeta}
+  changelogHref={changelogHref}
 >
   {isAsset ? (
     <div class="asset-viewer-wrapper">

--- a/packages/theme-docs/src/styles/global.css
+++ b/packages/theme-docs/src/styles/global.css
@@ -317,21 +317,51 @@
   scroll-margin-top: 5rem;
 }
 
-.prose :where(h2, h3, h4)[id] > a.heading-anchor {
-  color: var(--color-primary-400);
-  opacity: 0;
+.prose :where(h2, h3, h4)[id] > .heading-anchor-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15em;
   margin-left: 0.25em;
+  opacity: 0;
+  transition: opacity 150ms ease;
+  vertical-align: middle;
+}
+
+.prose :where(h2, h3, h4)[id]:hover > .heading-anchor-wrap {
+  opacity: 1;
+}
+
+.prose :where(h2, h3, h4)[id] > .heading-anchor-wrap > a.heading-anchor {
+  color: var(--color-primary-400);
   font-weight: 400;
   text-decoration: none !important;
-  transition: opacity 150ms ease;
 }
 
-.prose :where(h2, h3, h4)[id]:hover > a.heading-anchor {
-  opacity: 0.7;
-}
-
-.prose :where(h2, h3, h4)[id] > a.heading-anchor:hover {
+.prose :where(h2, h3, h4)[id] > .heading-anchor-wrap > a.heading-anchor:hover {
   opacity: 1;
+}
+
+.prose :where(h2, h3, h4)[id] > .heading-anchor-wrap > .heading-copy-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.1rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: var(--color-primary-500);
+  border-radius: 0.25rem;
+  opacity: 0.75;
+}
+
+.prose :where(h2, h3, h4)[id] > .heading-anchor-wrap > .heading-copy-link:hover,
+.prose :where(h2, h3, h4)[id] > .heading-anchor-wrap > .heading-copy-link.heading-copy-done {
+  opacity: 1;
+  color: var(--color-primary-600);
+}
+
+:global(.dark) .prose :where(h2, h3, h4)[id] > .heading-anchor-wrap > .heading-copy-link {
+  color: var(--color-primary-400);
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary

- **Accessibility**: Skip to `#main-content`, landmark ids on docs/pages/blog/landing.
- **TOC**: h2–h4 in sidebar; scroll-based active item; avoid duplicate listeners.
- **Trust**: Frontmatter `since`, `deprecated`, `experimental`, `changelogUrl`; site `changelogUrl`; footer changelog link.
- **Feedback**: i18n thanks; optional `feedback.issueUrl` with title prefilled.
- **Headings**: copy full section URL beside `#` anchor.

## Release

- Changeset + `docs/src/content/changelog/v10.0.8.mdx`

Fixes #153

Made with [Cursor](https://cursor.com)