### PR TITLE
fix(cli): isolated quick-mode npm install, tests, and docs

### DIFF
--- a/.changeset/quick-mode-isolated-install.md
+++ b/.changeset/quick-mode-isolated-install.md
@@ -1,0 +1,5 @@
+---
+"barodoc": patch
+---
+
+Quick mode: isolated `npm install` under `.barodoc/` (no symlink to monorepo root `node_modules`); monorepo `@barodoc/*` via `npm pack` with workspace-to-semver rewrite; dependency hash cache; file-based `astro.config.mjs`; `scheduler` for React; Vitest for `project.ts` helpers.

--- a/.cursor/skills/barodoc-cli/SKILL.md
+++ b/.cursor/skills/barodoc-cli/SKILL.md
@@ -17,6 +17,11 @@ npm install -g barodoc
 npx barodoc serve
 ```
 
+## Quick mode vs full Astro project
+
+- **Quick mode:** a folder with Markdown and `barodoc.config.json` only (no `astro.config.mjs`). The CLI uses **`<dir>/.barodoc/`** as the Astro app root, runs **`npm install`** there on first run or when the dependency set changes, then starts `astro dev` / `astro build`. You need **npm** on `PATH` and network access for that install.
+- **Full project:** the directory contains `astro.config.mjs` — Barodoc runs Astro against that project directly without the `.barodoc/` temp layout.
+
 ## Commands
 
 ### serve - Development Server

--- a/.cursor/skills/barodoc-dev/SKILL.md
+++ b/.cursor/skills/barodoc-dev/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: barodoc-dev
+description: Barodoc monorepo development and testing workflow. Use whenever working on the barodoc repo — building packages, running the docs site or my-docs, testing plugins, or type-checking. Prefer this skill when the user says they're developing barodoc, testing locally, debugging the docs site, or verifying plugin behavior in docs or my-docs.
+---
+
+# Barodoc Development & Testing
+
+This skill covers how to build, run, and verify the Barodoc monorepo and plugins locally. For CLI usage in end-user projects, see **barodoc-cli**. For config and plugins, see **barodoc-config** and **barodoc-plugins**.
+
+## Prerequisites (run first)
+
+From the **barodoc** repo root:
+
+```bash
+pnpm install
+pnpm build:packages
+```
+
+`build:packages` builds core, theme-docs, barodoc CLI, and all plugins. Run it after changing any package, then test.
+
+---
+
+## 1. Testing with the docs site
+
+The **docs** workspace is a full Astro project. Use it to test the framework and plugins in custom mode.
+
+| Goal | Command |
+|------|---------|
+| Dev server | `pnpm dev` (port 4321 or next available) |
+| Production build | `pnpm build` (output in `docs/dist`) |
+| Build + preview (full behavior) | `pnpm build:packages && pnpm build && pnpm preview` |
+
+**Why build + preview:** In the monorepo, `pnpm dev` can fail to load theme-docs React islands (e.g. mobile menu) due to dev-only `/@fs/` handling. For full navigation and mobile menu, use build then preview.
+
+**Config:** `docs/barodoc.config.json`. To test a plugin, add it to the `plugins` array.
+
+**Type-check (all packages):** Run after `astro sync` so content types exist:
+
+```bash
+pnpm --filter docs exec astro sync
+pnpm -r exec tsc --noEmit
+```
+
+---
+
+## 2. Testing with my-docs (quick mode)
+
+**my-docs** is a separate project (e.g. sibling `barocss/my-docs`) with only Markdown and `barodoc.config.json`. The CLI runs in quick mode via a project under `my-docs/.barodoc/`: it runs **`npm install`** there (isolated `package.json`, not a symlink to the monorepo root `node_modules`). From the Barodoc repo, `@barodoc/*` deps are installed via **`npm pack`** tarballs with `workspace:*` rewritten to semver. First run needs **npm** on `PATH` and network; see **AGENTS.md** for details.
+
+### From the barodoc repo
+
+```bash
+cd barodoc
+pnpm build:packages
+pnpm barodoc serve ../my-docs
+pnpm barodoc build ../my-docs -o ../my-docs/dist
+pnpm barodoc preview ../my-docs   # optional: preview production build
+```
+
+### From the my-docs directory (no install in my-docs)
+
+```bash
+cd my-docs
+node ../barodoc/packages/barodoc/dist/cli.js serve
+node ../barodoc/packages/barodoc/dist/cli.js build . -o dist
+```
+
+**Plugin in my-docs:** Add to `my-docs/barodoc.config.json` → `plugins`. Serve/build from barodoc CLI; extra `@barodoc/*` plugins are merged into the temp `package.json` and resolved like other workspace packages when running from the monorepo.
+
+**Quick-mode unit tests:** `pnpm test` runs Vitest including `packages/barodoc/src/runtime/project.test.ts` (dependency manifest, monorepo root detection, `generateAstroConfigFile` snippet).
+
+---
+
+## 3. Plugin development
+
+- **Location:** `packages/plugin-<name>/` (e.g. `plugin-raw-md`, `plugin-rss`).
+- **Build:** `pnpm --filter @barodoc/plugin-<name> build` then `pnpm --filter barodoc build`.
+
+**Test in docs:** Add plugin to `docs/barodoc.config.json`, run `pnpm dev` (or build+preview) and verify.
+
+**Test in my-docs:** Add plugin to `my-docs/barodoc.config.json`, run `pnpm barodoc serve ../my-docs` and `pnpm barodoc build ../my-docs -o ../my-docs/dist`; confirm dev and build both work.
+
+**Asset content (PDF, RST, etc.):** Put files in the docs content tree (e.g. `docs/src/content/docs/en/`), add slug to `barodoc.config.json` → navigation `pages`, then open the asset URL (e.g. `/docs/guide` for `guide.pdf`).
+
+---
+
+## Quick reference
+
+| Goal | Command / location |
+|------|--------------------|
+| Build all packages | `pnpm build:packages` |
+| Dev server (docs) | `pnpm dev` |
+| Full behavior (docs) | `pnpm build:packages && pnpm build && pnpm preview` |
+| Serve my-docs from repo | `pnpm barodoc serve ../my-docs` |
+| Build my-docs from repo | `pnpm barodoc build ../my-docs -o ../my-docs/dist` |
+| Type-check | `pnpm --filter docs exec astro sync` then `pnpm -r exec tsc --noEmit` |
+| Unit tests (incl. quick mode manifest) | `pnpm test` |
+| Plugin config (docs) | `docs/barodoc.config.json` → `plugins` |
+| Plugin config (my-docs) | `my-docs/barodoc.config.json` → `plugins` |
+
+For more detail (asset viewers, deploy, ECC setup), see **DEVELOPMENT.md** in the repo.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,11 @@ Barodoc supports two modes:
 
 ### Quick Mode (Zero Config)
 - Users only need MD files and optional `barodoc.config.json`
-- CLI creates temporary Astro project on-the-fly
-- No `package.json` or `node_modules` needed
+- CLI creates a temporary Astro project under **`<project>/.barodoc/`** and runs Astro from there
+- **Isolated install:** quick mode writes a dedicated `package.json` in `.barodoc/` and runs **`npm install`** there (not a symlink to the CLI or monorepo root `node_modules`), so dependency resolution matches a normal project and avoids hoisted dev-tooling conflicts
+- **Monorepo dev:** when the CLI runs from the Barodoc repo, `@barodoc/*` packages are installed via **`npm pack`** tarballs (with `workspace:*` rewritten to semver inside the pack) so Astro 5 builds stay inside `.barodoc/` without broken path joins
+- **Cache:** `.barodoc-deps-hash` plus workspace package versions decide when to reinstall; `src/`, `public`, and `overrides` are refreshed each run
+- **Requirements:** **npm** (on `PATH`) and network on first install or after dependency changes; local npm caches live under `.barodoc/.npm-cache` and `.barodoc/.npm-pack-cache`
 
 ### Full Custom Mode
 - Users have full Astro project with `astro.config.mjs`
@@ -182,6 +185,7 @@ export default definePlugin<Options>((options) => ({
 | `pnpm build:packages` | Build all packages |
 | `pnpm changeset` | Create changeset |
 | `pnpm release` | Publish to npm |
+| `pnpm test` | Vitest (includes `packages/barodoc/src/runtime/project.test.ts` for quick-mode helpers) |
 
 ## Development and testing
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,7 +69,13 @@ The public docs site (e.g. [barodoc.barocss.com](https://barodoc.barocss.com)) i
 
 ## 2. Testing with my-docs (quick mode)
 
-**my-docs** is a separate project (e.g. sibling of barodoc: `barocss/my-docs`) that has only Markdown and `barodoc.config.json` (no `package.json` or Astro setup). The Barodoc CLI runs in “quick mode”: it creates a temporary project under `my-docs/.barodoc/` and runs Astro from there.
+**my-docs** is a separate project (e.g. sibling of barodoc: `barocss/my-docs`) that has only Markdown and `barodoc.config.json` (no `package.json` or Astro setup). The Barodoc CLI runs in “quick mode”: it maintains a temporary project under `my-docs/.barodoc/` and runs Astro from there.
+
+### How `.barodoc/` dependencies work
+
+- Quick mode writes **`package.json`** inside `.barodoc/` and runs **`npm install`** there (with `--legacy-peer-deps` and a project-local npm cache). It does **not** symlink the monorepo root `node_modules` into `.barodoc/`, so installs stay isolated from unrelated hoisted tooling.
+- When you run the CLI **from the Barodoc monorepo**, `@barodoc/*` packages are packed with **`npm pack`** into `.barodoc/.barodoc-packs/`; staged `package.json` files rewrite `workspace:*` to semver so `npm install` succeeds. First run (or after dependency / version changes) needs **network** and **npm** on `PATH`.
+- **`.barodoc-deps-hash`** tracks when to reuse `node_modules`; `src/`, `public`, and `overrides` are regenerated each serve/build. Users can add `.barodoc/` to `.gitignore` (Barodoc scaffolds often do).
 
 ### Prerequisites
 

--- a/docs/src/content/changelog/v10.0.10.mdx
+++ b/docs/src/content/changelog/v10.0.10.mdx
@@ -1,0 +1,15 @@
+---
+version: "10.0.10"
+date: 2026-03-26
+title: "Quick mode isolated install and Astro config"
+---
+
+### CLI (`barodoc`)
+
+- **Quick mode** — `.barodoc/` now uses its own `package.json` and **`npm install`** (not a symlink to the monorepo root `node_modules`), with a dependency hash cache and project-local npm caches.
+- **Monorepo** — `@barodoc/*` workspace packages are installed via **`npm pack`** tarballs; staged manifests rewrite `workspace:*` to semver so installs succeed.
+- **Astro** — quick mode continues to use a generated `astro.config.mjs` (Vite options aligned with the docs app); `scheduler` remains a direct dependency for the React runtime chain.
+
+### Contributors
+
+- Vitest coverage for quick-mode dependency resolution in `packages/barodoc/src/runtime/project.test.ts`.

--- a/packages/barodoc/package.json
+++ b/packages/barodoc/package.json
@@ -46,6 +46,7 @@
     "picocolors": "^1.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "scheduler": "^0.27.0",
     "rst-compiler": "^0.5.7",
     "tailwindcss": "^4.0.0",
     "zod": "^3.24.0",

--- a/packages/barodoc/src/commands/build.ts
+++ b/packages/barodoc/src/commands/build.ts
@@ -3,8 +3,6 @@ import pc from "picocolors";
 import fs from "fs-extra";
 import { execa } from "execa";
 import { build as astroBuild } from "astro";
-import barodoc from "@barodoc/core";
-import docsTheme from "@barodoc/theme-docs/theme";
 import {
   isCustomProject,
   loadProjectConfig,
@@ -57,26 +55,11 @@ export async function build(dir: string, options: BuildOptions): Promise<void> {
   try {
     console.log(pc.dim("Building site..."));
 
+    // Load integrations and Vite options from generated astro.config.mjs (same as full
+    // projects). Programmatic inline config breaks Astro 5 static generation (astro: URLs in workers).
     await astroBuild({
       root: projectDir,
-      configFile: false,
-      integrations: [
-        barodoc({
-          config: "./barodoc.config.json",
-          theme: docsTheme(),
-        }),
-      ],
-      vite: {
-        resolve: {
-          preserveSymlinks: true,
-        },
-        ssr: {
-          noExternal: true,
-        },
-      },
       logLevel: "info",
-      ...(config.site ? { site: config.site } : {}),
-      ...(config.base ? { base: config.base } : {}),
     });
 
     console.log();

--- a/packages/barodoc/src/commands/serve.ts
+++ b/packages/barodoc/src/commands/serve.ts
@@ -1,8 +1,6 @@
 import path from "path";
 import pc from "picocolors";
 import { dev } from "astro";
-import barodoc from "@barodoc/core";
-import docsTheme from "@barodoc/theme-docs/theme";
 import {
   isCustomProject,
   loadProjectConfig,
@@ -59,28 +57,11 @@ export async function serve(dir: string, options: ServeOptions): Promise<void> {
 
   const devServer = await dev({
     root: projectDir,
-    configFile: false,
-    integrations: [
-      barodoc({
-        config: "./barodoc.config.json",
-        theme: docsTheme(),
-      }),
-    ],
-    vite: {
-      resolve: {
-        preserveSymlinks: true,
-      },
-      ssr: {
-        noExternal: [/^@barodoc\//],
-      },
-    },
     server: {
       port: options.port,
       host: options.host ? true : undefined,
       open: options.open,
     },
-    ...(config.site ? { site: config.site } : {}),
-    ...(config.base ? { base: config.base } : {}),
   });
 
   process.on("SIGINT", async () => {

--- a/packages/barodoc/src/runtime/project.test.ts
+++ b/packages/barodoc/src/runtime/project.test.ts
@@ -1,0 +1,130 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "path";
+import { fileURLToPath } from "url";
+import fs from "fs-extra";
+import { describe, expect, it } from "vitest";
+import {
+  findMonorepoRoot,
+  findDocsDir,
+  generateAstroConfigFile,
+  getDefaultConfig,
+  hashQuickModeDeps,
+  isCustomProject,
+  resolveTempPackageJsonSync,
+} from "./project.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+/** `packages/barodoc` (runtime/ is one level below package root). */
+const barodocPkgRoot = path.join(__dirname, "..", "..");
+
+describe("quick mode package manifest", () => {
+  it("findMonorepoRoot detects barodoc repo when run from packages/barodoc", () => {
+    const root = findMonorepoRoot(barodocPkgRoot);
+    expect(root).not.toBeNull();
+    expect(fs.existsSync(path.join(root!, "pnpm-workspace.yaml"))).toBe(true);
+    expect(
+      fs.existsSync(path.join(root!, "packages", "barodoc", "package.json"))
+    ).toBe(true);
+  });
+
+  it("findMonorepoRoot returns null outside a monorepo layout", () => {
+    expect(findMonorepoRoot("/tmp")).toBeNull();
+  });
+
+  it("resolveTempPackageJsonSync omits CLI-only deps and includes astro", () => {
+    const myDocs = mkdtempSync(path.join(tmpdir(), "barodoc-manifest-"));
+    const projectDir = path.join(myDocs, ".barodoc");
+    fs.mkdirSync(projectDir, { recursive: true });
+    try {
+      const monorepoRoot = findMonorepoRoot(barodocPkgRoot);
+      const pkg = resolveTempPackageJsonSync(
+        projectDir,
+        getDefaultConfig(),
+        barodocPkgRoot,
+        monorepoRoot
+      );
+      expect(pkg.dependencies).not.toHaveProperty("cac");
+      expect(pkg.dependencies).not.toHaveProperty("execa");
+      expect(pkg.dependencies).not.toHaveProperty("chokidar");
+      expect(pkg.dependencies).not.toHaveProperty("fs-extra");
+      expect(pkg.dependencies).not.toHaveProperty("picocolors");
+      expect(pkg.dependencies.astro).toBeDefined();
+      expect(pkg.dependencies["@barodoc/core"]).toBeDefined();
+    } finally {
+      rmSync(myDocs, { recursive: true, force: true });
+    }
+  });
+
+  it("resolveTempPackageJsonSync adds config plugins not in the CLI package.json", () => {
+    const myDocs = mkdtempSync(path.join(tmpdir(), "barodoc-plugins-"));
+    const projectDir = path.join(myDocs, ".barodoc");
+    fs.mkdirSync(projectDir, { recursive: true });
+    try {
+      const monorepoRoot = findMonorepoRoot(barodocPkgRoot);
+      const pkg = resolveTempPackageJsonSync(
+        projectDir,
+        {
+          ...getDefaultConfig(),
+          plugins: ["@barodoc/plugin-raw-md"],
+        },
+        barodocPkgRoot,
+        monorepoRoot
+      );
+      expect(pkg.dependencies["@barodoc/plugin-raw-md"]).toBeDefined();
+    } finally {
+      rmSync(myDocs, { recursive: true, force: true });
+    }
+  });
+
+  it("hashQuickModeDeps is stable and 64-char hex for the same inputs", () => {
+    const myDocs = mkdtempSync(path.join(tmpdir(), "barodoc-hash-"));
+    const projectDir = path.join(myDocs, ".barodoc");
+    fs.mkdirSync(projectDir, { recursive: true });
+    try {
+      const monorepoRoot = findMonorepoRoot(barodocPkgRoot);
+      const pkg = resolveTempPackageJsonSync(
+        projectDir,
+        getDefaultConfig(),
+        barodocPkgRoot,
+        monorepoRoot
+      );
+      const a = hashQuickModeDeps(pkg, monorepoRoot);
+      const b = hashQuickModeDeps(pkg, monorepoRoot);
+      expect(a).toBe(b);
+      expect(a).toMatch(/^[a-f0-9]{64}$/);
+    } finally {
+      rmSync(myDocs, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("generateAstroConfigFile", () => {
+  it("sets preserveSymlinks false for quick/eject template", () => {
+    const s = generateAstroConfigFile(getDefaultConfig());
+    expect(s).toContain("preserveSymlinks: false");
+  });
+});
+
+describe("findDocsDir", () => {
+  it("prefers docs when present", () => {
+    const d = mkdtempSync(path.join(tmpdir(), "barodoc-docsdir-"));
+    fs.mkdirSync(path.join(d, "docs"), { recursive: true });
+    try {
+      expect(findDocsDir(d)).toBe("docs");
+    } finally {
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("isCustomProject", () => {
+  it("is false without astro.config", () => {
+    const d = mkdtempSync(path.join(tmpdir(), "barodoc-custom-"));
+    try {
+      expect(isCustomProject(d)).toBe(false);
+    } finally {
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/barodoc/src/runtime/project.ts
+++ b/packages/barodoc/src/runtime/project.ts
@@ -1,37 +1,300 @@
+import crypto from "node:crypto";
+import { createRequire } from "node:module";
 import fs from "fs-extra";
 import path from "path";
 import { fileURLToPath } from "url";
+import { execa } from "execa";
 import pc from "picocolors";
 import type { BarodocConfig } from "@barodoc/core";
 
 const BARODOC_DIR = ".barodoc";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-/**
- * Walk up from the CLI's dist directory to find the best node_modules
- * for Astro's module resolution. Prefers the highest ancestor that
- * has all transitive deps (e.g. monorepo root). Works with npm, pnpm, npx.
- */
-function findCliNodeModules(): string {
-  let best: string | null = null;
-  let dir = __dirname;
+/** CLI-only deps (not needed inside the Astro temp project). */
+const EXCLUDE_FROM_TEMP = new Set([
+  "cac",
+  "execa",
+  "chokidar",
+  "fs-extra",
+  "picocolors",
+]);
+
+function findMonorepoRoot(barodocPkgRoot: string): string | null {
+  let dir = barodocPkgRoot;
   while (dir !== path.parse(dir).root) {
-    const candidate = path.join(dir, "node_modules");
-    if (
-      fs.existsSync(candidate) &&
-      fs.existsSync(path.join(candidate, "@barodoc", "theme-docs"))
-    ) {
-      best = candidate;
+    const ws = path.join(dir, "pnpm-workspace.yaml");
+    const marker = path.join(dir, "packages", "barodoc", "package.json");
+    if (fs.existsSync(ws) && fs.existsSync(marker)) {
+      return dir;
     }
     dir = path.dirname(dir);
   }
-  if (!best) {
-    throw new Error(
-      "Could not locate node_modules for barodoc runtime dependencies"
+  return null;
+}
+
+function barodocMonorepoPackageDir(
+  monorepoRoot: string,
+  name: string
+): string | null {
+  if (!name.startsWith("@barodoc/")) return null;
+  const rest = name.slice("@barodoc/".length);
+  const abs = path.join(monorepoRoot, "packages", rest);
+  return fs.existsSync(path.join(abs, "package.json")) ? abs : null;
+}
+
+function toFileDep(projectDir: string, targetDir: string): string {
+  let rel = path.relative(projectDir, targetDir);
+  if (!rel.startsWith(".")) rel = `./${rel}`;
+  return `file:${rel.split(path.sep).join("/")}`;
+}
+
+function collectPluginNames(config: BarodocConfig): string[] {
+  const plugins = config.plugins ?? [];
+  const out: string[] = [];
+  for (const p of plugins) {
+    const name = Array.isArray(p) ? p[0] : p;
+    if (typeof name === "string") out.push(name);
+  }
+  return [...new Set(out)];
+}
+
+function resolveDepVersion(
+  name: string,
+  ver: string,
+  projectDir: string,
+  barodocPkgRoot: string,
+  monorepoRoot: string | null,
+  req: NodeJS.Require
+): string {
+  if (monorepoRoot) {
+    const pkgDir = barodocMonorepoPackageDir(monorepoRoot, name);
+    if (pkgDir) return toFileDep(projectDir, pkgDir);
+  }
+  if (ver.startsWith("workspace:")) {
+    try {
+      const resolved = path.dirname(
+        req.resolve(`${name}/package.json`, { paths: [barodocPkgRoot] })
+      );
+      return toFileDep(projectDir, resolved);
+    } catch {
+      throw new Error(
+        `Cannot resolve ${name} for quick mode. Install barodoc from npm or run from the Barodoc monorepo.`
+      );
+    }
+  }
+  return ver;
+}
+
+function resolveExtraPlugin(
+  name: string,
+  projectDir: string,
+  barodocPkgRoot: string,
+  monorepoRoot: string | null,
+  req: NodeJS.Require
+): string {
+  if (monorepoRoot) {
+    const pkgDir = barodocMonorepoPackageDir(monorepoRoot, name);
+    if (pkgDir) return toFileDep(projectDir, pkgDir);
+  }
+  if (name.startsWith("@barodoc/")) {
+    try {
+      const resolved = path.dirname(
+        req.resolve(`${name}/package.json`, { paths: [barodocPkgRoot] })
+      );
+      return toFileDep(projectDir, resolved);
+    } catch {
+      return "*";
+    }
+  }
+  return "*";
+}
+
+function resolveTempPackageJsonSync(
+  projectDir: string,
+  config: BarodocConfig,
+  barodocPkgRoot: string,
+  monorepoRoot: string | null
+): {
+  name: string;
+  private: boolean;
+  type: string;
+  dependencies: Record<string, string>;
+} {
+  const raw = fs.readJsonSync(path.join(barodocPkgRoot, "package.json")) as {
+    dependencies: Record<string, string>;
+  };
+  const req = createRequire(path.join(barodocPkgRoot, "package.json"));
+
+  const deps: Record<string, string> = {};
+
+  for (const [name, ver] of Object.entries(raw.dependencies)) {
+    if (EXCLUDE_FROM_TEMP.has(name)) continue;
+    deps[name] = resolveDepVersion(
+      name,
+      ver,
+      projectDir,
+      barodocPkgRoot,
+      monorepoRoot,
+      req
     );
   }
-  return best;
+
+  for (const pluginName of collectPluginNames(config)) {
+    if (deps[pluginName]) continue;
+    deps[pluginName] = resolveExtraPlugin(
+      pluginName,
+      projectDir,
+      barodocPkgRoot,
+      monorepoRoot,
+      req
+    );
+  }
+
+  return {
+    name: "barodoc-temp",
+    private: true,
+    type: "module",
+    dependencies: deps,
+  };
 }
+
+/**
+ * In the monorepo, `file:` directory deps point outside `.barodoc/`, which breaks
+ * Astro 5's compiler cache for virtual `?astro` CSS chunks. `npm pack` + `file:` `.tgz`
+ * installs real files under `node_modules/@barodoc/*`.
+ *
+ * Tarballs must not contain `workspace:*` (npm install fails). We stage a copy and
+ * replace workspace refs to sibling `@barodoc/*` with their **semver** from the
+ * monorepo so npm can satisfy them from the root `file:` entries.
+ */
+async function materializeWorkspacePackagesAsTarballs(
+  projectDir: string,
+  deps: Record<string, string>,
+  monorepoRoot: string
+): Promise<Record<string, string>> {
+  const packDir = path.join(projectDir, ".barodoc-packs");
+  const packNpmCache = path.join(projectDir, ".npm-pack-cache");
+  const stageRoot = path.join(packDir, ".stage");
+  await fs.remove(stageRoot).catch(() => {});
+  await fs.ensureDir(packDir);
+  await fs.ensureDir(packNpmCache);
+
+  const toPack: string[] = [];
+  for (const name of Object.keys(deps)) {
+    if (!name.startsWith("@barodoc/")) continue;
+    const spec = deps[name];
+    if (!spec.startsWith("file:")) continue;
+    const rel = spec.replace(/^file:/, "").replace(/^\.\//, "");
+    const absPath = path.resolve(projectDir, rel);
+    try {
+      const st = await fs.stat(absPath);
+      if (!st.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    if (!(await fs.pathExists(path.join(absPath, "package.json")))) continue;
+    toPack.push(name);
+  }
+
+  const tgzByPackage = new Map<string, string>();
+
+  for (const name of toPack) {
+    const spec = deps[name];
+    const rel = spec!.replace(/^file:/, "").replace(/^\.\//, "");
+    const srcDir = path.resolve(projectDir, rel);
+    const folder = name.slice("@barodoc/".length);
+    const stageDir = path.join(stageRoot, folder);
+    await fs.remove(stageDir).catch(() => {});
+    await fs.copy(srcDir, stageDir, {
+      filter: (p) => !p.split(path.sep).includes("node_modules"),
+      overwrite: true,
+    });
+
+    const pjPath = path.join(stageDir, "package.json");
+    const pj = (await fs.readJSON(pjPath)) as Record<string, unknown>;
+    for (const sect of [
+      "dependencies",
+      "peerDependencies",
+      "optionalDependencies",
+      "devDependencies",
+    ] as const) {
+      const o = pj[sect] as Record<string, string> | undefined;
+      if (!o) continue;
+      for (const [depName, depVer] of Object.entries(o)) {
+        if (!depName.startsWith("@barodoc/")) continue;
+        if (
+          depVer !== "workspace:*" &&
+          !String(depVer).startsWith("workspace:")
+        ) {
+          continue;
+        }
+        const depDir = barodocMonorepoPackageDir(monorepoRoot, depName);
+        if (!depDir) continue;
+        const ver = (
+          fs.readJsonSync(path.join(depDir, "package.json")) as {
+            version: string;
+          }
+        ).version;
+        o[depName] = ver;
+      }
+    }
+    await fs.writeJSON(pjPath, pj, { spaces: 2 });
+
+    const { stdout } = await execa(
+      "npm",
+      ["pack", "--pack-destination", packDir, "--cache", packNpmCache],
+      { cwd: stageDir }
+    );
+    const lines = stdout
+      .trim()
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(Boolean);
+    const tgz = lines[lines.length - 1];
+    if (!tgz) {
+      throw new Error(`npm pack produced no tarball for ${name}`);
+    }
+    tgzByPackage.set(name, tgz);
+  }
+
+  await fs.remove(stageRoot).catch(() => {});
+
+  const next = { ...deps };
+  for (const name of toPack) {
+    const tgz = tgzByPackage.get(name);
+    if (!tgz) continue;
+    const tgzAbs = path.join(packDir, tgz);
+    let relOut = path.relative(projectDir, tgzAbs);
+    if (!relOut.startsWith(".")) relOut = `./${relOut}`;
+    next[name] = `file:${relOut.split(path.sep).join("/")}`;
+  }
+  return next;
+}
+
+function hashQuickModeDeps(
+  pkgJson: { dependencies: Record<string, string> },
+  monorepoRoot: string | null
+): string {
+  const lines = Object.keys(pkgJson.dependencies)
+    .sort()
+    .map((k) => `${k}@${pkgJson.dependencies[k]}`);
+  const parts = [lines.join("\n")];
+  if (monorepoRoot) {
+    for (const name of Object.keys(pkgJson.dependencies)) {
+      if (!name.startsWith("@barodoc/")) continue;
+      const dir = barodocMonorepoPackageDir(monorepoRoot, name);
+      if (!dir) continue;
+      const pj = path.join(dir, "package.json");
+      if (!fs.existsSync(pj)) continue;
+      const v = fs.readJsonSync(pj) as { version?: string };
+      parts.push(`${name}:src@${v.version ?? "0.0.0"}`);
+    }
+  }
+  return crypto.createHash("sha256").update(parts.join("\n")).digest("hex");
+}
+
+/** Used by Vitest and tooling that mirrors quick-mode dependency resolution. */
+export { findMonorepoRoot, hashQuickModeDeps, resolveTempPackageJsonSync };
 
 export interface ProjectOptions {
   root: string;
@@ -95,8 +358,9 @@ export function getDefaultConfig(): BarodocConfig {
 
 /**
  * Create temporary Astro project for quick mode.
- * Only generates config files and content symlinks — no node_modules needed.
- * Astro is invoked programmatically from the CLI process.
+ * Uses a dedicated `npm install` under `.barodoc/` (not a symlink to the CLI
+ * or monorepo root `node_modules`) so quick mode matches real installs and
+ * avoids hoisted dev-tooling conflicts.
  */
 export async function createProject(options: ProjectOptions): Promise<string> {
   const { root, docsDir, config } = options;
@@ -104,18 +368,79 @@ export async function createProject(options: ProjectOptions): Promise<string> {
 
   console.log(pc.dim(`Creating temporary project in ${BARODOC_DIR}/`));
 
-  await fs.remove(projectDir);
   await fs.ensureDir(projectDir);
 
-  // Symlink node_modules so Astro can resolve injected routes & components
-  const cliNodeModules = findCliNodeModules();
-  await fs.symlink(cliNodeModules, path.join(projectDir, "node_modules"), "junction");
+  const nodeModulesPath = path.join(projectDir, "node_modules");
+  if (await fs.pathExists(nodeModulesPath)) {
+    const st = await fs.lstat(nodeModulesPath);
+    if (st.isSymbolicLink()) {
+      await fs.remove(nodeModulesPath);
+    }
+  }
 
-  await fs.writeJSON(
-    path.join(projectDir, "package.json"),
-    { name: "barodoc-temp", private: true },
-    { spaces: 2 }
+  const barodocPkgRoot = path.join(__dirname, "..");
+  const monorepoRoot = findMonorepoRoot(barodocPkgRoot);
+  const pkgSync = resolveTempPackageJsonSync(
+    projectDir,
+    config,
+    barodocPkgRoot,
+    monorepoRoot
   );
+  const hash = hashQuickModeDeps(pkgSync, monorepoRoot);
+  const hashFile = path.join(projectDir, ".barodoc-deps-hash");
+  const astroMarker = path.join(nodeModulesPath, "astro", "package.json");
+  let prevHash = "";
+  try {
+    prevHash = await fs.readFile(hashFile, "utf8");
+  } catch {
+    prevHash = "";
+  }
+  const needInstall = !(await fs.pathExists(astroMarker)) || prevHash !== hash;
+
+  if (needInstall) {
+    if (await fs.pathExists(nodeModulesPath)) {
+      await fs.remove(nodeModulesPath);
+    }
+    await fs.remove(path.join(projectDir, ".barodoc-packs")).catch(() => {});
+    await fs.remove(path.join(projectDir, ".npm-pack-cache")).catch(() => {});
+    console.log(pc.dim("  Installing dependencies in .barodoc/ (npm install)…"));
+    let pkgFinal = pkgSync;
+    if (monorepoRoot) {
+      pkgFinal = {
+        ...pkgSync,
+        dependencies: await materializeWorkspacePackagesAsTarballs(
+          projectDir,
+          pkgSync.dependencies,
+          monorepoRoot
+        ),
+      };
+    }
+    await fs.writeJSON(path.join(projectDir, "package.json"), pkgFinal, {
+      spaces: 2,
+    });
+    const npmCache = path.join(projectDir, ".npm-cache");
+    await fs.ensureDir(npmCache);
+    await execa(
+      "npm",
+      [
+        "install",
+        "--no-fund",
+        "--no-audit",
+        "--legacy-peer-deps",
+        "--cache",
+        npmCache,
+      ],
+      {
+        cwd: projectDir,
+        stdio: "inherit",
+      }
+    );
+    await fs.writeFile(hashFile, hash, "utf8");
+  }
+
+  await fs.remove(path.join(projectDir, "src"));
+  await fs.remove(path.join(projectDir, "public"));
+  await fs.remove(path.join(projectDir, "overrides"));
 
   // Create barodoc.config.json in temp dir
   await fs.writeJSON(path.join(projectDir, "barodoc.config.json"), config, {
@@ -208,6 +533,12 @@ export async function createProject(options: ProjectOptions): Promise<string> {
     console.log(pc.dim("  Linked overrides/ directory"));
   }
 
+  await fs.writeFile(
+    path.join(projectDir, "astro.config.mjs"),
+    generateAstroConfigFile(config),
+    "utf-8"
+  );
+
   return projectDir;
 }
 
@@ -222,7 +553,7 @@ export async function cleanupProject(root: string): Promise<void> {
 }
 
 /**
- * Generate Astro config file content (used only for eject command)
+ * Generate Astro config file content (quick mode `.barodoc/` and `barodoc eject`).
  */
 export function generateAstroConfigFile(config: BarodocConfig): string {
   const siteLine = config.site
@@ -245,10 +576,27 @@ export default defineConfig({${siteLine}${baseLine}
   ],
   vite: {
     resolve: {
-      preserveSymlinks: true,
+      preserveSymlinks: false,
+      dedupe: ["react", "react-dom"],
+    },
+    optimizeDeps: {
+      include: ["mermaid"],
+      exclude: [
+        "fsevents",
+        "lightningcss",
+        "@tailwindcss/oxide",
+        "@barodoc/core",
+      ],
     },
     ssr: {
-      noExternal: true,
+      external: [
+        "fsevents",
+        "lightningcss",
+        "mermaid",
+        "d3-array",
+        "d3-contour",
+      ],
+      noExternal: [/^@barodoc\\//],
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       rst-compiler:
         specifier: ^0.5.7
         version: 0.5.7
+      scheduler:
+        specifier: ^0.27.0
+        version: 0.27.0
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.18


### PR DESCRIPTION
Fixes #163

## Summary
- Quick mode uses an isolated `npm install` under `.barodoc/` (no symlink to monorepo root `node_modules`).
- Monorepo: `@barodoc/*` via `npm pack` with workspace→semver rewrite; local caches under `.barodoc/`.
- Vitest: `packages/barodoc/src/runtime/project.test.ts`.
- Changelog `v10.0.10`, changeset (`barodoc` patch), AGENTS.md, DEVELOPMENT.md, barodoc-cli / barodoc-dev skills.
- Keeps file-based Astro config quick-mode path in `build.ts` / `serve.ts` and `scheduler` dep where applicable.

## Verification
- `pnpm test` (65 tests) passes locally.

Made with [Cursor](https://cursor.com)